### PR TITLE
[fix] delete portfolioGainHisotry when deleting portfolio

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
@@ -157,6 +157,7 @@ public class PortFolioService {
 				.collect(Collectors.toList());
 			purchaseHistoryRepository.deleteAllByPortfolioHoldingIdIn(portfolioStockIds);
 			portfolioHoldingRepository.deleteAllByPortfolioId(portfolio.getId());
+			portfolioGainHistoryRepository.deleteAllByPortfolioId(portfolioId);
 			portfolioRepository.deleteById(portfolio.getId());
 		}
 	}

--- a/src/test/java/codesquad/fineants/spring/api/portfolio/PortFolioServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio/PortFolioServiceTest.java
@@ -408,9 +408,11 @@ class PortFolioServiceTest {
 		PortfolioHolding portfolioHolding = portFolioHoldingRepository.save(createPortfolioHolding(portfolio, stock));
 		PurchaseHistory purchaseHistory1 = purchaseHistoryRepository.save(createPurchaseHistory(portfolioHolding));
 		PurchaseHistory purchaseHistory2 = purchaseHistoryRepository.save(createPurchaseHistory(portfolioHolding));
+		PortfolioGainHistory portfolioGainHistory = portfolioGainHistoryRepository.save(createPortfolioGainHistory(portfolio));
 		Portfolio portfolio2 = portfolioRepository.save(createPortfolioWithRandomName(member));
 
 		PortfoliosDeleteRequest request = new PortfoliosDeleteRequest(List.of(portfolio.getId(), portfolio2.getId()));
+
 		// when
 		service.deletePortfolios(request, AuthMember.from(member));
 
@@ -419,6 +421,7 @@ class PortFolioServiceTest {
 		assertThat(portFolioHoldingRepository.existsById(portfolioHolding.getId())).isFalse();
 		assertThat(purchaseHistoryRepository.existsById(purchaseHistory1.getId())).isFalse();
 		assertThat(purchaseHistoryRepository.existsById(purchaseHistory2.getId())).isFalse();
+		assertThat(portfolioGainHistoryRepository.existsById(portfolioGainHistory.getId())).isFalse();
 		assertThat(portfolioRepository.existsById(portfolio2.getId())).isFalse();
 	}
 


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 삭제시 포트폴리오 손익 내역 데이터가 삭제되도록 로직을 변경했습니다.
- 서비스 테스트코드에 손익 내역 데이터가 삭제되었는지 확인하는 로직을 추가했습니다.
