### PR TITLE
[fix] sse 응답 메시지 이름 변경

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockRestController.java
@@ -83,7 +83,7 @@ public class PortfolioStockRestController {
 				emitter.send(SseEmitter.event()
 					.data(
 						portfolioStockService.readMyPortfolioStocksInRealTime(portfolioId))
-					.name("sse event - myPortfolioStocks"));
+					.name("portfolioDetails"));
 				log.info("send message");
 				if (isComplete) {
 					Thread.sleep(2000L); // sse event - myPortfolioStocks 메시지와 전송 간격


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 상세 조회 SSE 응답시 메시지 이름을 "sse event - myPortfolioStocks"에서 "portfolioDetails"로 변경하였습니다.
