### PR TITLE
[feat] 대시보드 구현

### DIFF
--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -196,10 +196,12 @@ public class Portfolio extends BaseEntity {
 		Long totalGain = calculateTotalGain();
 		Long dailyGain = calculateDailyGain(history);
 		Long currentValuation = calculateTotalCurrentValuation();
+		Long cash = calculateBalance();
 		return PortfolioGainHistory.builder()
 			.totalGain(totalGain)
 			.dailyGain(dailyGain)
 			.currentValuation(currentValuation)
+			.cash(cash)
 			.portfolio(this)
 			.build();
 	}

--- a/src/main/java/codesquad/fineants/domain/portfolio_gain_history/PortfolioGainHistory.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio_gain_history/PortfolioGainHistory.java
@@ -24,6 +24,7 @@ public class PortfolioGainHistory extends BaseEntity {
 	private Long id;
 	private Long totalGain;
 	private Long dailyGain;
+	private Long cash;
 	private Long currentValuation;
 
 	@ManyToOne(fetch = FetchType.LAZY)
@@ -31,12 +32,14 @@ public class PortfolioGainHistory extends BaseEntity {
 	private Portfolio portfolio;
 
 	@Builder
-	public PortfolioGainHistory(Long id, Long totalGain, Long dailyGain, Long currentValuation, Portfolio portfolio) {
+	public PortfolioGainHistory(Long id, Long totalGain, Long dailyGain, Long currentValuation, Portfolio portfolio,
+		Long cash) {
 		this.id = id;
 		this.totalGain = totalGain;
 		this.dailyGain = dailyGain;
 		this.currentValuation = currentValuation;
 		this.portfolio = portfolio;
+		this.cash = cash;
 	}
 
 	public static PortfolioGainHistory empty() {
@@ -44,6 +47,7 @@ public class PortfolioGainHistory extends BaseEntity {
 			.totalGain(0L)
 			.dailyGain(0L)
 			.currentValuation(0L)
+			.cash(0L)
 			.build();
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/portfolio_gain_history/PortfolioGainHistoryRepository.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio_gain_history/PortfolioGainHistoryRepository.java
@@ -1,6 +1,7 @@
 package codesquad.fineants.domain.portfolio_gain_history;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,4 +16,6 @@ public interface PortfolioGainHistoryRepository extends JpaRepository<PortfolioG
 		+ "limit 1", nativeQuery = true)
 	Optional<PortfolioGainHistory> findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
 		@Param("portfolioId") Long portfolioId, @Param("createAt") LocalDateTime createAt);
+
+	List<PortfolioGainHistory> findAllByPortfolioId(Long portfolioId);
 }

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/controller/DashboardRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/controller/DashboardRestController.java
@@ -1,11 +1,15 @@
 package codesquad.fineants.spring.api.dashboard.controller;
 
+import java.util.List;
+
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.domain.oauth.support.AuthPrincipalMember;
+import codesquad.fineants.spring.api.dashboard.response.DashboardLineChartResponse;
+import codesquad.fineants.spring.api.dashboard.response.DashboardPieChartResponse;
 import codesquad.fineants.spring.api.dashboard.response.OverviewResponse;
 import codesquad.fineants.spring.api.dashboard.service.DashboardService;
 import codesquad.fineants.spring.api.response.ApiResponse;
@@ -23,5 +27,16 @@ public class DashboardRestController {
 	@GetMapping("/overview")
 	public ApiResponse<OverviewResponse> readDashboard(@AuthPrincipalMember AuthMember authMember) {
 		return ApiResponse.success(DashboardSuccessCode.OK_OVERVIEW, dashboardService.getOverview(authMember));
+	}
+
+	@GetMapping("/pieChart")
+	public ApiResponse<List<DashboardPieChartResponse>> readPieChart(@AuthPrincipalMember AuthMember authMember) {
+		return ApiResponse.success(DashboardSuccessCode.OK_PORTFOLIO_PIE_CHART,
+			dashboardService.getPieChart(authMember));
+	}
+
+	@GetMapping("/lineChart")
+	public ApiResponse<List<DashboardLineChartResponse>> readLineChart(@AuthPrincipalMember AuthMember authMember) {
+		return ApiResponse.success(DashboardSuccessCode.OK_LINE_CHART, dashboardService.getLineChart(authMember));
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/controller/DashboardRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/controller/DashboardRestController.java
@@ -1,0 +1,27 @@
+package codesquad.fineants.spring.api.dashboard.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.oauth.support.AuthPrincipalMember;
+import codesquad.fineants.spring.api.dashboard.response.OverviewResponse;
+import codesquad.fineants.spring.api.dashboard.service.DashboardService;
+import codesquad.fineants.spring.api.response.ApiResponse;
+import codesquad.fineants.spring.api.success.code.DashboardSuccessCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequestMapping("/api/dashboard")
+@RequiredArgsConstructor
+@RestController
+public class DashboardRestController {
+	private final DashboardService dashboardService;
+
+	@GetMapping("/overview")
+	public ApiResponse<OverviewResponse> readDashboard(@AuthPrincipalMember AuthMember authMember) {
+		return ApiResponse.success(DashboardSuccessCode.OK_OVERVIEW, dashboardService.getOverview(authMember));
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/response/DashboardLineChartResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/response/DashboardLineChartResponse.java
@@ -1,0 +1,14 @@
+package codesquad.fineants.spring.api.dashboard.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DashboardLineChartResponse {
+	private String time;
+	private Long value;
+
+	public static DashboardLineChartResponse of(String time, Long value) {
+		return new DashboardLineChartResponse(time, value);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/response/DashboardLineChartResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/response/DashboardLineChartResponse.java
@@ -2,7 +2,9 @@ package codesquad.fineants.spring.api.dashboard.response;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DashboardLineChartResponse {
 	private String time;

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/response/DashboardPieChartResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/response/DashboardPieChartResponse.java
@@ -1,0 +1,21 @@
+package codesquad.fineants.spring.api.dashboard.response;
+
+import codesquad.fineants.domain.portfolio.Portfolio;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class DashboardPieChartResponse {
+	private Long id;
+	private String name;
+	private Long valuation;
+	private Double weight;
+	private Long totalGain;
+	private Integer totalGainRate;
+
+	public static DashboardPieChartResponse of(Portfolio portfolio, Long totalValuation) {
+		return new DashboardPieChartResponse(portfolio.getId(), portfolio.getName(), portfolio.calculateTotalAsset()
+			, (double)(portfolio.calculateTotalAsset() / totalValuation) * 100, portfolio.calculateTotalGain(),
+			portfolio.calculateTotalGainRate());
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/response/DashboardPieChartResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/response/DashboardPieChartResponse.java
@@ -3,7 +3,9 @@ package codesquad.fineants.spring.api.dashboard.response;
 import codesquad.fineants.domain.portfolio.Portfolio;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 
+@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class DashboardPieChartResponse {
 	private Long id;
@@ -15,7 +17,7 @@ public class DashboardPieChartResponse {
 
 	public static DashboardPieChartResponse of(Portfolio portfolio, Long totalValuation) {
 		return new DashboardPieChartResponse(portfolio.getId(), portfolio.getName(), portfolio.calculateTotalAsset()
-			, (double)(portfolio.calculateTotalAsset() / totalValuation) * 100, portfolio.calculateTotalGain(),
+			, ((double)portfolio.calculateTotalAsset() / totalValuation) * 100, portfolio.calculateTotalGain(),
 			portfolio.calculateTotalGainRate());
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/response/OverviewResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/response/OverviewResponse.java
@@ -1,0 +1,22 @@
+package codesquad.fineants.spring.api.dashboard.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class OverviewResponse {
+	private String username;
+	private Long totalValuation;
+	private Long totalInvestment;
+	private Integer totalGainRate;
+	private Long totalAnnualDividend;
+	private Integer totalAnnualDividendYield;
+
+	public static OverviewResponse of(String username, Long totalValuation, Long totalInvestment, Integer totalGainRate,
+		Long totalAnnualDividend, Integer totalAnnualDividendYield) {
+		return new OverviewResponse(username, totalValuation, totalInvestment, totalGainRate, totalAnnualDividend,
+			totalAnnualDividendYield);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/response/OverviewResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/response/OverviewResponse.java
@@ -19,4 +19,9 @@ public class OverviewResponse {
 		return new OverviewResponse(username, totalValuation, totalInvestment, totalGainRate, totalAnnualDividend,
 			totalAnnualDividendYield);
 	}
+
+	public static OverviewResponse empty(String username) {
+		return new OverviewResponse(username, 0L, 0L,
+			0, 0L, 0);
+	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
@@ -1,0 +1,54 @@
+package codesquad.fineants.spring.api.dashboard.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import codesquad.fineants.domain.member.Member;
+import codesquad.fineants.domain.member.MemberRepository;
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.portfolio.Portfolio;
+import codesquad.fineants.domain.portfolio.PortfolioRepository;
+import codesquad.fineants.spring.api.dashboard.response.OverviewResponse;
+import codesquad.fineants.spring.api.errors.errorcode.MemberErrorCode;
+import codesquad.fineants.spring.api.errors.exception.BadRequestException;
+import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DashboardService {
+	private final PortfolioRepository portfolioRepository;
+	private final MemberRepository memberRepository;
+	private final CurrentPriceManager currentPriceManager;
+
+	public OverviewResponse getOverview(AuthMember authMember) {
+		List<Portfolio> portfolios = portfolioRepository.findAllByMemberId(authMember.getMemberId());
+		Member member = memberRepository.findById(authMember.getMemberId()).orElseThrow(() -> new BadRequestException(
+			MemberErrorCode.NOT_FOUND_MEMBER));
+		Long totalValuation = 0L;// 평가 금액 + 현금?
+		Long totalCurrentValuation = 0L; // 평가 금액
+		Long totalInvestment = 0L; //총 주식에 투자된 돈
+		long totalGain = 0L; // 총 수익
+		Long totalAnnualDividend = 0L; // 총 연간 배당금
+		if (portfolios.isEmpty()) {
+			return OverviewResponse.of(member.getNickname(), totalValuation, totalInvestment,
+				0,
+				totalAnnualDividend, 0);
+		}
+		for (Portfolio portfolio : portfolios) {
+			portfolio.changeCurrentPriceFromHoldings(currentPriceManager);
+			totalValuation += portfolio.calculateTotalAsset();
+			totalCurrentValuation += portfolio.calculateTotalCurrentValuation();
+			totalInvestment += portfolio.calculateTotalInvestmentAmount();
+			totalGain += portfolio.calculateTotalGain();
+			totalAnnualDividend += portfolio.calculateTotalAnnualDividend();
+		}
+		Integer totalAnnualDividendYield = (int)((totalAnnualDividend / totalCurrentValuation) * 100);
+		Integer totalGainRate = (int)(((double)totalGain / (double)totalInvestment) * 100);
+
+		return OverviewResponse.of(member.getNickname(), totalValuation, totalInvestment,
+			totalGainRate,
+			totalAnnualDividend, totalAnnualDividendYield);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
@@ -64,8 +64,12 @@ public class DashboardService {
 			totalAnnualDividend, totalAnnualDividendYield);
 	}
 
+	@Transactional(readOnly = true)
 	public List<DashboardPieChartResponse> getPieChart(AuthMember authMember) {
 		List<Portfolio> portfolios = portfolioRepository.findAllByMemberId(authMember.getMemberId());
+		if (portfolios.isEmpty()) {
+			return new ArrayList<>();
+		}
 		Long totalValuation = 0L;// 평가 금액 + 현금?
 		for (Portfolio portfolio : portfolios) {
 			portfolio.changeCurrentPriceFromHoldings(currentPriceManager);
@@ -76,11 +80,14 @@ public class DashboardService {
 			pieChartResponses.add(DashboardPieChartResponse.of(portfolio, totalValuation));
 		}
 		return pieChartResponses;
-
 	}
 
+	@Transactional(readOnly = true)
 	public List<DashboardLineChartResponse> getLineChart(AuthMember authMember) {
 		List<Portfolio> portfolios = portfolioRepository.findAllByMemberId(authMember.getMemberId());
+		if (portfolios.isEmpty()) {
+			return new ArrayList<>();
+		}
 		List<PortfolioGainHistory> portfolioGainHistories = new ArrayList<>();
 		for (Portfolio portfolio : portfolios) {
 			portfolioGainHistories.addAll(portfolioGainHistoryRepository.findAllByPortfolioId(portfolio.getId()));

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
@@ -1,6 +1,11 @@
 package codesquad.fineants.spring.api.dashboard.service;
 
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,6 +15,10 @@ import codesquad.fineants.domain.member.MemberRepository;
 import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.domain.portfolio.Portfolio;
 import codesquad.fineants.domain.portfolio.PortfolioRepository;
+import codesquad.fineants.domain.portfolio_gain_history.PortfolioGainHistory;
+import codesquad.fineants.domain.portfolio_gain_history.PortfolioGainHistoryRepository;
+import codesquad.fineants.spring.api.dashboard.response.DashboardLineChartResponse;
+import codesquad.fineants.spring.api.dashboard.response.DashboardPieChartResponse;
 import codesquad.fineants.spring.api.dashboard.response.OverviewResponse;
 import codesquad.fineants.spring.api.errors.errorcode.MemberErrorCode;
 import codesquad.fineants.spring.api.errors.exception.BadRequestException;
@@ -22,6 +31,7 @@ public class DashboardService {
 	private final PortfolioRepository portfolioRepository;
 	private final MemberRepository memberRepository;
 	private final CurrentPriceManager currentPriceManager;
+	private final PortfolioGainHistoryRepository portfolioGainHistoryRepository;
 
 	@Transactional(readOnly = true)
 	public OverviewResponse getOverview(AuthMember authMember) {
@@ -52,5 +62,39 @@ public class DashboardService {
 		return OverviewResponse.of(member.getNickname(), totalValuation, totalInvestment,
 			totalGainRate,
 			totalAnnualDividend, totalAnnualDividendYield);
+	}
+
+	public List<DashboardPieChartResponse> getPieChart(AuthMember authMember) {
+		List<Portfolio> portfolios = portfolioRepository.findAllByMemberId(authMember.getMemberId());
+		Long totalValuation = 0L;// 평가 금액 + 현금?
+		for (Portfolio portfolio : portfolios) {
+			portfolio.changeCurrentPriceFromHoldings(currentPriceManager);
+			totalValuation += portfolio.calculateTotalAsset();
+		}
+		List<DashboardPieChartResponse> pieChartResponses = new ArrayList<>();
+		for (Portfolio portfolio : portfolios) {
+			pieChartResponses.add(DashboardPieChartResponse.of(portfolio, totalValuation));
+		}
+		return pieChartResponses;
+
+	}
+
+	public List<DashboardLineChartResponse> getLineChart(AuthMember authMember) {
+		List<Portfolio> portfolios = portfolioRepository.findAllByMemberId(authMember.getMemberId());
+		List<PortfolioGainHistory> portfolioGainHistories = new ArrayList<>();
+		for (Portfolio portfolio : portfolios) {
+			portfolioGainHistories.addAll(portfolioGainHistoryRepository.findAllByPortfolioId(portfolio.getId()));
+		}
+		Map<String, Long> timeValueMap = new HashMap<>();
+		for (PortfolioGainHistory portfolioGainHistory : portfolioGainHistories) {
+			String time = portfolioGainHistory.getCreateAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+			timeValueMap.put(time, timeValueMap.getOrDefault(time, 0L) + portfolioGainHistory.getCash()
+				+ portfolioGainHistory.getCurrentValuation());
+		}
+		return timeValueMap.keySet()
+			.stream()
+			.map(key -> DashboardLineChartResponse.of(key, timeValueMap.get(key)))
+			.collect(
+				Collectors.toList());
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
@@ -3,6 +3,7 @@ package codesquad.fineants.spring.api.dashboard.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.fineants.domain.member.Member;
 import codesquad.fineants.domain.member.MemberRepository;
@@ -22,6 +23,7 @@ public class DashboardService {
 	private final MemberRepository memberRepository;
 	private final CurrentPriceManager currentPriceManager;
 
+	@Transactional(readOnly = true)
 	public OverviewResponse getOverview(AuthMember authMember) {
 		List<Portfolio> portfolios = portfolioRepository.findAllByMemberId(authMember.getMemberId());
 		Member member = memberRepository.findById(authMember.getMemberId()).orElseThrow(() -> new BadRequestException(

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
@@ -44,9 +44,7 @@ public class DashboardService {
 		long totalGain = 0L; // 총 수익
 		Long totalAnnualDividend = 0L; // 총 연간 배당금
 		if (portfolios.isEmpty()) {
-			return OverviewResponse.of(member.getNickname(), totalValuation, totalInvestment,
-				0,
-				totalAnnualDividend, 0);
+			return OverviewResponse.empty(member.getNickname());
 		}
 		for (Portfolio portfolio : portfolios) {
 			portfolio.changeCurrentPriceFromHoldings(currentPriceManager);

--- a/src/main/java/codesquad/fineants/spring/api/success/code/DashboardSuccessCode.java
+++ b/src/main/java/codesquad/fineants/spring/api/success/code/DashboardSuccessCode.java
@@ -1,0 +1,25 @@
+package codesquad.fineants.spring.api.success.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DashboardSuccessCode implements SuccessCode {
+	OK_OVERVIEW(HttpStatus.OK, "오버뷰 데이터 조회가 완료되었습니다."),
+	OK_PORTFOLIO_PIE_CHART(HttpStatus.OK, "포트폴리오 파이 차트 데이터 조회가 완료되었습니다."),
+	OK_LINE_CHART(HttpStatus.OK, "전체 평가액 데이터 조회가 완료되었습니다.");
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "대시 보드 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/src/test/java/codesquad/fineants/spring/api/dashboard/DashboardServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/dashboard/DashboardServiceTest.java
@@ -52,10 +52,11 @@ public class DashboardServiceTest {
 	@AfterEach
 	void tearDown() {
 		purchaseHistoryRepository.deleteAllInBatch();
-		stockRepository.deleteAllInBatch();
+		portfolioHoldingRepository.deleteAllInBatch();
 		portfolioGainHistoryRepository.deleteAllInBatch();
 		portfolioRepository.deleteAllInBatch();
 		memberRepository.deleteAllInBatch();
+		stockRepository.deleteAllInBatch();
 	}
 
 	@Test

--- a/src/test/java/codesquad/fineants/spring/api/dashboard/DashboardServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/dashboard/DashboardServiceTest.java
@@ -1,0 +1,101 @@
+package codesquad.fineants.spring.api.dashboard;
+
+import static org.assertj.core.api.AssertionsForClassTypes.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import codesquad.fineants.domain.member.Member;
+import codesquad.fineants.domain.member.MemberRepository;
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.portfolio.Portfolio;
+import codesquad.fineants.domain.portfolio.PortfolioRepository;
+import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
+import codesquad.fineants.domain.portfolio_holding.PortfolioHoldingRepository;
+import codesquad.fineants.domain.purchase_history.PurchaseHistory;
+import codesquad.fineants.domain.purchase_history.PurchaseHistoryRepository;
+import codesquad.fineants.domain.stock.Market;
+import codesquad.fineants.domain.stock.Stock;
+import codesquad.fineants.domain.stock.StockRepository;
+import codesquad.fineants.spring.api.dashboard.response.OverviewResponse;
+import codesquad.fineants.spring.api.dashboard.service.DashboardService;
+
+@ActiveProfiles("test")
+@SpringBootTest
+public class DashboardServiceTest {
+	@Autowired
+	MemberRepository memberRepository;
+	@Autowired
+	PortfolioRepository portfolioRepository;
+	@Autowired
+	DashboardService dashboardService;
+	@Autowired
+	PurchaseHistoryRepository purchaseHistoryRepository;
+	@Autowired
+	PortfolioHoldingRepository portfolioHoldingRepository;
+	@Autowired
+	StockRepository stockRepository;
+
+	@Test
+	void getOverviewWhenNoPortfolio() {
+		// given
+		Member member = Member.builder().email("member@member.com").password("password").nickname("nick").build();
+		AuthMember authMember = AuthMember.from(memberRepository.save(member));
+
+		// when
+		OverviewResponse response = dashboardService.getOverview(authMember);
+
+		// then
+		assertThat(response.getUsername()).isEqualTo(member.getNickname());
+		assertThat(response.getTotalValuation()).isEqualTo(0);
+	}
+
+	@Test
+	void getOverviewWithPortfolio() {
+		// given
+		Member member = Member.builder().email("member@member.com").password("password").nickname("nick").build();
+		AuthMember authMember = AuthMember.from(memberRepository.save(member));
+
+		Portfolio portfolio = portfolioRepository.save(Portfolio.builder()
+			.name("내꿈은 워렌버핏")
+			.securitiesFirm("토스")
+			.budget(1000000L)
+			.targetGain(1500000L)
+			.maximumLoss(900000L)
+			.member(member)
+			.build());
+		Stock stock = stockRepository.save(Stock.builder()
+			.companyName("삼성전자보통주")
+			.tickerSymbol("005930")
+			.companyNameEng("SamsungElectronics")
+			.stockCode("KR7005930003")
+			.market(Market.KOSPI)
+			.build());
+
+		PortfolioHolding portfolioHolding = portfolioHoldingRepository.save(
+			PortfolioHolding.of(portfolio, stock, 100L));
+
+		PurchaseHistory purchaseHistory = purchaseHistoryRepository.save(
+			PurchaseHistory.builder()
+				.portfolioHolding(portfolioHolding)
+				.purchaseDate(LocalDateTime.now())
+				.purchasePricePerShare(100.0)
+				.numShares(10L)
+				.build()
+		);
+
+		// when
+		OverviewResponse response = dashboardService.getOverview(authMember);
+
+		// then
+		assertThat(response.getUsername()).isEqualTo(member.getNickname());
+		assertThat((double)response.getTotalInvestment()).isEqualTo(
+			purchaseHistory.getNumShares() * purchaseHistory.getPurchasePricePerShare());
+		assertThat(response.getTotalGainRate() > 0).isTrue();
+	}
+
+}

--- a/src/test/java/codesquad/fineants/spring/api/dashboard/DashboardServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/dashboard/DashboardServiceTest.java
@@ -3,6 +3,7 @@ package codesquad.fineants.spring.api.dashboard;
 import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,7 @@ import codesquad.fineants.domain.purchase_history.PurchaseHistoryRepository;
 import codesquad.fineants.domain.stock.Market;
 import codesquad.fineants.domain.stock.Stock;
 import codesquad.fineants.domain.stock.StockRepository;
+import codesquad.fineants.spring.api.dashboard.response.DashboardPieChartResponse;
 import codesquad.fineants.spring.api.dashboard.response.OverviewResponse;
 import codesquad.fineants.spring.api.dashboard.service.DashboardService;
 
@@ -96,6 +98,94 @@ public class DashboardServiceTest {
 		assertThat((double)response.getTotalInvestment()).isEqualTo(
 			purchaseHistory.getNumShares() * purchaseHistory.getPurchasePricePerShare());
 		assertThat(response.getTotalGainRate() > 0).isTrue();
+	}
+
+	@Test
+	void getPieChartTest() {
+		// given
+		Member member = Member.builder().email("member@member.com").password("password").nickname("nick").build();
+		AuthMember authMember = AuthMember.from(memberRepository.save(member));
+
+		Portfolio portfolio = portfolioRepository.save(Portfolio.builder()
+			.name("내꿈은 워렌버핏")
+			.securitiesFirm("토스")
+			.budget(1000000L)
+			.targetGain(1500000L)
+			.maximumLoss(900000L)
+			.member(member)
+			.build());
+		Portfolio portfolio1 = portfolioRepository.save(Portfolio.builder()
+			.name("내꿈은 워렌버핏1")
+			.securitiesFirm("토스")
+			.budget(1000000L)
+			.targetGain(1500000L)
+			.maximumLoss(900000L)
+			.member(member)
+			.build());
+		Stock stock = stockRepository.save(Stock.builder()
+			.companyName("삼성전자보통주")
+			.tickerSymbol("005930")
+			.companyNameEng("SamsungElectronics")
+			.stockCode("KR7005930003")
+			.market(Market.KOSPI)
+			.build());
+
+		PortfolioHolding portfolioHolding = portfolioHoldingRepository.save(
+			PortfolioHolding.of(portfolio, stock, 100L));
+		PortfolioHolding portfolioHolding1 = portfolioHoldingRepository.save(
+			PortfolioHolding.of(portfolio1, stock, 100L));
+
+		// when
+		List<DashboardPieChartResponse> responses = dashboardService.getPieChart(authMember);
+
+		// then
+		assertThat(responses.get(0).getName()).isEqualTo("내꿈은 워렌버핏");
+		assertThat(responses.size()).isEqualTo(2);
+		assertThat(responses.get(0).getWeight()).isEqualTo(50.0);
+	}
+
+	@Test
+	void getLineChartTest() {
+		// given
+		Member member = Member.builder().email("member@member.com").password("password").nickname("nick").build();
+		AuthMember authMember = AuthMember.from(memberRepository.save(member));
+
+		Portfolio portfolio = portfolioRepository.save(Portfolio.builder()
+			.name("내꿈은 워렌버핏")
+			.securitiesFirm("토스")
+			.budget(1000000L)
+			.targetGain(1500000L)
+			.maximumLoss(900000L)
+			.member(member)
+			.build());
+		Portfolio portfolio1 = portfolioRepository.save(Portfolio.builder()
+			.name("내꿈은 워렌버핏1")
+			.securitiesFirm("토스")
+			.budget(1000000L)
+			.targetGain(1500000L)
+			.maximumLoss(900000L)
+			.member(member)
+			.build());
+		Stock stock = stockRepository.save(Stock.builder()
+			.companyName("삼성전자보통주")
+			.tickerSymbol("005930")
+			.companyNameEng("SamsungElectronics")
+			.stockCode("KR7005930003")
+			.market(Market.KOSPI)
+			.build());
+
+		PortfolioHolding portfolioHolding = portfolioHoldingRepository.save(
+			PortfolioHolding.of(portfolio, stock, 100L));
+		PortfolioHolding portfolioHolding1 = portfolioHoldingRepository.save(
+			PortfolioHolding.of(portfolio1, stock, 100L));
+
+		// when
+		List<DashboardPieChartResponse> responses = dashboardService.getPieChart(authMember);
+
+		// then
+		assertThat(responses.get(0).getName()).isEqualTo("내꿈은 워렌버핏");
+		assertThat(responses.size()).isEqualTo(2);
+		assertThat(responses.get(0).getWeight()).isEqualTo(50.0);
 	}
 
 }


### PR DESCRIPTION
## 구현한 것

- 대시보드
     - 오버뷰 : 모든 포트폴리오의 평가금액, 투자금액, 총손익금액, 총손익율, 총연배당금, 총연배당율을 합한 금액을 조회하는 API
         - api : GET /api/dashboard/overview 
     - 포트폴리오 파이 차트 : 사용자의 포트폴리오들을 대상으로 파이 차트 구성하는 API
         - api : GET /api/dashboard/pieChart 
     - 라인 차트 : 일자별 오버뷰 데이터에 대한 총 자산 그래프 데이터 API
         - api : /api/dashboard/lineChart
