### PR TITLE
[fix] 포트폴리오 종목(PortfolioHolding) 당일변동금액 문제해결

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v3
         with:
           submodules: true
+          token: ${{ secrets.GIT_TOKEN }}
       ## JDK 설정
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -20,9 +20,10 @@ jobs:
     defaults:
       run:
         shell: bash
-
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: true
       ## JDK 설정
       - name: Set up JDK 11
         uses: actions/setup-java@v3
@@ -43,14 +44,6 @@ jobs:
           # 캐시가 없거나 만료되었을때 이 키를 기반으로 이전에 생성된 캐시를 찾아 복원합니다.
           restore-keys: |
             ${{ runner.os }}-gradle-
-
-      # 환경별 yml 파일 생성(1) - application-secret.yml
-      - name: make application-secret.yml
-        run: |
-          cd ./src/main/resources
-          touch ./application-secret.yml
-          echo "${{ secrets.APPLICATION_SECRET }}" > ./application-secret.yml
-        shell: bash
       # env 파일 생성
       - name: make .env file
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 /.gradle/
 /src/main/resources/application-secret.yml
 /out/
+/src/main/resources/secret/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "secret"]
+	path = secret
+	url = https://github.com/fine-ants/fineAnts_was_secret.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "secret"]
+	path = secret
+	url = https://github.com/fine-ants/fineAnts_was_secret.git
+    branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "secret"]
 	path = secret
 	url = https://github.com/fine-ants/fineAnts_was_secret.git
+    branch = main

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "secret"]
-	path = secret
-	url = https://github.com/fine-ants/fineAnts_was_secret.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "secret"]
-	path = secret
-	url = https://github.com/fine-ants/fineAnts_was_secret.git
-    branch = main

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ WORKDIR /app
 COPY . .
 ARG JAR_FILE=./build/libs/*.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-Dspring.profiles.active=dev","-jar","app.jar"]
+ENTRYPOINT ["java","-Dspring.profiles.active=${PROFILE}","-jar","app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -101,6 +101,6 @@ task copyPrivate(type: Copy) {
 }
 
 bootJar {
-    enabled = false
+    archiveFileName = "fineAnts_app.jar"
     copyPrivate
 }

--- a/build.gradle
+++ b/build.gradle
@@ -92,8 +92,15 @@ configurations {
 }
 /** QueryDSL end **/
 
