### PR TITLE
[fix] 포트폴리오 상세 조회 응답 프로퍼티 변경

### DIFF
--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -161,19 +161,19 @@ public class Portfolio extends BaseEntity {
 	}
 
 	// 총 연간 배당금 = 각 종목들의 연배당금의 합계
-	public Long calculateTotalAnnualDividend() {
+	public Long calculateAnnualDividend() {
 		return portfolioHoldings.stream()
 			.mapToLong(PortfolioHolding::calculateAnnualDividend)
 			.sum();
 	}
 
 	// 총 연간배당율 = 모든 종목들의 연 배당금 합계 / 모든 종목들의 총 가치의 합계) * 100
-	public Integer calculateTotalAnnualDividendYield() {
+	public Integer calculateAnnualDividendYield() {
 		double currentValuation = calculateTotalCurrentValuation();
 		if (currentValuation == 0) {
 			return 0;
 		}
-		double totalAnnualDividend = calculateTotalAnnualDividend();
+		double totalAnnualDividend = calculateAnnualDividend();
 		return (int)((totalAnnualDividend / currentValuation) * 100);
 	}
 
@@ -188,7 +188,7 @@ public class Portfolio extends BaseEntity {
 		if (totalInvestmentAmount == 0) {
 			return 0;
 		}
-		double totalAnnualDividend = calculateTotalAnnualDividend();
+		double totalAnnualDividend = calculateAnnualDividend();
 		return (int)((totalAnnualDividend / totalInvestmentAmount) * 100);
 	}
 

--- a/src/main/java/codesquad/fineants/domain/stock/Market.java
+++ b/src/main/java/codesquad/fineants/domain/stock/Market.java
@@ -1,5 +1,18 @@
 package codesquad.fineants.domain.stock;
 
+import java.util.Arrays;
+
+import codesquad.fineants.spring.api.errors.errorcode.StockErrorCode;
+import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
+
 public enum Market {
-	KOSPI, KOSDAQ, KONEX;
+	KOSPI, KOSDAQ, KONEX, KOSDAQ_GLOBAL;
+
+	public static Market ofMarket(String dbData) {
+		return Arrays.stream(values())
+			.filter(market -> market.name().equals(dbData))
+			.findAny()
+			.orElseThrow(() -> new NotFoundResourceException(StockErrorCode.NOT_FOUND_MARKET,
+				String.format("%s 종류는 찾을 수 없습니다", dbData)));
+	}
 }

--- a/src/main/java/codesquad/fineants/domain/stock/Stock.java
+++ b/src/main/java/codesquad/fineants/domain/stock/Stock.java
@@ -7,15 +7,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import javax.persistence.Convert;
 import javax.persistence.Entity;
-import javax.persistence.EnumType;
-import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 
 import codesquad.fineants.domain.BaseEntity;
 import codesquad.fineants.domain.purchase_history.PurchaseHistory;
+import codesquad.fineants.domain.stock.converter.MarketConverter;
 import codesquad.fineants.domain.stock_dividend.StockDividend;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
 import codesquad.fineants.spring.api.kis.manager.LastDayClosingPriceManager;
@@ -37,7 +37,7 @@ public class Stock extends BaseEntity {
 	private String companyNameEng;
 	private String stockCode;
 	private String sector;
-	@Enumerated(value = EnumType.STRING)
+	@Convert(converter = MarketConverter.class)
 	private Market market;
 
 	@OneToMany(mappedBy = "stock", fetch = FetchType.LAZY)

--- a/src/main/java/codesquad/fineants/domain/stock/converter/MarketConverter.java
+++ b/src/main/java/codesquad/fineants/domain/stock/converter/MarketConverter.java
@@ -1,0 +1,18 @@
+package codesquad.fineants.domain.stock.converter;
+
+import javax.persistence.AttributeConverter;
+
+import codesquad.fineants.domain.stock.Market;
+
+public class MarketConverter implements AttributeConverter<Market, String> {
+
+	@Override
+	public String convertToDatabaseColumn(Market market) {
+		return market.name().replace("_", " ");
+	}
+
+	@Override
+	public Market convertToEntityAttribute(String dbData) {
+		return Market.ofMarket(dbData.replace(" ", "_"));
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
+++ b/src/main/java/codesquad/fineants/spring/api/dashboard/service/DashboardService.java
@@ -52,7 +52,7 @@ public class DashboardService {
 			totalCurrentValuation += portfolio.calculateTotalCurrentValuation();
 			totalInvestment += portfolio.calculateTotalInvestmentAmount();
 			totalGain += portfolio.calculateTotalGain();
-			totalAnnualDividend += portfolio.calculateTotalAnnualDividend();
+			totalAnnualDividend += portfolio.calculateAnnualDividend();
 		}
 		Integer totalAnnualDividendYield = (int)((totalAnnualDividend / totalCurrentValuation) * 100);
 		Integer totalGainRate = (int)(((double)totalGain / (double)totalInvestment) * 100);

--- a/src/main/java/codesquad/fineants/spring/api/errors/errorcode/PortfolioErrorCode.java
+++ b/src/main/java/codesquad/fineants/spring/api/errors/errorcode/PortfolioErrorCode.java
@@ -11,6 +11,7 @@ public enum PortfolioErrorCode implements ErrorCode {
 
 	TARGET_GAIN_LOSS_IS_EQUAL_LESS_THAN_BUDGET(HttpStatus.BAD_REQUEST, "목표 수익금액은 예산보다 커야 합니다"),
 	MAXIMUM_LOSS_IS_EQUAL_GREATER_THAN_BUDGET(HttpStatus.BAD_REQUEST, "최대 손실 금액은 예산 보다 작아야 합니다"),
+	SECURITIES_FIRM_IS_NOT_CONTAINS(HttpStatus.BAD_REQUEST, "해당 증권사는 포함되어 있지 않습니다"),
 	DUPLICATE_NAME(HttpStatus.CONFLICT, "포트폴리오 이름이 중복되었습니다"),
 	NOT_FOUND_PORTFOLIO(HttpStatus.NOT_FOUND, "포트폴리오를 찾을 수 없습니다"),
 	NOT_HAVE_AUTHORIZATION(HttpStatus.FORBIDDEN, "포트폴리오에 대한 권한이 없습니다");

--- a/src/main/java/codesquad/fineants/spring/api/errors/errorcode/StockErrorCode.java
+++ b/src/main/java/codesquad/fineants/spring/api/errors/errorcode/StockErrorCode.java
@@ -9,7 +9,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum StockErrorCode implements ErrorCode {
 
-	NOT_FOUND_STOCK(HttpStatus.NOT_FOUND, "종목을 찾을 수 없습니다");
+	NOT_FOUND_STOCK(HttpStatus.NOT_FOUND, "종목을 찾을 수 없습니다"),
+	NOT_FOUND_MARKET(HttpStatus.NOT_FOUND, "시장 종류를 찾을 수 없습니다");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
@@ -25,6 +25,7 @@ import codesquad.fineants.spring.api.errors.exception.ConflictException;
 import codesquad.fineants.spring.api.errors.exception.ForBiddenException;
 import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
+import codesquad.fineants.spring.api.portfolio.manager.PortfolioPropertiesManager;
 import codesquad.fineants.spring.api.portfolio.request.PortfolioCreateRequest;
 import codesquad.fineants.spring.api.portfolio.request.PortfolioModifyRequest;
 import codesquad.fineants.spring.api.portfolio.request.PortfoliosDeleteRequest;
@@ -46,11 +47,13 @@ public class PortFolioService {
 	private final PurchaseHistoryRepository purchaseHistoryRepository;
 	private final PortfolioGainHistoryRepository portfolioGainHistoryRepository;
 	private final CurrentPriceManager currentPriceManager;
+	private final PortfolioPropertiesManager portfolioPropertiesManager;
 
 	@Transactional
 	public PortFolioCreateResponse addPortFolio(PortfolioCreateRequest request, AuthMember authMember) {
 		validateTargetGainIsEqualLessThanBudget(request.getTargetGain(), request.getBudget());
 		validateMaximumLossIsEqualGraterThanBudget(request.getMaximumLoss(), request.getBudget());
+		validateSecuritiesFirm(request.getSecuritiesFirm());
 
 		Member member = findMember(authMember.getMemberId());
 
@@ -73,6 +76,12 @@ public class PortFolioService {
 	private void validateMaximumLossIsEqualGraterThanBudget(Long maximumLoss, Long budget) {
 		if (maximumLoss >= budget) {
 			throw new BadRequestException(PortfolioErrorCode.MAXIMUM_LOSS_IS_EQUAL_GREATER_THAN_BUDGET);
+		}
+	}
+
+	private void validateSecuritiesFirm(String securitiesFirm) {
+		if (!portfolioPropertiesManager.contains(securitiesFirm)) {
+			throw new BadRequestException(PortfolioErrorCode.SECURITIES_FIRM_IS_NOT_CONTAINS);
 		}
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/portfolio/manager/PortfolioPropertiesManager.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio/manager/PortfolioPropertiesManager.java
@@ -1,0 +1,16 @@
+package codesquad.fineants.spring.api.portfolio.manager;
+
+import org.springframework.stereotype.Component;
+
+import codesquad.fineants.spring.api.portfolio.properties.PortfolioProperties;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PortfolioPropertiesManager {
+	private final PortfolioProperties portfolioProperties;
+
+	public boolean contains(String securitiesFirm) {
+		return portfolioProperties.contains(securitiesFirm);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/portfolio/properties/PortfolioProperties.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio/properties/PortfolioProperties.java
@@ -1,0 +1,24 @@
+package codesquad.fineants.spring.api.portfolio.properties;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+import lombok.Getter;
+
+@Getter
+@ConfigurationProperties(prefix = "portfolio")
+public class PortfolioProperties {
+	private final List<String> securitiesFirms;
+
+	@ConstructorBinding
+	public PortfolioProperties(String[] securitiesFirm) {
+		this.securitiesFirms = Arrays.asList(securitiesFirm);
+	}
+
+	public boolean contains(String securitiesFirm) {
+		return this.securitiesFirms.contains(securitiesFirm);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioDetailResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioDetailResponse.java
@@ -25,8 +25,8 @@ public class PortfolioDetailResponse {
 	private Long dailyGain;
 	private Integer dailyGainRate;
 	private Long balance;
-	private Long totalAnnualDividend;
-	private Integer totalAnnualDividendYield;
+	private Long annualDividend;
+	private Integer annualDividendYield;
 	private Integer annualInvestmentDividendYield;
 	private Long provisionalLossBalance;
 	private Boolean targetGainNotification;
@@ -36,7 +36,7 @@ public class PortfolioDetailResponse {
 	private PortfolioDetailResponse(Long id, String securitiesFirm, String name, Long budget, Long targetGain,
 		Integer targetReturnRate, Long maximumLoss, Integer maximumLossRate, Long currentValuation, Long investedAmount,
 		Long totalGain, Integer totalGainRate, Long dailyGain, Integer dailyGainRate, Long balance,
-		Long totalAnnualDividend, Integer totalAnnualDividendYield, Integer annualInvestmentDividendYield,
+		Long annualDividend, Integer annualDividendYield, Integer annualInvestmentDividendYield,
 		Long provisionalLossBalance, Boolean targetGainNotification, Boolean maxLossNotification) {
 		this.id = id;
 		this.securitiesFirm = securitiesFirm;
@@ -53,8 +53,8 @@ public class PortfolioDetailResponse {
 		this.dailyGain = dailyGain;
 		this.dailyGainRate = dailyGainRate;
 		this.balance = balance;
-		this.totalAnnualDividend = totalAnnualDividend;
-		this.totalAnnualDividendYield = totalAnnualDividendYield;
+		this.annualDividend = annualDividend;
+		this.annualDividendYield = annualDividendYield;
 		this.annualInvestmentDividendYield = annualInvestmentDividendYield;
 		this.provisionalLossBalance = provisionalLossBalance;
 		this.targetGainNotification = targetGainNotification;
@@ -78,8 +78,8 @@ public class PortfolioDetailResponse {
 			.dailyGain(portfolio.calculateDailyGain(history))
 			.dailyGainRate(portfolio.calculateDailyGainRate(history))
 			.balance(portfolio.calculateBalance())
-			.totalAnnualDividend(portfolio.calculateTotalAnnualDividend())
-			.totalAnnualDividendYield(portfolio.calculateTotalAnnualDividendYield())
+			.annualDividend(portfolio.calculateAnnualDividend())
+			.annualInvestmentDividendYield(portfolio.calculateAnnualDividendYield())
 			.annualInvestmentDividendYield(portfolio.calculateAnnualInvestmentDividendYield())
 			.provisionalLossBalance(0L)
 			.targetGainNotification(portfolio.getTargetGainIsActive())

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioDetailResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioDetailResponse.java
@@ -79,7 +79,7 @@ public class PortfolioDetailResponse {
 			.dailyGainRate(portfolio.calculateDailyGainRate(history))
 			.balance(portfolio.calculateBalance())
 			.annualDividend(portfolio.calculateAnnualDividend())
-			.annualInvestmentDividendYield(portfolio.calculateAnnualDividendYield())
+			.annualDividendYield(portfolio.calculateAnnualDividendYield())
 			.annualInvestmentDividendYield(portfolio.calculateAnnualInvestmentDividendYield())
 			.provisionalLossBalance(0L)
 			.targetGainNotification(portfolio.getTargetGainIsActive())

--- a/src/main/java/codesquad/fineants/spring/config/SpringConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/SpringConfig.java
@@ -1,11 +1,15 @@
 package codesquad.fineants.spring.config;
 
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import codesquad.fineants.spring.api.portfolio.properties.PortfolioProperties;
+
 @EnableScheduling
 @EnableAspectJAutoProxy
+@EnableConfigurationProperties(value = PortfolioProperties.class)
 @Configuration
 public class SpringConfig {
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,6 +24,11 @@ spring:
     import:
       - ./secret/application-secret.yml
       - ./member.yml
+
+portfolio:
+  securities-firm: BNK투자증권,부국증권,케이프투자증권,대신증권,다올투자증권,DB금융투자,이베스트투자증권,유진투자증권,하나증권,한화투자증권,하이투자증권
+    ,현대차증권,IBK투자증권,카카오페이증권,KB증권,키움증권,한국투자증권,한국포스증권,교보증권,메리츠증권,미래에셋증권,나무증권,삼성증권,상상인증권,신한투자증권
+    ,신영증권,SK증권,토스증권,유안타증권,FineAnts
 ---
 spring:
   config:

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -56,7 +56,7 @@ VALUES (now(), 'dragonbead95@naver.com', '일개미2aa1c3d7',
 
 INSERT INTO fineAnts.portfolio (id, budget, maximum_loss, name, securities_firm, target_gain, target_gain_is_active,
                                 maximum_is_active, member_id)
-VALUES (1, 1000000, 900000, '내꿈은 워렌버핏', '토스', 1500000, false, false, 1);
+VALUES (1, 1000000, 900000, '내꿈은 워렌버핏', '토스증권', 1500000, false, false, 1);
 
 INSERT INTO fineAnts.portfolio_holding (id, create_at, modified_at, portfolio_id, ticker_symbol)
 VALUES (1, '2023-10-26 15:25:39.409612', '2023-10-26 15:25:39.409612', 1, '005930');

--- a/src/test/java/codesquad/fineants/spring/api/portfolio/PortFolioServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio/PortFolioServiceTest.java
@@ -92,12 +92,7 @@ class PortFolioServiceTest {
 	void addPortfolio() throws JsonProcessingException {
 		// given
 		Member member = memberRepository.save(createMember());
-		Map<String, Object> body = new HashMap<>();
-		body.put("name", "내꿈은 워렌버핏");
-		body.put("securitiesFirm", "토스");
-		body.put("budget", 1000000L);
-		body.put("targetGain", 1500000L);
-		body.put("maximumLoss", 900000L);
+		Map<String, Object> body = createAddPortfolioRequestBodyMap();
 
 		PortfolioCreateRequest request = objectMapper.readValue(objectMapper.writeValueAsString(body),
 			PortfolioCreateRequest.class);
@@ -120,7 +115,7 @@ class PortFolioServiceTest {
 		Member member = memberRepository.save(createMember());
 		Map<String, Object> body = new HashMap<>();
 		body.put("name", "내꿈은 워렌버핏");
-		body.put("securitiesFirm", "토스");
+		body.put("securitiesFirm", "토스증권");
 		body.put("budget", 1000000L);
 		body.put("targetGain", targetGain);
 		body.put("maximumLoss", 900000L);
@@ -146,7 +141,7 @@ class PortFolioServiceTest {
 		Member member = memberRepository.save(createMember());
 		Map<String, Object> body = new HashMap<>();
 		body.put("name", "내꿈은 워렌버핏");
-		body.put("securitiesFirm", "토스");
+		body.put("securitiesFirm", "토스증권");
 		body.put("budget", 1000000L);
 		body.put("targetGain", 1500000L);
 		body.put("maximumLoss", maximumLoss);
@@ -171,12 +166,7 @@ class PortFolioServiceTest {
 		Member member = memberRepository.save(createMember());
 		portfolioRepository.save(createPortfolio(member));
 
-		Map<String, Object> body = new HashMap<>();
-		body.put("name", "내꿈은 워렌버핏");
-		body.put("securitiesFirm", "토스");
-		body.put("budget", 1000000L);
-		body.put("targetGain", 1500000L);
-		body.put("maximumLoss", 900000L);
+		Map<String, Object> body = createAddPortfolioRequestBodyMap();
 
 		PortfolioCreateRequest request = objectMapper.readValue(objectMapper.writeValueAsString(body),
 			PortfolioCreateRequest.class);
@@ -189,6 +179,24 @@ class PortFolioServiceTest {
 			.isInstanceOf(ConflictException.class)
 			.extracting("message")
 			.isEqualTo("포트폴리오 이름이 중복되었습니다");
+	}
+
+	@DisplayName("회원은 포트폴리오 추가시 목록에 없는 증권사를 입력하여 추가할 수 없다")
+	@Test
+	void addPortfolio_shouldNotAllowNonExistingSecurities() throws JsonProcessingException {
+		Member member = memberRepository.save(createMember());
+		Map<String, Object> body = createAddPortfolioRequestBodyMap("없는증권");
+
+		PortfolioCreateRequest request = objectMapper.readValue(objectMapper.writeValueAsString(body),
+			PortfolioCreateRequest.class);
+
+		// when
+		Throwable throwable = catchThrowable(() -> service.addPortFolio(request, AuthMember.from(member)));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(BadRequestException.class)
+			.hasMessage("해당 증권사는 포함되어 있지 않습니다");
 	}
 
 	@DisplayName("회원이 포트폴리오를 수정한다")
@@ -434,7 +442,7 @@ class PortFolioServiceTest {
 	private Portfolio createPortfolio(Member member, String name) {
 		return Portfolio.builder()
 			.name(name)
-			.securitiesFirm("토스")
+			.securitiesFirm("토스증권")
 			.budget(1000000L)
 			.targetGain(1500000L)
 			.maximumLoss(900000L)
@@ -448,7 +456,7 @@ class PortFolioServiceTest {
 		String randomPostfix = UUID.randomUUID().toString().substring(0, 10);
 		return Portfolio.builder()
 			.name("내꿈은 워렌버핏" + randomPostfix)
-			.securitiesFirm("토스")
+			.securitiesFirm("토스증권")
 			.budget(1000000L)
 			.targetGain(1500000L)
 			.maximumLoss(900000L)
@@ -537,6 +545,20 @@ class PortFolioServiceTest {
 		body.put("budget", budget);
 		body.put("targetGain", targetGain);
 		body.put("maximumLoss", maximumLoss);
+		return body;
+	}
+
+	private Map<String, Object> createAddPortfolioRequestBodyMap() {
+		return createAddPortfolioRequestBodyMap("토스증권");
+	}
+
+	private Map<String, Object> createAddPortfolioRequestBodyMap(String securitiesFirm) {
+		Map<String, Object> body = new HashMap<>();
+		body.put("name", "내꿈은 워렌버핏");
+		body.put("securitiesFirm", securitiesFirm);
+		body.put("budget", 1000000L);
+		body.put("targetGain", 1500000L);
+		body.put("maximumLoss", 900000L);
 		return body;
 	}
 }

--- a/src/test/java/codesquad/fineants/spring/api/portfolio/properties/PortfolioPropertiesTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio/properties/PortfolioPropertiesTest.java
@@ -1,0 +1,30 @@
+package codesquad.fineants.spring.api.portfolio.properties;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class PortfolioPropertiesTest {
+
+	@Value("${portfolio.securities-firm}")
+	private String[] securitiesFirm;
+
+	@DisplayName("스프링 컨텍스트가 초기화되면 증권사 데이터들이 주입된다")
+	@Test
+	void whenContextIsInitialized_thenInjectedSecuritiesFirmContainsExpectedValues() {
+		String[] securities = {
+			"BNK투자증권", "부국증권", "케이프투자증권", "대신증권", "다올투자증권",
+			"DB금융투자", "이베스트투자증권", "유진투자증권", "하나증권", "한화투자증권",
+			"하이투자증권", "현대차증권", "IBK투자증권", "카카오페이증권", "KB증권",
+			"키움증권", "한국투자증권", "한국포스증권", "교보증권", "메리츠증권",
+			"미래에셋증권", "나무증권", "삼성증권", "상상인증권", "신한투자증권",
+			"신영증권", "SK증권", "토스증권", "유안타증권", "FineAnts"
+		};
+		Assertions.assertThat(securitiesFirm).containsExactlyInAnyOrder(securities);
+	}
+}

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/PortfolioStockServiceTest.java
@@ -105,7 +105,7 @@ class PortfolioStockServiceTest {
 			() -> assertThat(response).extracting("portfolioDetails")
 				.extracting("securitiesFirm", "name", "budget", "targetGain", "targetReturnRate",
 					"maximumLoss", "maximumLossRate", "investedAmount", "totalGain", "totalGainRate", "dailyGain",
-					"dailyGainRate", "balance", "totalAnnualDividend", "totalAnnualDividendYield",
+					"dailyGainRate", "balance", "annualDividend", "annualDividendYield",
 					"provisionalLossBalance",
 					"targetGainNotification", "maxLossNotification")
 				.containsExactlyInAnyOrder("토스", "내꿈은 워렌버핏", 1000000L, 1500000L, 50, 900000L, 10, 150000L, 30000L,


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 상세 조회 API 응답값의 프로퍼티를 변경하였습니다.
     - totalAunnalDividend -> annualDividend
     - totalAnnualDividendYield ->  annualDividendYield 

## 실행결과
<img width="1010" alt="image" src="https://github.com/fine-ants/FineAnts-was/assets/33227831/ddd86ad2-75cc-4986-b051-4bd0947066ab">

