### PR TITLE
[feat] jwt refresh token을 redis에 저장하지 않도록 변경

### DIFF
--- a/src/main/java/codesquad/fineants/domain/jwt/JwtProvider.java
+++ b/src/main/java/codesquad/fineants/domain/jwt/JwtProvider.java
@@ -2,7 +2,6 @@ package codesquad.fineants.domain.jwt;
 
 import java.time.LocalDateTime;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.stereotype.Component;
@@ -29,8 +28,7 @@ public class JwtProvider {
 		this.jwtProperties = jwtProperties;
 	}
 
-	public Jwt createJwtWithRefreshTokenBasedOnMember(Member member, String refreshToken, LocalDateTime now) {
-		Map<String, Object> claims = member.createClaims();
+	public Jwt createJwtWithRefreshToken(Claims claims, String refreshToken, LocalDateTime now) {
 		Date expireDateAccessToken = jwtProperties.createExpireAccessTokenDate(now);
 		Date expireDateRefreshToken = getClaims(refreshToken).getExpiration();
 		return createJwt(claims, expireDateAccessToken, expireDateRefreshToken);
@@ -45,7 +43,7 @@ public class JwtProvider {
 
 	private Jwt createJwt(Map<String, Object> claims, Date expireDateAccessToken, Date expireDateRefreshToken) {
 		String accessToken = createToken(claims, expireDateAccessToken);
-		String refreshToken = createToken(new HashMap<>(), expireDateRefreshToken);
+		String refreshToken = createToken(claims, expireDateRefreshToken);
 		return new Jwt(accessToken, refreshToken, expireDateAccessToken, expireDateRefreshToken);
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/member/service/OauthMemberRedisService.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/service/OauthMemberRedisService.java
@@ -1,18 +1,11 @@
 package codesquad.fineants.spring.api.member.service;
 
-import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Pattern;
 
-import org.apache.logging.log4j.util.Strings;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import codesquad.fineants.domain.jwt.Jwt;
-import codesquad.fineants.spring.api.errors.errorcode.JwtErrorCode;
 import codesquad.fineants.spring.api.errors.errorcode.OauthErrorCode;
-import codesquad.fineants.spring.api.errors.exception.BadRequestException;
 import codesquad.fineants.spring.api.errors.exception.UnAuthorizationException;
 import lombok.RequiredArgsConstructor;
 
@@ -21,8 +14,6 @@ import lombok.RequiredArgsConstructor;
 public class OauthMemberRedisService {
 
 	private static final String LOGOUT = "logout";
-	private static final String REFRESH_TOKEN_PREFIX = "RT:";
-	private static final Pattern REFRESH_TOKEN_PATTERN = Pattern.compile("RT:*");
 
 	private final RedisTemplate<String, String> redisTemplate;
 
@@ -30,34 +21,8 @@ public class OauthMemberRedisService {
 		return redisTemplate.opsForValue().get(key);
 	}
 
-	public String findEmailBy(String refreshToken) {
-		Set<String> keys = redisTemplate.keys(REFRESH_TOKEN_PATTERN.pattern());
-		if (keys == null) {
-			throw new UnAuthorizationException(JwtErrorCode.EMPTY_TOKEN);
-		}
-		return keys.stream()
-			.filter(key -> Objects.equals(redisTemplate.opsForValue().get(key), refreshToken))
-			.findAny()
-			.map(email -> email.replace(REFRESH_TOKEN_PREFIX, Strings.EMPTY))
-			.orElseThrow(() -> new BadRequestException(JwtErrorCode.INVALID_TOKEN));
-	}
-
-	public void saveRefreshToken(String key, Jwt jwt) {
-		redisTemplate.opsForValue().set(key,
-			jwt.getRefreshToken(),
-			jwt.convertExpireDateRefreshTokenTimeWithLong(),
-			TimeUnit.MILLISECONDS);
-	}
-
-	public boolean deleteRefreshToken(String key) {
-		if (key == null) {
-			return false;
-		}
-		return Boolean.TRUE.equals(redisTemplate.delete(key));
-	}
-
-	public void banAccessToken(String accessToken, long expiration) {
-		redisTemplate.opsForValue().set(accessToken, LOGOUT, expiration, TimeUnit.MILLISECONDS);
+	public void banToken(String token, long expiration) {
+		redisTemplate.opsForValue().set(token, LOGOUT, expiration, TimeUnit.MILLISECONDS);
 	}
 
 	public void validateAlreadyLogout(String token) {


### PR DESCRIPTION
## 구현한 것

- 로그인시 refresh토큰에 memberId와 email 클레임 삽입하고 redis에 저장하는 부분 삭제
- 토큰 재발급시 refresh토큰에 있는 클레임 재사용
- 로그아웃시 access토큰과 refresh토큰 블랙리스팅
