### PR TITLE
#15 feat: spring security 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
+    // spring security 라이브러리
+    implementation 'org.springframework.boot:spring-boot-starter-security'
 
     // websocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'

--- a/env
+++ b/env
@@ -1,0 +1,4 @@
+MYSQL_USER=admin
+MYSQL_PASSWORD=fineantspassword1234
+MYSQL_ROOT_PASSWORD=fineantspassword1234
+MYSQL_DATABASE=fineAnts

--- a/src/main/java/codesquad/fineants/spring/config/CacheConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/CacheConfig.java
@@ -1,9 +1,0 @@
-package codesquad.fineants.spring.config;
-
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Configuration;
-
-@Configuration
-@EnableCaching
-public class CacheConfig {
-}

--- a/src/main/java/codesquad/fineants/spring/config/FilterConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/FilterConfig.java
@@ -1,41 +1,41 @@
-package codesquad.fineants.spring.config;
-
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-
-import codesquad.fineants.domain.jwt.JwtProvider;
-import codesquad.fineants.domain.oauth.support.AuthenticationContext;
-import codesquad.fineants.spring.api.member.service.OauthMemberRedisService;
-import codesquad.fineants.spring.filter.JwtAuthorizationFilter;
-import codesquad.fineants.spring.filter.LogoutFilter;
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
-@Configuration
-public class FilterConfig {
-
-	private final JwtProvider jwtProvider;
-	private final AuthenticationContext authenticationContext;
-	private final ObjectMapper objectMapper;
-	private final OauthMemberRedisService redisService;
-
-	@Bean
-	public FilterRegistrationBean<JwtAuthorizationFilter> jwtAuthorizationFilter() {
-		FilterRegistrationBean<JwtAuthorizationFilter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
-		filterFilterRegistrationBean.setFilter(
-			new JwtAuthorizationFilter(jwtProvider, authenticationContext, objectMapper, redisService));
-		filterFilterRegistrationBean.addUrlPatterns("/api/*");
-		return filterFilterRegistrationBean;
-	}
-
-	@Bean
-	public FilterRegistrationBean<LogoutFilter> logoutFiler() {
-		FilterRegistrationBean<LogoutFilter> logoutFilerBean = new FilterRegistrationBean<>();
-		logoutFilerBean.setFilter(new LogoutFilter(redisService, objectMapper));
-		logoutFilerBean.addUrlPatterns("/api/auth/logout");
-		return logoutFilerBean;
-	}
-}
+//package codesquad.fineants.spring.config;
+//
+//import org.springframework.boot.web.servlet.FilterRegistrationBean;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//
+//import codesquad.fineants.domain.jwt.JwtProvider;
+//import codesquad.fineants.domain.oauth.support.AuthenticationContext;
+//import codesquad.fineants.spring.api.member.service.OauthMemberRedisService;
+//import codesquad.fineants.spring.filter.JwtAuthorizationFilter;
+//import codesquad.fineants.spring.filter.LogoutFilter;
+//import lombok.RequiredArgsConstructor;
+//
+//@RequiredArgsConstructor
+//@Configuration
+//public class FilterConfig {
+//
+//	private final JwtProvider jwtProvider;
+//	private final AuthenticationContext authenticationContext;
+//	private final ObjectMapper objectMapper;
+//	private final OauthMemberRedisService redisService;
+//
+//	@Bean
+//	public FilterRegistrationBean<JwtAuthorizationFilter> jwtAuthorizationFilter() {
+//		FilterRegistrationBean<JwtAuthorizationFilter> filterFilterRegistrationBean = new FilterRegistrationBean<>();
+//		filterFilterRegistrationBean.setFilter(
+//			new JwtAuthorizationFilter(jwtProvider, authenticationContext, objectMapper, redisService));
+//		filterFilterRegistrationBean.addUrlPatterns("/api/*");
+//		return filterFilterRegistrationBean;
+//	}
+//
+//	@Bean
+//	public FilterRegistrationBean<LogoutFilter> logoutFiler() {
+//		FilterRegistrationBean<LogoutFilter> logoutFilerBean = new FilterRegistrationBean<>();
+//		logoutFilerBean.setFilter(new LogoutFilter(redisService, objectMapper));
+//		logoutFilerBean.addUrlPatterns("/api/auth/logout");
+//		return logoutFilerBean;
+//	}
+//}

