### PR TITLE
[fix] sse 전송 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,8 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:okhttp:4.12.0';
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/codesquad/fineants/spring/api/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/service/KisService.java
@@ -40,7 +40,7 @@ public class KisService {
 	private final HolidayManager holidayManager;
 
 	// 평일 9am ~ 15:59pm 5초마다 현재가 갱신 수행
-	// @Scheduled(cron = "0/5 * 9-15 ? * MON,TUE,WED,THU,FRI")
+	@Scheduled(cron = "0/5 * 9-15 ? * MON,TUE,WED,THU,FRI")
 	public void refreshStockCurrentPrice() {
 		// 휴장일인 경우 실행하지 않음
 		if (holidayManager.isHoliday(LocalDate.now())) {

--- a/src/main/java/codesquad/fineants/spring/api/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/spring/api/kis/service/KisService.java
@@ -40,7 +40,7 @@ public class KisService {
 	private final HolidayManager holidayManager;
 
 	// 평일 9am ~ 15:59pm 5초마다 현재가 갱신 수행
-	@Scheduled(cron = "0/5 * 9-15 ? * MON,TUE,WED,THU,FRI")
+	// @Scheduled(cron = "0/5 * 9-15 ? * MON,TUE,WED,THU,FRI")
 	public void refreshStockCurrentPrice() {
 		// 휴장일인 경우 실행하지 않음
 		if (holidayManager.isHoliday(LocalDate.now())) {

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestController.java
@@ -18,6 +18,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.domain.oauth.support.AuthPrincipalMember;
+import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterKey;
 import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterManager;
 import codesquad.fineants.spring.api.portfolio_stock.request.PortfolioStockCreateRequest;
 import codesquad.fineants.spring.api.portfolio_stock.request.PortfolioStocksDeleteRequest;
@@ -80,19 +81,20 @@ public class PortfolioStockRestController {
 	public SseEmitter readMyPortfolioStocksInRealTime(@PathVariable Long portfolioId,
 		@AuthPrincipalMember AuthMember authMember) {
 		SseEmitter emitter = new SseEmitter(Duration.ofSeconds(30).toMillis());
+		SseEmitterKey key = SseEmitterKey.create(portfolioId);
 		emitter.onTimeout(() -> {
 			log.info("emitter{} timeout으로 인한 제거", portfolioId);
 			emitter.complete();
 		});
 		emitter.onCompletion(() -> {
 			log.info("emitter{} completion으로 인한 제거", portfolioId);
-			manager.remove(portfolioId);
+			manager.remove(key);
 		});
 		emitter.onError(throwable -> {
 			log.error(throwable.getMessage(), throwable);
 			emitter.complete();
 		});
-		manager.add(portfolioId, emitter);
+		manager.add(key, emitter);
 		return emitter;
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/PortfolioEvent.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/PortfolioEvent.java
@@ -4,27 +4,28 @@ import java.time.LocalDateTime;
 
 import org.springframework.context.ApplicationEvent;
 
+import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterKey;
 import codesquad.fineants.spring.api.portfolio_stock.response.PortfolioHoldingsRealTimeResponse;
 import lombok.Getter;
 
 @Getter
 public class PortfolioEvent extends ApplicationEvent {
 
-	private final Long portfolioId;
+	private final SseEmitterKey key;
 	private final PortfolioHoldingsRealTimeResponse response;
 	private final LocalDateTime eventDateTime;
 
-	public PortfolioEvent(Long portfolioId, PortfolioHoldingsRealTimeResponse response, LocalDateTime eventDateTime) {
-		super(System.currentTimeMillis());
-		this.portfolioId = portfolioId;
+	public PortfolioEvent(SseEmitterKey key, PortfolioHoldingsRealTimeResponse response, LocalDateTime eventDateTime) {
+		super(key.getEventId());
+		this.key = key;
 		this.response = response;
 		this.eventDateTime = eventDateTime;
 	}
 
 	@Override
 	public String toString() {
-		return String.format("%s, %s(portfolioId=%d)", "포트폴리오 발행 이벤트",
+		return String.format("%s, %s(key=%s)", "포트폴리오 발행 이벤트",
 			this.getClass().getSimpleName(),
-			portfolioId);
+			key);
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
@@ -1,7 +1,5 @@
 package codesquad.fineants.spring.api.portfolio_stock.event.listener;
 
-import java.io.IOException;
-
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -32,8 +30,8 @@ public class PortfolioEventListener {
 				.id(event.getKey().getEventId().toString())
 				.data(event.getResponse())
 				.name(EVENT_NAME));
-			log.info("emitter{} 포트폴리오 전송", event.getKey().getPortfolioId());
-			if (!stockMarketChecker.isMarketOpen(event.getEventDateTime())) {
+			log.info("포트폴리오 이벤트 전송 : {}", event);
+			if (stockMarketChecker.isMarketOpen(event.getEventDateTime())) {
 				Thread.sleep(2000L);
 				emitter.send(SseEmitter.event()
 					.data("sse complete")
@@ -41,11 +39,9 @@ public class PortfolioEventListener {
 				emitter.complete();
 			}
 
-		} catch (IOException | InterruptedException e) {
-			log.error(e.getMessage(), e);
-			emitter.completeWithError(e);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
+			emitter.completeWithError(e);
 		}
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
@@ -25,14 +25,14 @@ public class PortfolioEventListener {
 
 	@EventListener
 	public void handleMessage(PortfolioEvent event) {
-		SseEmitter emitter = manager.get(event.getPortfolioId());
+		SseEmitter emitter = manager.get(event.getKey());
 		log.info("emitter 전송준비 : {}", emitter);
 		try {
 			emitter.send(SseEmitter.event()
+				.id(event.getKey().getEventId().toString())
 				.data(event.getResponse())
 				.name(EVENT_NAME));
-			log.info("emitter{} 포트폴리오 전송", event.getPortfolioId());
-
+			log.info("emitter{} 포트폴리오 전송", event.getKey().getPortfolioId());
 			if (!stockMarketChecker.isMarketOpen(event.getEventDateTime())) {
 				Thread.sleep(2000L);
 				emitter.send(SseEmitter.event()
@@ -40,6 +40,7 @@ public class PortfolioEventListener {
 					.name(COMPLETE_NAME));
 				emitter.complete();
 			}
+
 		} catch (IOException | InterruptedException e) {
 			log.error(e.getMessage(), e);
 			emitter.completeWithError(e);

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
@@ -31,7 +31,7 @@ public class PortfolioEventListener {
 				.data(event.getResponse())
 				.name(EVENT_NAME));
 			log.info("포트폴리오 이벤트 전송 : {}", event);
-			if (stockMarketChecker.isMarketOpen(event.getEventDateTime())) {
+			if (!stockMarketChecker.isMarketOpen(event.getEventDateTime())) {
 				Thread.sleep(2000L);
 				emitter.send(SseEmitter.event()
 					.data("sse complete")

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/manager/SseEmitterKey.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/manager/SseEmitterKey.java
@@ -1,0 +1,22 @@
+package codesquad.fineants.spring.api.portfolio_stock.manager;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode(of = "eventId")
+@RequiredArgsConstructor
+public class SseEmitterKey {
+	private final Long eventId;
+	private final Long portfolioId;
+
+	public static SseEmitterKey create(Long portfolioId) {
+		return new SseEmitterKey(
+			System.currentTimeMillis(),
+			portfolioId
+		);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/manager/SseEmitterManager.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/manager/SseEmitterManager.java
@@ -9,25 +9,25 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Component
 public class SseEmitterManager {
-	private final Map<Long, SseEmitter> clients = new ConcurrentHashMap<>();
+	private final Map<SseEmitterKey, SseEmitter> clients = new ConcurrentHashMap<>();
 
-	public void add(Long portfolioId, SseEmitter emitter) {
-		clients.put(portfolioId, emitter);
+	public void add(SseEmitterKey key, SseEmitter emitter) {
+		clients.put(key, emitter);
 	}
 
-	public void remove(Long portfolioId) {
-		clients.remove(portfolioId);
+	public void remove(SseEmitterKey key) {
+		clients.remove(key);
 	}
 
 	public int size() {
 		return clients.size();
 	}
 
-	public SseEmitter get(Long id) {
-		return clients.get(id);
+	public SseEmitter get(SseEmitterKey key) {
+		return clients.get(key);
 	}
 
-	public Set<Long> keys() {
+	public Set<SseEmitterKey> keys() {
 		return clients.keySet();
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListRestController.java
@@ -44,7 +44,7 @@ public class WatchListRestController {
 	}
 
 	@GetMapping("/{watchlistId}")
-	public ApiResponse<List<ReadWatchListResponse>> readWatchList(@AuthPrincipalMember AuthMember authMember,
+	public ApiResponse<ReadWatchListResponse> readWatchList(@AuthPrincipalMember AuthMember authMember,
 		@PathVariable Long watchlistId){
 		return ApiResponse.success(WatchListSuccessCode.READ_WATCH_LIST,
 			watchListService.readWatchList(authMember, watchlistId));

--- a/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListRestController.java
@@ -23,7 +23,6 @@ import codesquad.fineants.spring.api.watch_list.response.ReadWatchListResponse;
 import codesquad.fineants.spring.api.watch_list.response.ReadWatchListsResponse;
 import lombok.RequiredArgsConstructor;
 
-
 @RequestMapping("/api/watchlists")
 @RequiredArgsConstructor
 @RestController
@@ -33,41 +32,48 @@ public class WatchListRestController {
 
 	@PostMapping
 	public ApiResponse<CreateWatchListResponse> createWatchList(@AuthPrincipalMember AuthMember authMember,
-		@RequestBody CreateWatchListRequest request){
+		@RequestBody CreateWatchListRequest request) {
 		return ApiResponse.success(WatchListSuccessCode.CREATED_WATCH_LIST,
 			watchListService.createWatchList(authMember, request));
 	}
 
 	@GetMapping
-	public ApiResponse<List<ReadWatchListsResponse>> readWatchLists(@AuthPrincipalMember AuthMember authMember){
+	public ApiResponse<List<ReadWatchListsResponse>> readWatchLists(@AuthPrincipalMember AuthMember authMember) {
 		return ApiResponse.success(WatchListSuccessCode.READ_WATCH_LISTS, watchListService.readWatchLists(authMember));
 	}
 
 	@GetMapping("/{watchlistId}")
 	public ApiResponse<ReadWatchListResponse> readWatchList(@AuthPrincipalMember AuthMember authMember,
-		@PathVariable Long watchlistId){
+		@PathVariable Long watchlistId) {
 		return ApiResponse.success(WatchListSuccessCode.READ_WATCH_LIST,
 			watchListService.readWatchList(authMember, watchlistId));
 	}
 
 	@DeleteMapping
 	public ApiResponse<Void> deleteWatchLists(@AuthPrincipalMember AuthMember authMember,
-		@RequestBody DeleteWatchListsRequests deleteWatchListsRequests){
+		@RequestBody DeleteWatchListsRequests deleteWatchListsRequests) {
 		watchListService.deleteWatchLists(authMember, deleteWatchListsRequests);
 		return ApiResponse.success(WatchListSuccessCode.DELETED_WATCH_LIST);
 	}
 
 	@PostMapping("/{watchlistId}/stock")
 	public ApiResponse<Void> createWatchStocks(@AuthPrincipalMember AuthMember authMember,
-		@PathVariable Long watchlistId, @RequestBody CreateWatchStockRequest request){
+		@PathVariable Long watchlistId, @RequestBody CreateWatchStockRequest request) {
 		watchListService.createWatchStocks(authMember, watchlistId, request);
 		return ApiResponse.success(WatchListSuccessCode.CREATED_WATCH_STOCK);
 	}
 
 	@DeleteMapping("/{watchlistId}/stock")
 	public ApiResponse<Void> deleteWatchStocks(@AuthPrincipalMember AuthMember authMember,
-		@PathVariable("watchlistId") Long watchListId, @RequestBody DeleteWatchStocksRequest deleteWatchStocksRequest){
+		@PathVariable("watchlistId") Long watchListId, @RequestBody DeleteWatchStocksRequest deleteWatchStocksRequest) {
 		watchListService.deleteWatchStocks(authMember, watchListId, deleteWatchStocksRequest);
+		return ApiResponse.success(WatchListSuccessCode.DELETED_WATCH_STOCK);
+	}
+
+	@DeleteMapping("/{watchlistId}/stock/{tickerSymbol}")
+	public ApiResponse<Void> deleteWatchStock(@AuthPrincipalMember AuthMember authMember,
+		@PathVariable("watchlistId") Long watchListId, @PathVariable("tickerSymbol") String tickerSymbol) {
+		watchListService.deleteWatchStock(authMember, watchListId, tickerSymbol);
 		return ApiResponse.success(WatchListSuccessCode.DELETED_WATCH_STOCK);
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListService.java
+++ b/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListService.java
@@ -61,7 +61,7 @@ public class WatchListService {
 	}
 
 	@Transactional(readOnly = true)
-	public List<ReadWatchListResponse> readWatchList(AuthMember authMember, Long watchListId) {
+	public ReadWatchListResponse readWatchList(AuthMember authMember, Long watchListId) {
 		Member member = findMember(authMember.getMemberId());
 		WatchList watchList = watchListRepository.findById(watchListId)
 			.orElseThrow(() -> new NotFoundResourceException(WatchListErrorCode.NOT_FOUND_WATCH_LIST));
@@ -70,9 +70,10 @@ public class WatchListService {
 
 		List<WatchStock> watchStocks = watchStockRepository.findWithStockAndDividendsByWatchList(watchList);
 
-		return watchStocks.stream()
+		List<ReadWatchListResponse.WatchStockResponse> watchStockResponses = watchStocks.stream()
 			.map(watchStock -> ReadWatchListResponse.from(watchStock, currentPriceManager, lastDayClosingPriceManager))
 			.collect(Collectors.toList());
+		return new ReadWatchListResponse(watchList.getName(), watchStockResponses);
 	}
 
 	@Transactional

--- a/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListService.java
+++ b/src/main/java/codesquad/fineants/spring/api/watch_list/WatchListService.java
@@ -1,7 +1,6 @@
 package codesquad.fineants.spring.api.watch_list;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -115,6 +114,16 @@ public class WatchListService {
 		validateWatchListAuthorization(member.getId(), watchList.getMember().getId());
 
 		watchStockRepository.deleteByWatchListAndStock_TickerSymbolIn(watchList, request.getTickerSymbols());
+	}
+
+	@Transactional
+	public void deleteWatchStock(AuthMember authMember, Long watchListId, String tickerSymbol) {
+		Member member = findMember(authMember.getMemberId());
+		WatchList watchList = watchListRepository.findById(watchListId)
+			.orElseThrow(() -> new NotFoundResourceException(WatchListErrorCode.NOT_FOUND_WATCH_LIST));
+		validateWatchListAuthorization(member.getId(), watchList.getMember().getId());
+
+		watchStockRepository.deleteByWatchListAndStock_TickerSymbolIn(watchList, List.of(tickerSymbol));
 	}
 
 	private Member findMember(Long memberId) {

--- a/src/main/java/codesquad/fineants/spring/api/watch_list/response/ReadWatchListResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/watch_list/response/ReadWatchListResponse.java
@@ -1,6 +1,7 @@
 package codesquad.fineants.spring.api.watch_list.response;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
@@ -15,20 +16,29 @@ import lombok.Getter;
 @Builder
 @AllArgsConstructor
 public class ReadWatchListResponse {
-	private long id;
-	private String companyName;
-	private String tickerSymbol;
-	private long currentPrice;
-	private long dailyChange;
-	private float dailyChangeRate;
-	private float annualDividendYield;
-	private String sector;
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
-	private LocalDateTime dateAdded;
+	private String name;
+	private List<WatchStockResponse> watchStocks;
 
-	public static ReadWatchListResponse from(WatchStock watchStock, CurrentPriceManager currentPriceManager,
+
+	@Builder
+	@Getter
+	public static class WatchStockResponse {
+		private long id;
+		private String companyName;
+		private String tickerSymbol;
+		private long currentPrice;
+		private long dailyChange;
+		private float dailyChangeRate;
+		private float annualDividendYield;
+		private String sector;
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+		private LocalDateTime dateAdded;
+	}
+
+
+	public static ReadWatchListResponse.WatchStockResponse from(WatchStock watchStock, CurrentPriceManager currentPriceManager,
 		LastDayClosingPriceManager lastDayClosingPriceManager) {
-		return ReadWatchListResponse.builder()
+		return ReadWatchListResponse.WatchStockResponse.builder()
 			.id(watchStock.getId())
 			.companyName(watchStock.getStock().getCompanyName())
 			.tickerSymbol(watchStock.getStock().getTickerSymbol())

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestControllerTest.java
@@ -220,6 +220,35 @@ class PortfolioStockRestControllerTest {
 			.andExpect(jsonPath("data").value(equalTo(null)));
 	}
 
+	@DisplayName("사용자는 포트폴리오에 종목만 추가한다")
+	@Test
+	void addPortfolioStockOnly() throws Exception {
+		Member member = createMember();
+		Portfolio portfolio = createPortfolio(member);
+		Stock stock = createStock();
+
+		PortfolioStockCreateResponse response = PortfolioStockCreateResponse.from(
+			PortfolioHolding.empty(portfolio, stock));
+		given(portfolioRepository.findById(anyLong())).willReturn(Optional.of(portfolio));
+		given(portfolioStockService.addPortfolioStock(anyLong(), any(PortfolioStockCreateRequest.class),
+			any(AuthMember.class))).willReturn(response);
+
+		Map<String, Object> requestBodyMap = new HashMap<>();
+		requestBodyMap.put("tickerSymbol", "005930");
+
+		String body = ObjectMapperUtil.serialize(requestBodyMap);
+		Long portfolioId = portfolio.getId();
+		// when & then
+		mockMvc.perform(post("/api/portfolio/" + portfolioId + "/holdings")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(body))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("code").value(equalTo(201)))
+			.andExpect(jsonPath("status").value(equalTo("Created")))
+			.andExpect(jsonPath("message").value(equalTo("포트폴리오 종목이 추가되었습니다")))
+			.andExpect(jsonPath("data").value(equalTo(null)));
+	}
+
 	@DisplayName("사용자는 포트폴리오에 종목을 추가할때 stockId를 필수로 같이 전송해야 한다")
 	@Test
 	void addPortfolioStockWithStockIdIsNull() throws Exception {

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestControllerTest.java
@@ -179,7 +179,6 @@ class PortfolioStockRestControllerTest {
 		requestBodyMap.put("tickerSymbol", "005930");
 		requestBodyMap.put("purchaseHistory", purchaseHistoryMap);
 
-
 		String body = ObjectMapperUtil.serialize(requestBodyMap);
 		Long portfolioId = portfolio.getId();
 		// when & then
@@ -202,7 +201,6 @@ class PortfolioStockRestControllerTest {
 
 		PortfolioStockCreateResponse response = PortfolioStockCreateResponse.from(
 			PortfolioHolding.empty(portfolio, stock));
-		given(portfolioRepository.findById(anyLong())).willReturn(Optional.of(portfolio));
 		given(portfolioStockService.addPortfolioStock(anyLong(), any(PortfolioStockCreateRequest.class),
 			any(AuthMember.class))).willReturn(response);
 

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestControllerTest.java
@@ -179,7 +179,6 @@ class PortfolioStockRestControllerTest {
 		requestBodyMap.put("tickerSymbol", "005930");
 		requestBodyMap.put("purchaseHistory", purchaseHistoryMap);
 
-
 		String body = ObjectMapperUtil.serialize(requestBodyMap);
 		Long portfolioId = portfolio.getId();
 		// when & then

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestControllerTest.java
@@ -220,35 +220,6 @@ class PortfolioStockRestControllerTest {
 			.andExpect(jsonPath("data").value(equalTo(null)));
 	}
 
-	@DisplayName("사용자는 포트폴리오에 종목만 추가한다")
-	@Test
-	void addPortfolioStockOnly() throws Exception {
-		Member member = createMember();
-		Portfolio portfolio = createPortfolio(member);
-		Stock stock = createStock();
-
-		PortfolioStockCreateResponse response = PortfolioStockCreateResponse.from(
-			PortfolioHolding.empty(portfolio, stock));
-		given(portfolioRepository.findById(anyLong())).willReturn(Optional.of(portfolio));
-		given(portfolioStockService.addPortfolioStock(anyLong(), any(PortfolioStockCreateRequest.class),
-			any(AuthMember.class))).willReturn(response);
-
-		Map<String, Object> requestBodyMap = new HashMap<>();
-		requestBodyMap.put("tickerSymbol", "005930");
-
-		String body = ObjectMapperUtil.serialize(requestBodyMap);
-		Long portfolioId = portfolio.getId();
-		// when & then
-		mockMvc.perform(post("/api/portfolio/" + portfolioId + "/holdings")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(body))
-			.andExpect(status().isCreated())
-			.andExpect(jsonPath("code").value(equalTo(201)))
-			.andExpect(jsonPath("status").value(equalTo("Created")))
-			.andExpect(jsonPath("message").value(equalTo("포트폴리오 종목이 추가되었습니다")))
-			.andExpect(jsonPath("data").value(equalTo(null)));
-	}
-
 	@DisplayName("사용자는 포트폴리오에 종목을 추가할때 stockId를 필수로 같이 전송해야 한다")
 	@Test
 	void addPortfolioStockWithStockIdIsNull() throws Exception {

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/event/publisher/PortfolioEventPublisherTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/event/publisher/PortfolioEventPublisherTest.java
@@ -36,6 +36,7 @@ import codesquad.fineants.domain.stock_dividend.StockDividendRepository;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
 import codesquad.fineants.spring.api.kis.manager.LastDayClosingPriceManager;
 import codesquad.fineants.spring.api.kis.response.CurrentPriceResponse;
+import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterKey;
 import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterManager;
 import codesquad.fineants.spring.api.portfolio_stock.service.PortfolioStockService;
 import lombok.extern.slf4j.Slf4j;
@@ -106,9 +107,10 @@ class PortfolioEventPublisherTest {
 		lastDayClosingPriceManager.addPrice("005930", 50000);
 
 		SseEmitter emitter = mock(SseEmitter.class);
-		emitter.onTimeout(() -> manager.remove(portfolio.getId()));
-		emitter.onCompletion(() -> manager.remove(portfolio.getId()));
-		manager.add(portfolio.getId(), emitter);
+		SseEmitterKey key = SseEmitterKey.create(portfolio.getId());
+		emitter.onTimeout(() -> manager.remove(key));
+		emitter.onCompletion(() -> manager.remove(key));
+		manager.add(key, emitter);
 
 		// when
 		publisher.sendEventToPortfolio(LocalDateTime.of(2023, 12, 22, 10, 0, 0));
@@ -133,9 +135,10 @@ class PortfolioEventPublisherTest {
 			.willThrow(new IllegalArgumentException("005930 종목에 대한 가격을 찾을 수 없습니다."));
 
 		SseEmitter emitter = new SseEmitter();
-		emitter.onTimeout(() -> manager.remove(portfolio.getId()));
-		emitter.onCompletion(() -> manager.remove(portfolio.getId()));
-		manager.add(portfolio.getId(), emitter);
+		SseEmitterKey key = SseEmitterKey.create(portfolio.getId());
+		emitter.onTimeout(() -> manager.remove(key));
+		emitter.onCompletion(() -> manager.remove(key));
+		manager.add(key, emitter);
 
 		// when
 		publisher.sendEventToPortfolio(LocalDateTime.of(2023, 12, 22, 10, 0, 0));

--- a/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListRestControllerTest.java
@@ -161,10 +161,19 @@ class WatchListRestControllerTest {
 		given(authPrincipalArgumentResolver.supportsParameter(any())).willReturn(true);
 		given(authPrincipalArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(authMember);
 
-		List<ReadWatchListResponse> response = List.of(
-			new ReadWatchListResponse(1L, "삼성전자", "005930", 68000,
-				1200, 1.85f, 2.12f, "제조업",
-				LocalDateTime.of(2023, 12, 2, 15, 0, 0)));
+		ReadWatchListResponse.WatchStockResponse watchStockResponse = ReadWatchListResponse.WatchStockResponse.builder()
+			.id(1L)
+			.companyName("삼성전자")
+			.tickerSymbol("005930")
+			.currentPrice(68000)
+			.dailyChange(1200)
+			.dailyChangeRate(1.85f)
+			.annualDividendYield(2.12f)
+			.sector("제조업")
+			.dateAdded(LocalDateTime.of(2023, 12, 2, 15, 0, 0))
+			.build();
+
+		ReadWatchListResponse response = new ReadWatchListResponse("My Watchlist", List.of(watchStockResponse));
 
 		given(watchListService.readWatchList(any(AuthMember.class), any(Long.class))).willReturn(response);
 
@@ -175,15 +184,15 @@ class WatchListRestControllerTest {
 			.andExpect(jsonPath("code").value(equalTo(200)))
 			.andExpect(jsonPath("status").value(equalTo("OK")))
 			.andExpect(jsonPath("message").value(equalTo("관심종목 단일 목록 조회가 완료되었습니다")))
-			.andExpect(jsonPath("data[0].id").value(equalTo(1)))
-			.andExpect(jsonPath("data[0].companyName").value(equalTo("삼성전자")))
-			.andExpect(jsonPath("data[0].tickerSymbol").value(equalTo("005930")))
-			.andExpect(jsonPath("data[0].currentPrice").value(equalTo(68000)))
-			.andExpect(jsonPath("data[0].dailyChange").value(equalTo(1200)))
-			.andExpect(jsonPath("data[0].dailyChangeRate").value(equalTo(1.85)))
-			.andExpect(jsonPath("data[0].annualDividendYield").value(equalTo(2.12)))
-			.andExpect(jsonPath("data[0].sector").value(equalTo("제조업")))
-			.andExpect(jsonPath("data[0].dateAdded").value(equalTo("2023-12-02T15:00:00")));
+			.andExpect(jsonPath("data.watchStocks[0].id").value(equalTo(1)))
+			.andExpect(jsonPath("data.watchStocks[0].companyName").value(equalTo("삼성전자")))
+			.andExpect(jsonPath("data.watchStocks[0].tickerSymbol").value(equalTo("005930")))
+			.andExpect(jsonPath("data.watchStocks[0].currentPrice").value(equalTo(68000)))
+			.andExpect(jsonPath("data.watchStocks[0].dailyChange").value(equalTo(1200)))
+			.andExpect(jsonPath("data.watchStocks[0].dailyChangeRate").value(equalTo(1.85)))
+			.andExpect(jsonPath("data.watchStocks[0].annualDividendYield").value(equalTo(2.12)))
+			.andExpect(jsonPath("data.watchStocks[0].sector").value(equalTo("제조업")))
+			.andExpect(jsonPath("data.watchStocks[0].dateAdded").value(equalTo("2023-12-02T15:00:00")));
 	}
 
 	@DisplayName("사용자가 watchlist에 종목을 추가한다.")

--- a/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListRestControllerTest.java
@@ -263,7 +263,7 @@ class WatchListRestControllerTest {
 			.andExpect(jsonPath("data").value(equalTo(null)));
 	}
 
-	@DisplayName("사용자가 watchlist에서 종목을 삭제한다.")
+	@DisplayName("사용자가 watchlist에서 종목을 여러개 삭제한다.")
 	@Test
 	void deleteWatchStocks() throws Exception {
 		// given
@@ -291,6 +291,36 @@ class WatchListRestControllerTest {
 		mockMvc.perform(delete("/api/watchlists/1/stock")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(body))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("code").value(equalTo(200)))
+			.andExpect(jsonPath("status").value(equalTo("OK")))
+			.andExpect(jsonPath("message").value(equalTo("관심목록 종목이 삭제되었습니다")))
+			.andExpect(jsonPath("data").value(equalTo(null)));
+	}
+
+	@DisplayName("사용자가 watchlist에서 종목을 삭제한다.")
+	@Test
+	void deleteWatchStock() throws Exception {
+		// given
+		Member member = Member.builder()
+			.id(1L)
+			.nickname("일개미1234")
+			.email("kim1234@gmail.com")
+			.provider("local")
+			.password("kim1234@")
+			.profileUrl("profileValue")
+			.build();
+		AuthMember authMember = AuthMember.from(member);
+
+
+		given(authPrincipalArgumentResolver.supportsParameter(any())).willReturn(true);
+		given(authPrincipalArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(authMember);
+		doNothing().when(watchListService)
+			.deleteWatchStocks(any(AuthMember.class), any(Long.class), any(DeleteWatchStocksRequest.class));
+
+		// when & then
+		mockMvc.perform(delete("/api/watchlists/1/stock/\"005930\"")
+				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("code").value(equalTo(200)))
 			.andExpect(jsonPath("status").value(equalTo("OK")))

--- a/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListServiceTest.java
@@ -251,7 +251,7 @@ class WatchListServiceTest {
 		assertThat(watchStockRepository.findByWatchList(watchList)).hasSize(0);
 	}
 
-	@DisplayName("회원이 watchlist에서 종목을 삭제한다.")
+	@DisplayName("회원이 watchlist에서 종목을 여러개 삭제한다.")
 	@Test
 	void deleteWatchStocks() {
 		// given
@@ -283,6 +283,41 @@ class WatchListServiceTest {
 
 		// when
 		watchListService.deleteWatchStocks(authMember, watchListId, request);
+
+		// then
+		assertThat(watchStockRepository.findById(watchStockId).isPresent()).isFalse();
+	}
+
+	@DisplayName("회원이 watchlist에서 종목을 삭제한다.")
+	@Test
+	void deleteWatchStock() {
+		// given
+		String tickerSymbol = "005930";
+		Stock stock = stockRepository.save(
+			Stock.builder()
+				.tickerSymbol(tickerSymbol)
+				.market(Market.KOSPI)
+				.build()
+		);
+
+		AuthMember authMember = AuthMember.from(member);
+
+		WatchList watchList = watchListRepository.save(WatchList.builder()
+			.name("My WatchList")
+			.member(member)
+			.build());
+		Long watchListId = watchList.getId();
+
+		WatchStock watchStock = watchStockRepository.save(
+			WatchStock.builder()
+				.watchList(watchList)
+				.stock(stock)
+				.build()
+		);
+		Long watchStockId = watchStock.getId();
+
+		// when
+		watchListService.deleteWatchStock(authMember, watchListId, stock.getTickerSymbol());
 
 		// then
 		assertThat(watchStockRepository.findById(watchStockId).isPresent()).isFalse();

--- a/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/watch_list/WatchListServiceTest.java
@@ -174,15 +174,16 @@ class WatchListServiceTest {
 		given(lastDayClosingPriceManager.getPrice(any(String.class))).willReturn(77000L);
 
 		// when
-		List<ReadWatchListResponse> response = watchListService.readWatchList(authMember, watchList.getId());
+		ReadWatchListResponse response = watchListService.readWatchList(authMember, watchList.getId());
 
 		// then
-		assertThat(response.get(0).getCompanyName()).isEqualTo(stock.getCompanyName());
-		assertThat(response.get(0).getTickerSymbol()).isEqualTo(stock.getTickerSymbol());
-		assertThat(response.get(0).getCurrentPrice()).isEqualTo(77000L);
-		assertThat(response.get(0).getDailyChange()).isEqualTo(0);
-		assertThat(response.get(0).getAnnualDividendYield()).isEqualTo((362f/77000)*100);
-		assertThat(response.get(0).getSector()).isEqualTo("전기전자");
+		assertThat(response.getName()).isEqualTo(watchList.getName());
+		assertThat(response.getWatchStocks().get(0).getCompanyName()).isEqualTo(stock.getCompanyName());
+		assertThat(response.getWatchStocks().get(0).getTickerSymbol()).isEqualTo(stock.getTickerSymbol());
+		assertThat(response.getWatchStocks().get(0).getCurrentPrice()).isEqualTo(77000L);
+		assertThat(response.getWatchStocks().get(0).getDailyChange()).isEqualTo(0);
+		assertThat(response.getWatchStocks().get(0).getAnnualDividendYield()).isEqualTo((362f/77000)*100);
+		assertThat(response.getWatchStocks().get(0).getSector()).isEqualTo("전기전자");
 	}
 
 	@DisplayName("회원이 watchlist에 종목을 추가한다.")


### PR DESCRIPTION
## 구현한 것

- SseEmitterManager 객체의 키값 형태를 포트폴리오 등록번호에서 SseEmitterKey 객체로 변경하였습니다.
    - 서로 다른 클라이언트에서 동일한 포트폴리오 번호를 이용하여 sse 요청시 기존 SseEmitter가 제거되는 문제를 해결하였습니다.
- 포트폴리오 이벤트 리스너에서 모든 Exception에 대하여 emitter.completeWithError() 메소드를 수행하도록 변경하였습니다.
     - 기존 일부 예외에 대해서만 completeWithError 처리를 하였지만 IllegalStateException 예외 발생시에는 complete 처리가 되지 않아서 제거되지 않은 문제를 해결하였습니다. 
