### PR TITLE
[fix] 서버 시작시 한국투자증권 액세스 토큰 재발급 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,6 +62,10 @@ dependencies {
     //encoder 추가
     implementation 'org.springframework.security:spring-security-crypto'
 
+    // mockWebserver
+    testImplementation 'com.squareup.okhttp3:okhttp:4.12.0';
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/codesquad/fineants/spring/api/kis/aop/AccessTokenAspect.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/aop/AccessTokenAspect.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Component;
 
 import codesquad.fineants.spring.api.kis.client.KisClient;
 import codesquad.fineants.spring.api.kis.manager.KisAccessTokenManager;
+import codesquad.fineants.spring.api.kis.properties.OauthKisProperties;
 import codesquad.fineants.spring.api.kis.service.KisRedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +23,7 @@ public class AccessTokenAspect {
 	private final KisAccessTokenManager manager;
 	private final KisClient client;
 	private final KisRedisService redisService;
+	private final OauthKisProperties oauthKisProperties;
 
 	@Pointcut("execution(* codesquad.fineants.spring.api.kis.service.KisService.refreshStockCurrentPrice())")
 	public void refreshStockPrice() {
@@ -41,7 +43,7 @@ public class AccessTokenAspect {
 	}
 
 	private Runnable handleNewAccessToken(LocalDateTime now) {
-		return () -> client.accessToken()
+		return () -> client.accessToken(oauthKisProperties.getTokenURI())
 			.subscribe(accessToken -> {
 				redisService.setAccessTokenMap(accessToken, now);
 				manager.refreshAccessToken(accessToken);

--- a/src/main/java/codesquad/fineants/spring/api/kis/aop/AccessTokenAspect.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/aop/AccessTokenAspect.java
@@ -1,7 +1,6 @@
 package codesquad.fineants.spring.api.kis.aop;
 
 import java.time.LocalDateTime;
-import java.util.Map;
 import java.util.Optional;
 
 import org.aspectj.lang.annotation.Aspect;
@@ -9,11 +8,13 @@ import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
 
+import codesquad.fineants.spring.api.kis.client.KisAccessToken;
 import codesquad.fineants.spring.api.kis.client.KisClient;
 import codesquad.fineants.spring.api.kis.manager.KisAccessTokenManager;
 import codesquad.fineants.spring.api.kis.service.KisRedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -37,17 +38,19 @@ public class AccessTokenAspect {
 	public void checkAccessTokenExpiration() {
 		LocalDateTime now = LocalDateTime.now();
 		if (manager.isAccessTokenExpired(now)) {
-			final Optional<Map<String, Object>> optionalMap = redisService.getAccessTokenMap();
-			optionalMap.ifPresentOrElse(accessTokenMap -> {
-				log.info("기존 accessToken 존재로 인한 재사용 : {}", accessTokenMap);
-				manager.refreshAccessToken(accessTokenMap);
+			Optional<KisAccessToken> optionalAccessToken = redisService.getAccessTokenMap();
+			optionalAccessToken.ifPresentOrElse(accessToken -> {
+				log.info("기존 accessToken 존재로 인한 재사용 : {}", accessToken);
+				manager.refreshAccessToken(accessToken);
 				log.info("기존 accessToken으로 갱신한 manager : {}", manager);
 			}, () -> {
-				final Map<String, Object> newAccessTokenMap = client.accessToken();
-				log.info("kis accessToken 만료로 인한 새로운 accessToken 갱신, newAccessTokenMap : {}", newAccessTokenMap);
-				redisService.setAccessTokenMap(newAccessTokenMap, now);
-				manager.refreshAccessToken(newAccessTokenMap);
-				log.info("새로 발급한 accessToken으로 갱신한 manager : {}", manager);
+				Mono<KisAccessToken> accessTokenMono = client.accessToken();
+				accessTokenMono.subscribe(accessToken -> {
+					log.info("kis accessToken 만료로 인한 새로운 accessToken 갱신, accessToken : {}", accessToken);
+					redisService.setAccessTokenMap(accessToken, now);
+					manager.refreshAccessToken(accessToken);
+					log.info("새로 발급한 accessToken으로 갱신한 manager : {}", manager);
+				});
 			});
 		}
 	}

--- a/src/main/java/codesquad/fineants/spring/api/kis/aop/AccessTokenAspect.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/aop/AccessTokenAspect.java
@@ -45,6 +45,7 @@ public class AccessTokenAspect {
 			.subscribe(accessToken -> {
 				redisService.setAccessTokenMap(accessToken, now);
 				manager.refreshAccessToken(accessToken);
+				log.info("새로운 액세스 토큰 갱신 완료");
 			});
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/kis/aop/AccessTokenAspect.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/aop/AccessTokenAspect.java
@@ -1,20 +1,17 @@
 package codesquad.fineants.spring.api.kis.aop;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.aspectj.lang.annotation.Pointcut;
 import org.springframework.stereotype.Component;
 
-import codesquad.fineants.spring.api.kis.client.KisAccessToken;
 import codesquad.fineants.spring.api.kis.client.KisClient;
 import codesquad.fineants.spring.api.kis.manager.KisAccessTokenManager;
 import codesquad.fineants.spring.api.kis.service.KisRedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import reactor.core.publisher.Mono;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -38,20 +35,16 @@ public class AccessTokenAspect {
 	public void checkAccessTokenExpiration() {
 		LocalDateTime now = LocalDateTime.now();
 		if (manager.isAccessTokenExpired(now)) {
-			Optional<KisAccessToken> optionalAccessToken = redisService.getAccessTokenMap();
-			optionalAccessToken.ifPresentOrElse(accessToken -> {
-				log.info("기존 accessToken 존재로 인한 재사용 : {}", accessToken);
-				manager.refreshAccessToken(accessToken);
-				log.info("기존 accessToken으로 갱신한 manager : {}", manager);
-			}, () -> {
-				Mono<KisAccessToken> accessTokenMono = client.accessToken();
-				accessTokenMono.subscribe(accessToken -> {
-					log.info("kis accessToken 만료로 인한 새로운 accessToken 갱신, accessToken : {}", accessToken);
-					redisService.setAccessTokenMap(accessToken, now);
-					manager.refreshAccessToken(accessToken);
-					log.info("새로 발급한 accessToken으로 갱신한 manager : {}", manager);
-				});
-			});
+			redisService.getAccessTokenMap()
+				.ifPresentOrElse(manager::refreshAccessToken, handleNewAccessToken(now));
 		}
+	}
+
+	private Runnable handleNewAccessToken(LocalDateTime now) {
+		return () -> client.accessToken()
+			.subscribe(accessToken -> {
+				redisService.setAccessTokenMap(accessToken, now);
+				manager.refreshAccessToken(accessToken);
+			});
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/kis/client/KisAccessToken.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/client/KisAccessToken.java
@@ -11,10 +11,14 @@ import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
+@ToString
+@EqualsAndHashCode
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class KisAccessToken {
 	@JsonProperty("access_token")

--- a/src/main/java/codesquad/fineants/spring/api/kis/client/KisAccessToken.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/client/KisAccessToken.java
@@ -1,0 +1,50 @@
+package codesquad.fineants.spring.api.kis.client;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class KisAccessToken {
+	@JsonProperty("access_token")
+	private String accessToken;
+	@JsonProperty("token_type")
+	private String tokenType;
+	@JsonProperty("access_token_token_expired")
+	@JsonSerialize(using = LocalDateTimeSerializer.class)
+	@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+	@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+	private LocalDateTime accessTokenExpired;
+	@JsonProperty("expires_in")
+	private Integer expiresIn;
+
+	public KisAccessToken(String accessToken, String tokenType, LocalDateTime accessTokenExpired, Integer expiresIn) {
+		this.accessToken = accessToken;
+		this.tokenType = tokenType;
+		this.accessTokenExpired = accessTokenExpired;
+		this.expiresIn = expiresIn;
+	}
+
+	public Duration betweenSecondFrom(LocalDateTime localDateTime) {
+		return Duration.ofSeconds(Duration.between(localDateTime, accessTokenExpired).toSeconds());
+	}
+
+	public boolean isAccessTokenExpired(LocalDateTime dateTime) {
+		return accessTokenExpired != null && dateTime.isAfter(accessTokenExpired);
+	}
+
+	public String createAuthorization() {
+		return String.format("%s %s", tokenType, accessToken);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/client/KisClient.java
@@ -63,17 +63,19 @@ public class KisClient {
 			.flatMap(body -> Mono.error(() -> new KisException(body)));
 	}
 
-	public Map<String, Object> accessToken() {
+	public Mono<KisAccessToken> accessToken() {
 		Map<String, String> requestBodyMap = new HashMap<>();
 		requestBodyMap.put("grant_type", "client_credentials");
 		requestBodyMap.put("appkey", appkey);
 		requestBodyMap.put("appsecret", secretkey);
 
-		return postPerform(
-			tokenPURI,
-			new LinkedMultiValueMap<>(),
-			requestBodyMap
-		);
+		return webClient.build()
+			.post()
+			.uri(tokenPURI)
+			.bodyValue(requestBodyMap)
+			.retrieve()
+			.bodyToMono(KisAccessToken.class);
+		// return postPerform(tokenPURI, new LinkedMultiValueMap<>(), requestBodyMap);
 	}
 
 	public long readRealTimeCurrentPrice(String tickerSymbol, String authorization) {

--- a/src/main/java/codesquad/fineants/spring/api/kis/config/KisConfig.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/config/KisConfig.java
@@ -1,0 +1,22 @@
+package codesquad.fineants.spring.api.kis.config;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import codesquad.fineants.spring.api.kis.properties.OauthKisProperties;
+
+@EnableConfigurationProperties(value = OauthKisProperties.class)
+@Configuration
+public class KisConfig {
+
+	public static final String baseUrl = "https://openapivts.koreainvestment.com:29443";
+
+	@Bean(name = "kisWebClient")
+	public WebClient webClient() {
+		return WebClient.builder()
+			.baseUrl(baseUrl)
+			.build();
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/kis/manager/KisAccessTokenManager.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/manager/KisAccessTokenManager.java
@@ -1,12 +1,10 @@
 package codesquad.fineants.spring.api.kis.manager;
 
-import static codesquad.fineants.spring.api.kis.service.KisRedisService.*;
-
 import java.time.LocalDateTime;
-import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
+import codesquad.fineants.spring.api.kis.client.KisAccessToken;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
@@ -17,36 +15,21 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
 public class KisAccessTokenManager {
-	private String accessToken;
-	private String tokenType;
-	private LocalDateTime expirationDatetime;
 
-	public static KisAccessTokenManager from(Map<String, Object> accessTokenMap) {
-		return new KisAccessTokenManager(
-			(String)accessTokenMap.get("access_token"),
-			(String)accessTokenMap.get("token_type"),
-			LocalDateTime.parse((String)accessTokenMap.get("access_token_token_expired"),
-				formatter));
-	}
+	private KisAccessToken accessToken;
 
 	public boolean isAccessTokenExpired(LocalDateTime dateTime) {
-		if (expirationDatetime == null) {
-			return true;
-		}
-		return dateTime.isAfter(expirationDatetime);
+		return accessToken.isAccessTokenExpired(dateTime);
 	}
 
-	public void refreshAccessToken(Map<String, Object> accessTokenMap) {
-		this.accessToken = (String)accessTokenMap.get("access_token");
-		this.tokenType = (String)accessTokenMap.get("token_type");
-		this.expirationDatetime = LocalDateTime.parse((String)accessTokenMap.get("access_token_token_expired"),
-			formatter);
+	public void refreshAccessToken(KisAccessToken accessToken) {
+		this.accessToken = accessToken;
 	}
 
 	public String createAuthorization() {
-		return String.format("%s %s", tokenType, accessToken);
+		return accessToken.createAuthorization();
 	}
 }
 

--- a/src/main/java/codesquad/fineants/spring/api/kis/manager/KisAccessTokenManager.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/manager/KisAccessTokenManager.java
@@ -21,6 +21,9 @@ public class KisAccessTokenManager {
 	private KisAccessToken accessToken;
 
 	public boolean isAccessTokenExpired(LocalDateTime dateTime) {
+		if (accessToken == null) {
+			return true;
+		}
 		return accessToken.isAccessTokenExpired(dateTime);
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/kis/properties/OauthKisProperties.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/properties/OauthKisProperties.java
@@ -11,10 +11,17 @@ public class OauthKisProperties {
 
 	private final String appkey;
 	private final String secretkey;
+	private final String tokenURI;
+	private final String currentPriceURI;
+	private final String lastDayClosingPriceURI;
 
 	@ConstructorBinding
-	public OauthKisProperties(String appkey, String secretkey) {
+	public OauthKisProperties(String appkey, String secretkey, String tokenURI, String currentPriceURI,
+		String lastDayClosingPriceURI) {
 		this.appkey = appkey;
 		this.secretkey = secretkey;
+		this.tokenURI = tokenURI;
+		this.currentPriceURI = currentPriceURI;
+		this.lastDayClosingPriceURI = lastDayClosingPriceURI;
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/kis/service/KisRedisService.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/service/KisRedisService.java
@@ -56,10 +56,10 @@ public class KisRedisService {
 	}
 
 	public void setAccessTokenMap(KisAccessToken accessToken, LocalDateTime now) {
-		String json = ObjectMapperUtil.serialize(accessToken);
-		Duration timeout = accessToken.betweenSecondFrom(now);
 		try {
-			redisTemplate.opsForValue().set(ACCESS_TOKEN_MAP_KEY, json, timeout);
+			redisTemplate.opsForValue().set(ACCESS_TOKEN_MAP_KEY,
+				ObjectMapperUtil.serialize(accessToken),
+				accessToken.betweenSecondFrom(now));
 		} catch (RedisSystemException e) {
 			log.error(e.getMessage(), e);
 			throw new RuntimeException(e.getMessage());

--- a/src/main/java/codesquad/fineants/spring/api/kis/service/KisRedisService.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/service/KisRedisService.java
@@ -11,9 +11,10 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import codesquad.fineants.spring.api.kis.client.KisAccessToken;
+import codesquad.fineants.spring.util.ObjectMapperUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,22 +28,12 @@ public class KisRedisService {
 	private final RedisTemplate<String, Object> redisTemplate;
 	private final ObjectMapper objectMapper;
 
-	public Optional<Map<String, Object>> getAccessTokenMap() {
-		if (Boolean.FALSE.equals(redisTemplate.hasKey(ACCESS_TOKEN_MAP_KEY))) {
-			return Optional.empty();
-		}
-
+	public Optional<KisAccessToken> getAccessTokenMap() {
 		Object result = redisTemplate.opsForValue().get(ACCESS_TOKEN_MAP_KEY);
 		if (result == null) {
 			return Optional.empty();
 		}
-		try {
-			Map<String, Object> accessTokenMap = objectMapper.readValue((String)result, new TypeReference<>() {
-			});
-			return Optional.ofNullable(accessTokenMap);
-		} catch (JsonProcessingException e) {
-			throw new RuntimeException(e);
-		}
+		return Optional.ofNullable(ObjectMapperUtil.deserialize((String)result, KisAccessToken.class));
 	}
 
 	public void setAccessTokenMap(Map<String, Object> accessTokenMap, LocalDateTime now) {
@@ -62,7 +53,17 @@ public class KisRedisService {
 			log.error(e.getMessage(), e);
 			throw new RuntimeException(e.getMessage());
 		}
+	}
 
+	public void setAccessTokenMap(KisAccessToken accessToken, LocalDateTime now) {
+		String json = ObjectMapperUtil.serialize(accessToken);
+		Duration timeout = accessToken.betweenSecondFrom(now);
+		try {
+			redisTemplate.opsForValue().set(ACCESS_TOKEN_MAP_KEY, json, timeout);
+		} catch (RedisSystemException e) {
+			log.error(e.getMessage(), e);
+			throw new RuntimeException(e.getMessage());
+		}
 	}
 
 	public void deleteAccessTokenMap() {

--- a/src/main/java/codesquad/fineants/spring/config/OauthConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/OauthConfig.java
@@ -6,11 +6,10 @@ import org.springframework.context.annotation.Configuration;
 
 import codesquad.fineants.domain.oauth.properties.OauthProperties;
 import codesquad.fineants.domain.oauth.repository.InMemoryOauthClientRepository;
-import codesquad.fineants.spring.api.kis.properties.OauthKisProperties;
 import codesquad.fineants.spring.api.member.service.WebClientWrapper;
 import lombok.RequiredArgsConstructor;
 
-@EnableConfigurationProperties({OauthProperties.class, OauthKisProperties.class})
+@EnableConfigurationProperties({OauthProperties.class})
 @RequiredArgsConstructor
 @Configuration
 public class OauthConfig {

--- a/src/test/java/codesquad/fineants/spring/api/kis/client/KisClientTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/kis/client/KisClientTest.java
@@ -1,0 +1,85 @@
+package codesquad.fineants.spring.api.kis.client;
+
+import static java.nio.charset.StandardCharsets.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import codesquad.fineants.spring.util.ObjectMapperUtil;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+import reactor.util.retry.Retry;
+
+@Slf4j
+@ActiveProfiles("test")
+@SpringBootTest
+class KisClientTest {
+
+	@Autowired
+	private KisClient kisClient;
+
+	@MockBean
+	private WebClient webClient;
+
+	@DisplayName("한국투자증권 서버로부터 액세스 토큰 발급이 한번 실패하는 경우 재발급을 다시 요청한다")
+	@Test
+	void accessToken() {
+		// given
+		WebClient.RequestBodyUriSpec requestBodyUriSpec = Mockito.mock(WebClient.RequestBodyUriSpec.class);
+		WebClient.RequestHeadersSpec requestHeadersSpec = Mockito.mock(WebClient.RequestHeadersSpec.class);
+		WebClient.ResponseSpec responseSpec = Mockito.mock(WebClient.ResponseSpec.class);
+
+		KisAccessToken accessToken = createKisAccessToken();
+		when(webClient.post()).thenReturn(requestBodyUriSpec);
+		when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodyUriSpec);
+		when(requestBodyUriSpec.bodyValue(anyMap())).thenReturn(requestHeadersSpec);
+		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+
+		when(responseSpec.onStatus(any(), any()))
+			.thenReturn(responseSpec);
+		when(responseSpec.bodyToMono(KisAccessToken.class))
+			.thenReturn(Mono.error(createError()));
+		when(responseSpec.bodyToMono(KisAccessToken.class)
+			.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofMinutes(1L)))
+		).thenReturn(Mono.just(accessToken));
+
+		// when & then
+		Mono<KisAccessToken> mono = kisClient.accessToken();
+		StepVerifier.create(mono)
+			.expectNext(accessToken)
+			.verifyComplete();
+	}
+
+	private WebClientResponseException createError() {
+		Map<String, String> responseBody = new HashMap<>();
+		responseBody.put("error_description", "접근토큰 발급 잠시 후 다시 시도하세요(1분당 1회)");
+		responseBody.put("error_code", "EGW00133");
+		return new WebClientResponseException("Forbidden", HttpStatus.FORBIDDEN.value(),
+			"Forbidden", null, ObjectMapperUtil.serialize(responseBody).getBytes(UTF_8),
+			UTF_8);
+	}
+
+	private KisAccessToken createKisAccessToken() {
+		return new KisAccessToken(
+			"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJ0b2tlbiIsImF1ZCI6ImE1OGY4YzAyLWMzMzYtNGY3ZC04OGE0LWZkZDRhZTA3NmQ5YyIsImlzcyI6InVub2d3IiwiZXhwIjoxNzAxOTE2ODg3LCJpYXQiOjE3MDE4MzA0ODcsImp0aSI6IlBTRGc4WlVJd041eVl5ZkR6bnA0TDM2Z2xhRUpic2RJNGd6biJ9.uLZAu9_ompf8ycwiRJ5jrdoB-MiUG9a8quoQ3OeVOrUDGxyEhHmzZTPnCdLRWOEHowFlmyNOf3v-lPZGZqi9Kw",
+			"Bearer",
+			LocalDateTime.of(2023, 12, 7, 11, 41, 27),
+			86400
+		);
+	}
+}

--- a/src/test/java/codesquad/fineants/spring/api/kis/client/KisClientTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/kis/client/KisClientTest.java
@@ -38,7 +38,7 @@ class KisClientTest {
 
 	@DisplayName("한국투자증권 서버로부터 액세스 토큰 발급이 한번 실패하는 경우 재발급을 다시 요청한다")
 	@Test
-	void accessToken() {
+	void accessToken_whenIssueAccessToken_thenRetryOnAccessTokenFailure() {
 		// given
 		WebClient.RequestBodyUriSpec requestBodyUriSpec = Mockito.mock(WebClient.RequestBodyUriSpec.class);
 		WebClient.RequestHeadersSpec requestHeadersSpec = Mockito.mock(WebClient.RequestHeadersSpec.class);

--- a/src/test/java/codesquad/fineants/spring/api/kis/client/KisClientTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/kis/client/KisClientTest.java
@@ -1,77 +1,96 @@
 package codesquad.fineants.spring.api.kis.client;
 
-import static java.nio.charset.StandardCharsets.*;
-import static org.mockito.BDDMockito.*;
-
+import java.io.IOException;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.reactive.function.client.WebClient;
-import org.springframework.web.reactive.function.client.WebClientResponseException;
 
+import codesquad.fineants.spring.api.kis.properties.OauthKisProperties;
+import codesquad.fineants.spring.api.kis.service.KisService;
 import codesquad.fineants.spring.util.ObjectMapperUtil;
 import lombok.extern.slf4j.Slf4j;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
-import reactor.util.retry.Retry;
 
 @Slf4j
 @ActiveProfiles("test")
 @SpringBootTest
 class KisClientTest {
+	public static MockWebServer mockWebServer;
 
 	@Autowired
+	private OauthKisProperties oauthKisProperties;
+
 	private KisClient kisClient;
 
 	@MockBean
-	private WebClient webClient;
+	private KisService kisService; // 스케줄링 메소드 비활성화
+
+	@BeforeAll
+	static void setUp() throws IOException {
+		mockWebServer = new MockWebServer();
+		mockWebServer.start();
+	}
+
+	@AfterAll
+	static void tearDown() throws IOException {
+		mockWebServer.shutdown();
+	}
+
+	@BeforeEach
+	void initialize() {
+		String baseUrl = String.format("http://localhost:%s", mockWebServer.getPort());
+		this.kisClient = new KisClient(
+			oauthKisProperties,
+			WebClient.builder().baseUrl(baseUrl).build());
+	}
 
 	@DisplayName("한국투자증권 서버로부터 액세스 토큰 발급이 한번 실패하는 경우 재발급을 다시 요청한다")
 	@Test
 	void accessToken_whenIssueAccessToken_thenRetryOnAccessTokenFailure() {
 		// given
-		WebClient.RequestBodyUriSpec requestBodyUriSpec = Mockito.mock(WebClient.RequestBodyUriSpec.class);
-		WebClient.RequestHeadersSpec requestHeadersSpec = Mockito.mock(WebClient.RequestHeadersSpec.class);
-		WebClient.ResponseSpec responseSpec = Mockito.mock(WebClient.ResponseSpec.class);
+		KisAccessToken expectedKisAccessToken = createKisAccessToken();
+		mockWebServer.enqueue(new MockResponse().setResponseCode(403)
+			.setBody(ObjectMapperUtil.serialize(createError()))
+			.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
+		mockWebServer.enqueue(new MockResponse().setResponseCode(200)
+			.setBody(ObjectMapperUtil.serialize(expectedKisAccessToken))
+			.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON));
 
-		KisAccessToken accessToken = createKisAccessToken();
-		when(webClient.post()).thenReturn(requestBodyUriSpec);
-		when(requestBodyUriSpec.uri(anyString())).thenReturn(requestBodyUriSpec);
-		when(requestBodyUriSpec.bodyValue(anyMap())).thenReturn(requestHeadersSpec);
-		when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+		// when
+		Mono<KisAccessToken> responseMono = this.kisClient.accessToken("/oauth2/tokenP");
 
-		when(responseSpec.onStatus(any(), any()))
-			.thenReturn(responseSpec);
-		when(responseSpec.bodyToMono(KisAccessToken.class))
-			.thenReturn(Mono.error(createError()));
-		when(responseSpec.bodyToMono(KisAccessToken.class)
-			.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofMinutes(1L)))
-		).thenReturn(Mono.just(accessToken));
-
-		// when & then
-		Mono<KisAccessToken> mono = kisClient.accessToken();
-		StepVerifier.create(mono)
-			.expectNext(accessToken)
-			.verifyComplete();
+		// then
+		StepVerifier
+			.withVirtualTime(() -> responseMono)
+			.expectSubscription()
+			.thenAwait(Duration.ofMinutes(1))
+			.expectNextMatches(expectedKisAccessToken::equals)
+			.expectComplete()
+			.verify();
 	}
 
-	private WebClientResponseException createError() {
+	private Map<String, String> createError() {
 		Map<String, String> responseBody = new HashMap<>();
 		responseBody.put("error_description", "접근토큰 발급 잠시 후 다시 시도하세요(1분당 1회)");
 		responseBody.put("error_code", "EGW00133");
-		return new WebClientResponseException("Forbidden", HttpStatus.FORBIDDEN.value(),
-			"Forbidden", null, ObjectMapperUtil.serialize(responseBody).getBytes(UTF_8),
-			UTF_8);
+		return responseBody;
 	}
 
 	private KisAccessToken createKisAccessToken() {
@@ -83,3 +102,4 @@ class KisClientTest {
 		);
 	}
 }
+

--- a/src/test/java/codesquad/fineants/spring/api/kis/manager/KisAccessTokenManagerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/kis/manager/KisAccessTokenManagerTest.java
@@ -3,11 +3,11 @@ package codesquad.fineants.spring.api.kis.manager;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+
+import codesquad.fineants.spring.api.kis.client.KisAccessToken;
 
 class KisAccessTokenManagerTest {
 
@@ -15,12 +15,9 @@ class KisAccessTokenManagerTest {
 	@Test
 	void isAccessTokenExpired() {
 		// given
-		Map<String, Object> map = new HashMap<>();
-		map.put("access_token", "accessTokenValue");
-		map.put("token_type", "Bearer");
-		map.put("access_token_token_expired", "2023-12-23 14:08:26");
-		map.put("expires_in", 86400);
-		KisAccessTokenManager manager = KisAccessTokenManager.from(map);
+		KisAccessToken accessToken = new KisAccessToken("accessTokenValue", "Bearer",
+			LocalDateTime.of(2023, 12, 23, 14, 8, 26), 86400);
+		KisAccessTokenManager manager = new KisAccessTokenManager(accessToken);
 		LocalDateTime now = LocalDateTime.of(2023, 12, 22, 15, 0, 0);
 
 		// when


### PR DESCRIPTION
## 구현한 것

- retryWhen operator를 사용하여 서버 시작시 한국투자증권의 액세스 토큰 재발급에 실패하는 경우 1분 간격으로 성공할때까지 재시도하도록 변경하였습니다.
- mockwebserver 의존성 라이브러리를 추가하여 재발급 관련 테스트 코드를 구현하였습니다. 

## TO-BE
- Hikari Connection Pool 고갈 문제 해결
