### PR TITLE
[fix] AuthMember 문제 해결

### DIFF
--- a/src/main/java/codesquad/fineants/spring/config/WebConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/WebConfig.java
@@ -1,17 +1,30 @@
 package codesquad.fineants.spring.config;
 
+import java.util.List;
+
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+import codesquad.fineants.domain.oauth.support.AuthPrincipalArgumentResolver;
 import codesquad.fineants.spring.intercetpor.LogoutInterceptor;
+import lombok.RequiredArgsConstructor;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebConfig implements WebMvcConfigurer {
+
+	private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
 
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(new LogoutInterceptor())
 			.addPathPatterns("/api/auth/logout");
+	}
+
+	@Override
+	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+		resolvers.add(authPrincipalArgumentResolver);
 	}
 }


### PR DESCRIPTION
## 상황
- 로그인 후 포트폴리오 목록 조회와 같이 컨트롤러 매핑 메소드에 AuthMember 매개변수에 로그인한 사용자 정보를 넣어주지 못하고 있습니다.

## 원인
- seucirty 라이브러리 적용 과정에서 AuthPrincipalArgumentResolver를 설정한 WebConfig 파일이 제거되면서 설정되지 않아서 입니다.

## 해결방법
- WebConfig 파일에 AuthPrincipalArgumentResolver를 설정 추가합니다.
```java
@Configuration
@RequiredArgsConstructor
public class WebConfig implements WebMvcConfigurer {

	private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;

         // ...

	@Override
	public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
		resolvers.add(authPrincipalArgumentResolver);
	}
}
```