### PR TITLE
[feat] 포트폴리오 상세 조회 및 종목 조회 응답 형식 변경

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/StockMarketChecker.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/StockMarketChecker.java
@@ -1,0 +1,29 @@
+package codesquad.fineants.spring.api.portfolio_stock;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class StockMarketChecker {
+	private static final LocalTime MARKET_OPEN_TIME = LocalTime.of(9, 0);
+	private static final LocalTime MARKET_CLOSE_TIME = LocalTime.of(15, 30);
+
+	// 주식 시장이 열려 있는지 확인한다
+	public boolean isMarketOpen(LocalDateTime dateTime) {
+		DayOfWeek dayOfWeek = dateTime.getDayOfWeek();
+		LocalTime currentTime = dateTime.toLocalTime();
+
+		if (dayOfWeek == DayOfWeek.SATURDAY || dayOfWeek == DayOfWeek.SUNDAY) {
+			return false;
+		}
+
+		// 평일인 경우 개장 시간과 폐장 시간 사이에 있는지 확인한다
+		if (currentTime.isAfter(MARKET_OPEN_TIME) && currentTime.isBefore(MARKET_CLOSE_TIME)) {
+			return true;
+		}
+		return false;
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioStockItem.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioStockItem.java
@@ -16,19 +16,15 @@ public class PortfolioStockItem {
 	private StockItem stock;
 	@JsonUnwrapped
 	private PortfolioHoldingDetailItem portfolioHolding;
-	private List<StockDividendItem> dividends;
 	private List<PurchaseHistoryItem> purchaseHistory;
 
 	public static PortfolioStockItem from(PortfolioHolding portfolioHolding, long lastDayClosingPrice) {
 		StockItem stockItem = StockItem.from(portfolioHolding.getStock());
 		PortfolioHoldingDetailItem holdingDetailItem = PortfolioHoldingDetailItem.from(portfolioHolding,
 			lastDayClosingPrice);
-		List<StockDividendItem> dividends = portfolioHolding.getStock().getStockDividends().stream()
-			.map(StockDividendItem::from)
-			.collect(Collectors.toList());
 		List<PurchaseHistoryItem> purchaseHistory = portfolioHolding.getPurchaseHistory().stream()
 			.map(PurchaseHistoryItem::from)
 			.collect(Collectors.toList());
-		return new PortfolioStockItem(stockItem, holdingDetailItem, dividends, purchaseHistory);
+		return new PortfolioStockItem(stockItem, holdingDetailItem, purchaseHistory);
 	}
 }

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioHoldingRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioHoldingRestControllerTest.java
@@ -74,6 +74,9 @@ class PortfolioHoldingRestControllerTest {
 	@MockBean
 	private LastDayClosingPriceManager lastDayClosingPriceManager;
 
+	@MockBean
+	private StockMarketChecker stockMarketChecker;
+
 	private Member member;
 	private Portfolio portfolio;
 	private Stock stock;

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockRestControllerTest.java
@@ -72,6 +72,9 @@ class PortfolioStockRestControllerTest {
 	@MockBean
 	private LastDayClosingPriceManager lastDayClosingPriceManager;
 
+	@MockBean
+	private StockMarketChecker stockMarketChecker;
+
 	@BeforeEach
 	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(portfolioStockRestController)
@@ -85,6 +88,7 @@ class PortfolioStockRestControllerTest {
 		AuthMember authMember = AuthMember.from(createMember());
 		given(authPrincipalArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(authMember);
 		given(authPrincipalArgumentResolver.supportsParameter(any())).willReturn(true);
+		given(stockMarketChecker.isMarketOpen(any())).willReturn(true);
 	}
 
 	@DisplayName("사용자의 포트폴리오 상세 정보를 가져온다")

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockRestControllerTest.java
@@ -91,7 +91,6 @@ class PortfolioStockRestControllerTest {
 	@Test
 	void readMyPortfolioStocks() throws Exception {
 		// given
-		long portfolioId = 1;
 		Member member = createMember();
 		Portfolio portfolio = createPortfolio(member);
 		Stock stock = createStock();
@@ -108,7 +107,7 @@ class PortfolioStockRestControllerTest {
 			.willReturn(mockResponse);
 
 		// when & then
-		mockMvc.perform(get("/api/portfolio/{portfolioId}/holdings", portfolioId))
+		mockMvc.perform(get("/api/portfolio/{portfolioId}/holdings", portfolio.getId()))
 			.andExpect(request().asyncStarted())
 			.andExpect(content().contentType(MediaType.TEXT_EVENT_STREAM));
 	}

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockServiceTest.java
@@ -194,19 +194,6 @@ class PortfolioStockServiceTest {
 					"numShares", "dailyChange", "dailyChangeRate", "totalGain", "totalReturnRate", "annualDividend")
 				.containsExactlyInAnyOrder(Tuple.tuple(
 					portfolioHolding.getId(), 180000L, 60000L, 50000.0, 3L, 10000L, 20, 30000L, 20, 4332L)),
-
-			() -> assertThat(response).extracting("portfolioHoldings")
-				.asList()
-				.hasSize(1)
-				.flatExtracting("dividends")
-				.extracting("dividendMonth", "dividendAmount")
-				.containsExactlyInAnyOrder(
-					Tuple.tuple(LocalDate.of(2023, 4, 1).atStartOfDay(), 361L),
-					Tuple.tuple(LocalDate.of(2023, 5, 1).atStartOfDay(), 361L),
-					Tuple.tuple(LocalDate.of(2023, 8, 1).atStartOfDay(), 361L),
-					Tuple.tuple(LocalDate.of(2023, 11, 1).atStartOfDay(), 361L)
-				),
-
 			() -> assertThat(response).extracting("portfolioHoldings")
 				.asList()
 				.hasSize(1)


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 상세 조회 및 종목 조회에서 각 종목별 배당금 내역을 삭제하였습니다.
- 포트폴리오 상세 조회 및 종목 조회 테스트 코드에서 샘플 데이터 생성 하는 부분을 별도의 메소드로 분리하였습니다.
- 장시간 내에서는 5초에 한번씩 지속적으로 응답하도록 하고 장시간이 끝나면 한번의 SSE 응답하고 HTTP 연결을 끊도록 변경하였습니다.
     -  프론트 엔드 팀원들과 의논하여 요구사항이 변경되어 적용하였습니다.

## 개선할것
- 장시간에 따라서 SSE 응답을 위한 테스크를 생성하는데 중복된 메소드가 발생하였습니다. 별도의 객체로 분리하여 제거하여야 합니다.