--- a/src/main/java/codesquad/fineants/spring/config/SecurityConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/SecurityConfig.java
@@ -1,0 +1,72 @@
+package codesquad.fineants.spring.config;
+
+import codesquad.fineants.domain.jwt.JwtProvider;
+import codesquad.fineants.domain.oauth.support.AuthenticationContext;
+import codesquad.fineants.spring.api.member.service.OauthMemberRedisService;
+import codesquad.fineants.spring.filter.CorsFilter;
+import codesquad.fineants.spring.filter.JwtAuthorizationFilter;
+import codesquad.fineants.spring.filter.LogoutFilter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtProvider jwtProvider;
+    private final AuthenticationContext authenticationContext;
+    private final ObjectMapper objectMapper;
+    private final OauthMemberRedisService redisService;
+
+    // 인증이 필요하지 않은 주소
+    private final String[] accessUrl = {"/api/auth/login",
+            "/api/auth/signup",
+            "/api/auth/**/authUrl",
+            "/api/auth/**/login",
+            "/api/auth/refresh/token",
+            "/api/auth/logout",
+            "/api/stocks/**"};
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        /**
+         * 기본 설정
+         */
+        http.csrf().disable();
+        http.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS); // 세션을 사용하지 않는다.
+        http.formLogin().disable(); // 로그인 UI Form 미사용
+        http.httpBasic().disable(); // http basic 방식 미사용 (ID+PW로 인증), bearer token 방식 사용 (JWT 토큰)
+
+        /**
+         * 필터 추가
+         */
+        http.addFilterBefore(new CorsFilter(), UsernamePasswordAuthenticationFilter.class); // cors 필터
+        http.addFilterBefore(new JwtAuthorizationFilter(jwtProvider, authenticationContext,objectMapper,redisService), UsernamePasswordAuthenticationFilter.class); // JWT 토큰으로 모든 접근에 대해 인증한다.
+        http.addFilterBefore(new LogoutFilter(redisService,objectMapper), UsernamePasswordAuthenticationFilter.class);
+
+        /**
+         * 요청 허용 / 미허용
+         */
+        http.authorizeRequests()
+                .antMatchers(accessUrl).permitAll()
+                .anyRequest().authenticated();
+
+        return http.build();
+    }
+}

--- a/src/main/java/codesquad/fineants/spring/config/WebConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/WebConfig.java
@@ -1,32 +1,32 @@
-package codesquad.fineants.spring.config;
-
-import java.util.List;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
-import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-
-import codesquad.fineants.domain.oauth.support.AuthPrincipalArgumentResolver;
-import codesquad.fineants.spring.intercetpor.LogoutInterceptor;
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor
-@Configuration
-public class WebConfig implements WebMvcConfigurer {
-
-	private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
-
-	@Override
-	public void addInterceptors(InterceptorRegistry registry) {
-		registry.addInterceptor(new LogoutInterceptor())
-			.excludePathPatterns("/api/*")
-			.addPathPatterns("/api/auth/logout");
-	}
-
-	@Override
-	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
-		resolvers.add(authPrincipalArgumentResolver);
-		WebMvcConfigurer.super.addArgumentResolvers(resolvers);
-	}
-}
+//package codesquad.fineants.spring.config;
+//
+//import java.util.List;
+//
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+//import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+//import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+//
+//import codesquad.fineants.domain.oauth.support.AuthPrincipalArgumentResolver;
+//import codesquad.fineants.spring.intercetpor.LogoutInterceptor;
+//import lombok.RequiredArgsConstructor;
+//
+//@RequiredArgsConstructor
+//@Configuration
+//public class WebConfig implements WebMvcConfigurer {
+//
+//	private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
+//
+//	@Override
+//	public void addInterceptors(InterceptorRegistry registry) {
+//		registry.addInterceptor(new LogoutInterceptor())
+//			.excludePathPatterns("/api/*")
+//			.addPathPatterns("/api/auth/logout");
+//	}
+//
+//	@Override
+//	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+//		resolvers.add(authPrincipalArgumentResolver);
+//		WebMvcConfigurer.super.addArgumentResolvers(resolvers);
+//	}
+//}

--- a/src/main/java/codesquad/fineants/spring/filter/CorsFilter.java
+++ b/src/main/java/codesquad/fineants/spring/filter/CorsFilter.java
@@ -17,8 +17,8 @@ import org.springframework.stereotype.Component;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Component
-@Order(Ordered.HIGHEST_PRECEDENCE)
+//@Component
+//@Order(Ordered.HIGHEST_PRECEDENCE)
 public class CorsFilter implements Filter {
 
 	@Override

--- a/src/main/java/codesquad/fineants/spring/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/codesquad/fineants/spring/filter/JwtAuthorizationFilter.java
@@ -37,6 +37,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 	private static final List<String> excludeUrlPatterns = List.of(
 		"/api/auth/**/authUrl",
 		"/api/auth/**/login",
+		"/api/auth/signup",
+		"/api/auth/login",
 		"/api/auth/refresh/token",
 		"/api/auth/logout",
 		"/api/stocks/**");


### PR DESCRIPTION
## 구현한 것

- AS-IS : 인증 처리 필터를 WebConfig, FilterConfig에 등록해서 URL 별 인증 구현
- TO-BE : SecurityConfig 파일에서 각각의 필터 등록(인증/로그아웃/Cors) 및 인증을 거쳐야하는 URL 지정 

## 기타

1. 기존에 인증을 구현하셨던 WebConfig, FilterConfig 파일과 일부 코드를 삭제 대신 주석처리 해두었습니다. 
   => 다른 분들 개발 진행 방식에 따라 삭제하고 Push 할지 정하도록 하겠습니다!
2. URL 별 인가 처리는 아직 진행하지 않았습니다. 
   => 추후 진행 예정(사용자 별 Role 이 정해진 후)