-// executable jar만 생성하도록 설정
-jar {
-    enabled = false
+task copyPrivate(type: Copy) {
+    copy {
+        from './secret'
+        include "*.yml"
+        into 'src/main/resources/secret'
+    }
 }
 
+bootJar {
+    enabled = false
+    copyPrivate
+}

--- a/docker-compose-analyze.yml
+++ b/docker-compose-analyze.yml
@@ -7,12 +7,27 @@ services:
       dockerfile: Dockerfile
     restart: always
     ports:
-      - 443:443
+      - "8080:8080"
     environment:
-      - PROFILE=dev
+      - PROFILE=analyze
       - TZ=Asia/Seoul
     depends_on:
       - redis
+      - db
+    networks:
+      - backend_net
+  db:
+    container_name: fineAnts_db
+    image: mysql:latest
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_USER=${MYSQL_USER}
+      - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+      - MYSQL_DATABASE=${MYSQL_DATABASE}
+    command:
+      - '--local-infile=1'
     networks:
       - backend_net
   redis:

--- a/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHolding.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHolding.java
@@ -91,6 +91,7 @@ public class PortfolioHolding extends BaseEntity {
 		return (double)(calculateTotalInvestmentAmount() / numShares);
 	}
 
+	// 총 매입 개수 = 매입 내역들의 매입개수의 합계
 	public long calculateNumShares() {
 		return purchaseHistory.stream()
 			.mapToLong(PurchaseHistory::getNumShares)
@@ -129,12 +130,12 @@ public class PortfolioHolding extends BaseEntity {
 		return stock.readDividend(monthDateTime) * calculateNumShares();
 	}
 
-	// 당일 손익 = 현재 평가금액 - 총 투자 금액
-	public Long calculateDailyChange() {
-		return calculateCurrentValuation() - calculateTotalInvestmentAmount();
+	// 당일 변동 금액 = 직전 거래일의 종가 - 종목 현재가
+	public Long calculateDailyChange(long lastDayClosingPrice) {
+		return lastDayClosingPrice - currentPrice;
 	}
 
-	// 당일 손익율 = ((현재 평가금액 - 총 투자 금액) / 총 투자 금액) * 100
+	// 당일 변동율 = ((직전 거래일 종가 - 종목 현재가) / 종목 현재가) * 100%
 	public Integer calculateDailyChangeRate() {
 		long currentValuation = calculateCurrentValuation();
 		long totalInvestmentAmount = calculateTotalInvestmentAmount();

--- a/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHolding.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHolding.java
@@ -130,19 +130,18 @@ public class PortfolioHolding extends BaseEntity {
 		return stock.readDividend(monthDateTime) * calculateNumShares();
 	}
 
-	// 당일 변동 금액 = 직전 거래일의 종가 - 종목 현재가
+	// 당일 변동 금액 = 종목 현재가 - 직전 거래일의 종가
 	public Long calculateDailyChange(long lastDayClosingPrice) {
-		return lastDayClosingPrice - currentPrice;
+		return currentPrice - lastDayClosingPrice;
 	}
 
-	// 당일 변동율 = ((직전 거래일 종가 - 종목 현재가) / 종목 현재가) * 100%
-	public Integer calculateDailyChangeRate() {
-		long currentValuation = calculateCurrentValuation();
-		long totalInvestmentAmount = calculateTotalInvestmentAmount();
-		if (totalInvestmentAmount == 0) {
+	// 당일 변동율 = ((종목 현재가 - 직전 거래일 종가) / 직전 거래일 종가) * 100%
+	public Integer calculateDailyChangeRate(long lastDayClosingPrice) {
+		if (lastDayClosingPrice == 0) {
 			return 0;
 		}
-		return (int)(((double)(currentValuation - totalInvestmentAmount) / (double)totalInvestmentAmount) * 100);
+		double dailyChange = currentPrice - lastDayClosingPrice;
+		return (int)((dailyChange / (double)lastDayClosingPrice) * 100);
 	}
 
 	// 연간배당율 = (연간배당금 / 현재 가치) * 100

--- a/src/main/java/codesquad/fineants/spring/api/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/client/KisClient.java
@@ -110,7 +110,6 @@ public class KisClient {
 	// 직전 거래일의 종가 조회
 	public LastDayClosingPriceResponse readLastDayClosingPrice(String tickerSymbol, String authorization) {
 		MultiValueMap<String, String> headerMap = new LinkedMultiValueMap<>();
-		log.info("authorization : {}", authorization);
 		headerMap.add("authorization", authorization);
 		headerMap.add("appkey", appkey);
 		headerMap.add("appsecret", secretkey);
@@ -125,7 +124,7 @@ public class KisClient {
 		queryParamMap.add("FID_ORG_ADJ_PRC", "0");
 
 		Map<String, Object> responseMap = getPerform(lastDayClosingPrice, headerMap, queryParamMap);
-		Map<String, String> output = (Map<String, String>)responseMap.get("output2");
-		return LastDayClosingPriceResponse.of(tickerSymbol, Long.parseLong(output.get("stck_clpr")));
+		Map<String, String> output = (Map<String, String>)responseMap.get("output1");
+		return LastDayClosingPriceResponse.of(tickerSymbol, Long.parseLong(output.get("stck_prdy_clpr")));
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/client/KisClient.java
@@ -14,6 +14,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import codesquad.fineants.spring.api.errors.exception.KisException;
 import codesquad.fineants.spring.api.kis.properties.OauthKisProperties;
+import codesquad.fineants.spring.api.kis.response.LastDayClosingPriceResponse;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 
@@ -21,7 +22,6 @@ import reactor.core.publisher.Mono;
 @Component
 public class KisClient {
 	public static final String baseUrl = "https://openapivts.koreainvestment.com:29443";
-	private static final String approvalURI = "https://openapivts.koreainvestment.com:29443/oauth2/Approval";
 	private static final String tokenPURI = "https://openapivts.koreainvestment.com:29443/oauth2/tokenP";
 	public static final String currentPrice = "/uapi/domestic-stock/v1/quotations/inquire-price";
 	private static final String lastDayClosingPrice = "/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
@@ -108,7 +108,7 @@ public class KisClient {
 	}
 
 	// 직전 거래일의 종가 조회
-	public long readLastDayClosingPrice(String tickerSymbol, String authorization) {
+	public LastDayClosingPriceResponse readLastDayClosingPrice(String tickerSymbol, String authorization) {
 		MultiValueMap<String, String> headerMap = new LinkedMultiValueMap<>();
 		log.info("authorization : {}", authorization);
 		headerMap.add("authorization", authorization);
@@ -126,6 +126,6 @@ public class KisClient {
 
 		Map<String, Object> responseMap = getPerform(lastDayClosingPrice, headerMap, queryParamMap);
 		Map<String, String> output = (Map<String, String>)responseMap.get("output2");
-		return Long.parseLong(output.get("stck_clpr"));
+		return LastDayClosingPriceResponse.of(tickerSymbol, Long.parseLong(output.get("stck_clpr")));
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/client/KisClient.java
@@ -1,5 +1,6 @@
 package codesquad.fineants.spring.api.kis.client;
 
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -23,6 +24,7 @@ public class KisClient {
 	private static final String approvalURI = "https://openapivts.koreainvestment.com:29443/oauth2/Approval";
 	private static final String tokenPURI = "https://openapivts.koreainvestment.com:29443/oauth2/tokenP";
 	public static final String currentPrice = "/uapi/domestic-stock/v1/quotations/inquire-price";
+	private static final String lastDayClosingPrice = "/uapi/domestic-stock/v1/quotations/inquire-daily-itemchartprice";
 
 	private final WebClient.Builder webClient;
 
@@ -105,4 +107,25 @@ public class KisClient {
 		return handleClientResponse(responseSpec);
 	}
 
+	// 직전 거래일의 종가 조회
+	public long readLastDayClosingPrice(String tickerSymbol, String authorization) {
+		MultiValueMap<String, String> headerMap = new LinkedMultiValueMap<>();
+		log.info("authorization : {}", authorization);
+		headerMap.add("authorization", authorization);
+		headerMap.add("appkey", appkey);
+		headerMap.add("appsecret", secretkey);
+		headerMap.add("tr_id", "FHKST03010100");
+
+		MultiValueMap<String, String> queryParamMap = new LinkedMultiValueMap<>();
+		queryParamMap.add("FID_COND_MRKT_DIV_CODE", "J");
+		queryParamMap.add("FID_INPUT_ISCD", tickerSymbol);
+		queryParamMap.add("FID_INPUT_DATE_1", LocalDate.now().minusDays(1L).toString());
+		queryParamMap.add("FID_INPUT_DATE_2", LocalDate.now().minusDays(1L).toString());
+		queryParamMap.add("FID_PERIOD_DIV_CODE", "D");
+		queryParamMap.add("FID_ORG_ADJ_PRC", "0");
+
+		Map<String, Object> responseMap = getPerform(lastDayClosingPrice, headerMap, queryParamMap);
+		Map<String, String> output = (Map<String, String>)responseMap.get("output2");
+		return Long.parseLong(output.get("stck_clpr"));
+	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/kis/manager/CurrentPriceManager.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/manager/CurrentPriceManager.java
@@ -1,7 +1,5 @@
 package codesquad.fineants.spring.api.kis.manager;
 
-import java.time.Duration;
-
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -11,19 +9,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 @Component
 public class CurrentPriceManager {
-	private static final String pattern = "cp:*";
 	private static final String format = "cp:%s";
-	private static final Duration duration = Duration.ofMinutes(1);
 	private final RedisTemplate<String, String> redisTemplate;
 
 	public void addKey(String tickerSymbol) {
-		redisTemplate.opsForValue().set(String.format(format, tickerSymbol), "0", duration);
+		redisTemplate.opsForValue().set(String.format(format, tickerSymbol), "0");
 	}
 
 	public void addCurrentPrice(CurrentPriceResponse response) {
 		redisTemplate.opsForValue()
-			.set(String.format(format, response.getTickerSymbol()), String.valueOf(response.getCurrentPrice()),
-				duration);
+			.set(String.format(format, response.getTickerSymbol()), String.valueOf(response.getCurrentPrice()));
 	}
 
 	public Long getCurrentPrice(String tickerSymbol) {

--- a/src/main/java/codesquad/fineants/spring/api/kis/manager/LastDayClosingPriceManager.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/manager/LastDayClosingPriceManager.java
@@ -1,5 +1,7 @@
 package codesquad.fineants.spring.api.kis.manager;
 
+import java.time.Duration;
+
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
@@ -13,7 +15,7 @@ public class LastDayClosingPriceManager {
 	private final RedisTemplate<String, String> redisTemplate;
 
 	public void addPrice(String tickerSymbol, long price) {
-		redisTemplate.opsForValue().set(String.format(format, tickerSymbol), String.valueOf(price));
+		redisTemplate.opsForValue().set(String.format(format, tickerSymbol), String.valueOf(price), Duration.ofDays(1));
 	}
 
 	public Long getPrice(String tickerSymbol) {
@@ -22,5 +24,10 @@ public class LastDayClosingPriceManager {
 			throw new IllegalArgumentException(String.format("%s 종목에 대한 가격을 찾을 수 없습니다.", tickerSymbol));
 		}
 		return Long.valueOf(price);
+	}
+
+	public boolean hasPrice(String tickerSymbol) {
+		String currentPrice = redisTemplate.opsForValue().get(String.format(format, tickerSymbol));
+		return currentPrice != null;
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/kis/manager/LastDayClosingPriceManager.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/manager/LastDayClosingPriceManager.java
@@ -1,0 +1,26 @@
+package codesquad.fineants.spring.api.kis.manager;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class LastDayClosingPriceManager {
+
+	private static final String format = "lastDayClosingPrice:%s";
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void addPrice(String tickerSymbol, long price) {
+		redisTemplate.opsForValue().set(String.format(format, tickerSymbol), String.valueOf(price));
+	}
+
+	public Long getPrice(String tickerSymbol) {
+		String price = redisTemplate.opsForValue().get(String.format(format, tickerSymbol));
+		if (price == null) {
+			throw new IllegalArgumentException(String.format("%s 종목에 대한 가격을 찾을 수 없습니다.", tickerSymbol));
+		}
+		return Long.valueOf(price);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/kis/response/LastDayClosingPriceResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/response/LastDayClosingPriceResponse.java
@@ -1,0 +1,16 @@
+package codesquad.fineants.spring.api.kis.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class LastDayClosingPriceResponse {
+	private String tickerSymbol;
+	private long price;
+
+	public static LastDayClosingPriceResponse of(String tickerSymbol, long price) {
+		return new LastDayClosingPriceResponse(tickerSymbol, price);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/kis/response/LastDayClosingPriceResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/response/LastDayClosingPriceResponse.java
@@ -3,8 +3,10 @@ package codesquad.fineants.spring.api.kis.response;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class LastDayClosingPriceResponse {
 	private String tickerSymbol;

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockRestController.java
@@ -21,6 +21,7 @@ import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
 import codesquad.fineants.domain.stock.Stock;
 import codesquad.fineants.spring.api.kis.KisService;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
+import codesquad.fineants.spring.api.kis.manager.LastDayClosingPriceManager;
 import codesquad.fineants.spring.api.portfolio.PortFolioService;
 import codesquad.fineants.spring.api.portfolio_stock.request.PortfolioStockCreateRequest;
 import codesquad.fineants.spring.api.portfolio_stock.response.PortfolioHoldingsResponse;
@@ -37,6 +38,7 @@ public class PortfolioStockRestController {
 	private final KisService kisService;
 	private final PortFolioService portFolioService;
 	private final CurrentPriceManager currentPriceManager;
+	private final LastDayClosingPriceManager lastDayClosingPriceManager;
 
 	@ResponseStatus(HttpStatus.CREATED)
 	@PostMapping
@@ -64,7 +66,8 @@ public class PortfolioStockRestController {
 			.collect(Collectors.toList());
 		kisService.refreshCurrentPrice(tickerSymbols);
 
-		PortfolioHoldingsResponse response = portfolioStockService.readMyPortfolioStocks(portfolioId);
+		PortfolioHoldingsResponse response = portfolioStockService.readMyPortfolioStocks(portfolioId,
+			lastDayClosingPriceManager);
 		return ApiResponse.success(PortfolioStockSuccessCode.OK_READ_PORTFOLIO_STOCKS, response);
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioHoldingDetailItem.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioHoldingDetailItem.java
@@ -34,15 +34,15 @@ public class PortfolioHoldingDetailItem {
 		this.annualDividendYield = annualDividendYield;
 	}
 
-	public static PortfolioHoldingDetailItem from(PortfolioHolding portfolioHolding) {
+	public static PortfolioHoldingDetailItem from(PortfolioHolding portfolioHolding, long lastDayClosingPrice) {
 		return PortfolioHoldingDetailItem.builder()
 			.portfolioHoldingId(portfolioHolding.getId())
 			.currentValuation(portfolioHolding.calculateCurrentValuation())
 			.currentPrice(portfolioHolding.getCurrentPrice())
 			.averageCostPerShare(portfolioHolding.calculateAverageCostPerShare())
 			.numShares(portfolioHolding.calculateNumShares())
-			.dailyChange(portfolioHolding.calculateDailyChange())
-			.dailyChangeRate(portfolioHolding.calculateDailyChangeRate())
+			.dailyChange(portfolioHolding.calculateDailyChange(lastDayClosingPrice))
+			.dailyChangeRate(portfolioHolding.calculateDailyChangeRate(lastDayClosingPrice))
 			.totalGain(portfolioHolding.calculateTotalGain())
 			.totalReturnRate(portfolioHolding.calculateTotalReturnRate())
 			.annualDividend(portfolioHolding.calculateAnnualDividend())

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioHoldingsResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioHoldingsResponse.java
@@ -1,6 +1,7 @@
 package codesquad.fineants.spring.api.portfolio_stock.response;
 
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import codesquad.fineants.domain.portfolio.Portfolio;
@@ -15,10 +16,11 @@ public class PortfolioHoldingsResponse {
 	private List<PortfolioStockItem> portfolioHoldings;
 
 	public static PortfolioHoldingsResponse of(Portfolio portfolio, PortfolioGainHistory history,
-		List<PortfolioHolding> portfolioHoldings) {
+		List<PortfolioHolding> portfolioHoldings, Map<String, Long> lastDayClosingPriceMap) {
 		PortfolioDetailResponse portfolioDetailResponse = PortfolioDetailResponse.from(portfolio, history);
 		List<PortfolioStockItem> portfolioStockItems = portfolioHoldings.stream()
-			.map(PortfolioStockItem::from)
+			.map(portfolioHolding -> PortfolioStockItem.from(portfolioHolding,
+				lastDayClosingPriceMap.getOrDefault(portfolioHolding.getStock().getTickerSymbol(), 0L)))
 			.collect(Collectors.toList());
 		return new PortfolioHoldingsResponse(portfolioDetailResponse, portfolioStockItems);
 	}

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioStockItem.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioStockItem.java
@@ -19,9 +19,10 @@ public class PortfolioStockItem {
 	private List<StockDividendItem> dividends;
 	private List<PurchaseHistoryItem> purchaseHistory;
 
-	public static PortfolioStockItem from(PortfolioHolding portfolioHolding) {
+	public static PortfolioStockItem from(PortfolioHolding portfolioHolding, long lastDayClosingPrice) {
 		StockItem stockItem = StockItem.from(portfolioHolding.getStock());
-		PortfolioHoldingDetailItem holdingDetailItem = PortfolioHoldingDetailItem.from(portfolioHolding);
+		PortfolioHoldingDetailItem holdingDetailItem = PortfolioHoldingDetailItem.from(portfolioHolding,
+			lastDayClosingPrice);
 		List<StockDividendItem> dividends = portfolioHolding.getStock().getStockDividends().stream()
 			.map(StockDividendItem::from)
 			.collect(Collectors.toList());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,7 @@ spring:
       local: local, secret, s3
       dev: dev, secret, s3
       test: test, secret, s3
+      analyze: analyze, secret, s3
     default: local
 
   jackson:
@@ -117,6 +118,38 @@ spring:
 logging:
   level:
     codesquard: info
+---
+spring:
+  config:
+    activate:
+      on-profile: analyze
+  datasource:
+    url: ${db.analyze.datasource.url}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${db.analyze.datasource.username}
+    password: ${db.analyze.datasource.password}
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    defer-datasource-initialization: true
+    show-sql: true
+  redis:
+    host: redis
+    port: 6379
+  sql:
+    init:
+      mode: always
+      data-locations: classpath*:db/mysql/data.sql
+
+logging:
+  level:
+    codesquad: debug
 ---
 
 spring:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,6 +28,8 @@ spring:
           timeout: 5000
           starttls:
             enable: true
+  config:
+    import: ./secret/application-secret.yml
 ---
 spring:
   config:

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioHoldingRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioHoldingRestControllerTest.java
@@ -34,6 +34,7 @@ import codesquad.fineants.domain.stock.Stock;
 import codesquad.fineants.spring.api.errors.handler.GlobalExceptionHandler;
 import codesquad.fineants.spring.api.kis.KisService;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
+import codesquad.fineants.spring.api.kis.manager.LastDayClosingPriceManager;
 import codesquad.fineants.spring.api.portfolio.PortFolioService;
 import codesquad.fineants.spring.api.portfolio_stock.request.PortfolioStockCreateRequest;
 import codesquad.fineants.spring.api.portfolio_stock.response.PortfolioStockCreateResponse;
@@ -69,6 +70,9 @@ class PortfolioHoldingRestControllerTest {
 
 	@MockBean
 	private CurrentPriceManager currentPriceManager;
+
+	@MockBean
+	private LastDayClosingPriceManager lastDayClosingPriceManager;
 
 	private Member member;
 	private Portfolio portfolio;

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockServiceTest.java
@@ -33,6 +33,7 @@ import codesquad.fineants.domain.stock.StockRepository;
 import codesquad.fineants.domain.stock_dividend.StockDividend;
 import codesquad.fineants.domain.stock_dividend.StockDividendRepository;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
+import codesquad.fineants.spring.api.kis.manager.LastDayClosingPriceManager;
 import codesquad.fineants.spring.api.kis.response.CurrentPriceResponse;
 import codesquad.fineants.spring.api.portfolio_stock.response.PortfolioHoldingsResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -71,6 +72,9 @@ class PortfolioStockServiceTest {
 
 	@Autowired
 	private CurrentPriceManager currentPriceManager;
+
+	@Autowired
+	private LastDayClosingPriceManager lastDayClosingPriceManager;
 
 	private Member member;
 	private Portfolio portfolio;
@@ -161,9 +165,9 @@ class PortfolioStockServiceTest {
 		// given
 		Long portfolioId = portfolio.getId();
 		currentPriceManager.addCurrentPrice(new CurrentPriceResponse("005930", 60000L));
-
+		lastDayClosingPriceManager.addPrice("005930", 50000);
 		// when
-		PortfolioHoldingsResponse response = service.readMyPortfolioStocks(portfolioId);
+		PortfolioHoldingsResponse response = service.readMyPortfolioStocks(portfolioId, lastDayClosingPriceManager);
 
 		// then
 		assertAll(
@@ -189,7 +193,7 @@ class PortfolioStockServiceTest {
 				.extracting("portfolioHoldingId", "currentValuation", "currentPrice", "averageCostPerShare",
 					"numShares", "dailyChange", "dailyChangeRate", "totalGain", "totalReturnRate", "annualDividend")
 				.containsExactlyInAnyOrder(Tuple.tuple(
-					portfolioHolding.getId(), 180000L, 60000L, 50000.0, 3L, 30000L, 20, 30000L, 20, 4332L)),
+					portfolioHolding.getId(), 180000L, 60000L, 50000.0, 3L, 10000L, 20, 30000L, 20, 4332L)),
 
 			() -> assertThat(response).extracting("portfolioHoldings")
 				.asList()


### PR DESCRIPTION
## 구현한 것

- [x] 포트폴리오 종목(PortfolioHolding) 엔티티의 당일변동금액, 당일변동율 메소드(calculateDailyChange, calculateDailyChangeRate)의 버그 수정
    -  당일 손익에서 당일 변동 금액으로 주석 수정
    - 당일 변동 금액 공식에 맞게 코드 수정
    - 주식의 전일 종가를 저장하기 위해서 LastDayClosingPriceManager라는 매니저 객체 생성
- [x] application-secret.yml 파일 정보를 숨기기 위해서 submodule 저장소 추가 및 설정 추가
## 실행 결과
다음 포트폴리오 상세 조회 및 종목 조회 실행 결과를 보면 삼성전자 종목의 전일 종가는 "72200"인 상태이고 주식 현재가(currentPrice)는 72800원으로써 당일 변동 금액은 600임을 볼 수 있습니다. 당일 변동율은 0.83%로써 정수단위만 응답하여 0을 반환하였습니다.

<img width="981" alt="image" src="https://github.com/fine-ants/FineAnts-was/assets/33227831/5da94610-1d82-4709-871d-b52fd5c41ad0">
