### PR TITLE
[fix] get rid of watchlists in response

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListRestController.java
@@ -37,7 +37,7 @@ public class WatchListRestController {
 	}
 
 	@GetMapping
-	public ApiResponse<ReadWatchListsResponse> readWatchLists(@AuthPrincipalMember AuthMember authMember){
+	public ApiResponse<List<ReadWatchListsResponse>> readWatchLists(@AuthPrincipalMember AuthMember authMember){
 		return ApiResponse.success(WatchListSuccessCode.READ_WATCH_LISTS, watchListService.readWatchLists(authMember));
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListService.java
+++ b/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListService.java
@@ -53,7 +53,7 @@ public class WatchListService {
 	}
 
 	@Transactional(readOnly = true)
-	public ReadWatchListsResponse readWatchLists(AuthMember authMember) {
+	public List<ReadWatchListsResponse> readWatchLists(AuthMember authMember) {
 		Member member = findMember(authMember.getMemberId());
 		List<WatchList> watchLists = watchListRepository.findByMember(member);
 		return ReadWatchListsResponse.from(watchLists);

--- a/src/main/java/codesquad/fineants/spring/api/watch_list/response/ReadWatchListsResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/watch_list/response/ReadWatchListsResponse.java
@@ -10,19 +10,12 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ReadWatchListsResponse {
-	private List<WatchListResponse> watchLists;
+	private Long id;
+	private String name;
 
-	@Getter
-	@AllArgsConstructor
-	public static class WatchListResponse {
-		private Long id;
-		private String name;
-	}
-
-	public static ReadWatchListsResponse from(List<WatchList> watchLists) {
-		List<WatchListResponse> responses = watchLists.stream()
-			.map(watchList -> new WatchListResponse(watchList.getId(), watchList.getName()))
+	public static List<ReadWatchListsResponse> from(List<WatchList> watchLists) {
+		return watchLists.stream()
+			.map(watchList -> new ReadWatchListsResponse(watchList.getId(), watchList.getName()))
 			.collect(Collectors.toList());
-		return new ReadWatchListsResponse(responses);
 	}
 }

--- a/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListRestControllerTest.java
@@ -124,11 +124,9 @@ class WatchListRestControllerTest {
 		given(authPrincipalArgumentResolver.supportsParameter(any())).willReturn(true);
 		given(authPrincipalArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(authMember);
 
-		ReadWatchListsResponse response = new ReadWatchListsResponse(
-			Arrays.asList(
-				new ReadWatchListsResponse.WatchListResponse(1L, "My WatchList 1"),
-				new ReadWatchListsResponse.WatchListResponse(2L, "My WatchList 2")
-			)
+		List<ReadWatchListsResponse> response = Arrays.asList(
+			new ReadWatchListsResponse(1L, "My WatchList 1"),
+			new ReadWatchListsResponse(2L, "My WatchList 2")
 		);
 		given(watchListService.readWatchLists(any(AuthMember.class))).willReturn(response);
 
@@ -139,10 +137,10 @@ class WatchListRestControllerTest {
 			.andExpect(jsonPath("code").value(equalTo(200)))
 			.andExpect(jsonPath("status").value(equalTo("OK")))
 			.andExpect(jsonPath("message").value(equalTo("관심목록 목록 조회가 완료되었습니다")))
-			.andExpect(jsonPath("data.watchLists[0].id").value(1L))
-			.andExpect(jsonPath("data.watchLists[0].name").value("My WatchList 1"))
-			.andExpect(jsonPath("data.watchLists[1].id").value(2L))
-			.andExpect(jsonPath("data.watchLists[1].name").value("My WatchList 2"));
+			.andExpect(jsonPath("data[0].id").value(1L))
+			.andExpect(jsonPath("data[0].name").value("My WatchList 1"))
+			.andExpect(jsonPath("data[1].id").value(2L))
+			.andExpect(jsonPath("data[1].name").value("My WatchList 2"));
 	}
 
 	@DisplayName("사용자가 watchlist 단일 조회를 한다.")

--- a/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListServiceTest.java
@@ -124,10 +124,10 @@ class WatchListServiceTest {
 		);
 
 		//when
-		ReadWatchListsResponse response = watchListService.readWatchLists(authMember);
+		List<ReadWatchListsResponse> response = watchListService.readWatchLists(authMember);
 
 		//then
-		assertThat(response.getWatchLists().size()).isEqualTo(2);
+		assertThat(response.size()).isEqualTo(2);
 	}
 
 	@DisplayName("회원이 watchlist 단일 목록을 조회한다.")


### PR DESCRIPTION
## 구현한 것

- GET /api/watchlists의 응답 형식을 변경했습니다.