### PR TITLE
[fix] 로그아웃 문제 해결

### DIFF
--- a/src/main/java/codesquad/fineants/spring/config/WebConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/WebConfig.java
@@ -1,0 +1,17 @@
+package codesquad.fineants.spring.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import codesquad.fineants.spring.intercetpor.LogoutInterceptor;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+	@Override
+	public void addInterceptors(InterceptorRegistry registry) {
+		registry.addInterceptor(new LogoutInterceptor())
+			.addPathPatterns("/api/auth/logout");
+	}
+}


### PR DESCRIPTION
## 상황
- oauth 로그인까지는 잘 수행되지만 로그아웃이 수행되지 않습니다.

## 원인
- 컨트롤러 매핑 메소드에 accessToken을 전달하지 않고 있습니다.
<img width="975" alt="image" src="https://github.com/fine-ants/FineAnts-was/assets/33227831/3e519073-9c42-4e39-9518-c4f82c183325">

- 기존에는 LogoutInterceptor에 의해서 컨트롤러 전달전에 Authorization 헤더에서 accessToken을 파싱하여 RequestAttribute로 설정하였지만 security 라이브러리 도입 과정에서 설정이 빠진 것을 확인하였습니다.

## 해결방법
- LogoutInterceptor를 설정에 추가합니다.
```java
@Configuration
public class WebConfig implements WebMvcConfigurer {

	@Override
	public void addInterceptors(InterceptorRegistry registry) {
		registry.addInterceptor(new LogoutInterceptor())
			.addPathPatterns("/api/auth/logout");
	}
}
```