### PR TITLE
[fix] sse 전송 문제 해결

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioStockRestController.java
@@ -18,6 +18,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.domain.oauth.support.AuthPrincipalMember;
+import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterKey;
 import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterManager;
 import codesquad.fineants.spring.api.portfolio_stock.request.PortfolioStockCreateRequest;
 import codesquad.fineants.spring.api.portfolio_stock.request.PortfolioStocksDeleteRequest;
@@ -80,19 +81,20 @@ public class PortfolioStockRestController {
 	public SseEmitter readMyPortfolioStocksInRealTime(@PathVariable Long portfolioId,
 		@AuthPrincipalMember AuthMember authMember) {
 		SseEmitter emitter = new SseEmitter(Duration.ofSeconds(30).toMillis());
+		SseEmitterKey key = SseEmitterKey.create(portfolioId);
 		emitter.onTimeout(() -> {
 			log.info("emitter{} timeout으로 인한 제거", portfolioId);
 			emitter.complete();
 		});
 		emitter.onCompletion(() -> {
 			log.info("emitter{} completion으로 인한 제거", portfolioId);
-			manager.remove(portfolioId);
+			manager.remove(key);
 		});
 		emitter.onError(throwable -> {
 			log.error(throwable.getMessage(), throwable);
 			emitter.complete();
 		});
-		manager.add(portfolioId, emitter);
+		manager.add(key, emitter);
 		return emitter;
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/PortfolioEvent.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/PortfolioEvent.java
@@ -4,27 +4,28 @@ import java.time.LocalDateTime;
 
 import org.springframework.context.ApplicationEvent;
 
+import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterKey;
 import codesquad.fineants.spring.api.portfolio_stock.response.PortfolioHoldingsRealTimeResponse;
 import lombok.Getter;
 
 @Getter
 public class PortfolioEvent extends ApplicationEvent {
 
-	private final Long portfolioId;
+	private final SseEmitterKey key;
 	private final PortfolioHoldingsRealTimeResponse response;
 	private final LocalDateTime eventDateTime;
 
-	public PortfolioEvent(Long portfolioId, PortfolioHoldingsRealTimeResponse response, LocalDateTime eventDateTime) {
-		super(System.currentTimeMillis());
-		this.portfolioId = portfolioId;
+	public PortfolioEvent(SseEmitterKey key, PortfolioHoldingsRealTimeResponse response, LocalDateTime eventDateTime) {
+		super(key.getEventId());
+		this.key = key;
 		this.response = response;
 		this.eventDateTime = eventDateTime;
 	}
 
 	@Override
 	public String toString() {
-		return String.format("%s, %s(portfolioId=%d)", "포트폴리오 발행 이벤트",
+		return String.format("%s, %s(key=%s)", "포트폴리오 발행 이벤트",
 			this.getClass().getSimpleName(),
-			portfolioId);
+			key);
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
@@ -1,7 +1,5 @@
 package codesquad.fineants.spring.api.portfolio_stock.event.listener;
 
-import java.io.IOException;
-
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -40,11 +38,9 @@ public class PortfolioEventListener {
 					.name(COMPLETE_NAME));
 				emitter.complete();
 			}
-		} catch (IOException | InterruptedException e) {
-			log.error(e.getMessage(), e);
-			emitter.completeWithError(e);
 		} catch (Exception e) {
 			log.error(e.getMessage(), e);
+			emitter.completeWithError(e);
 		}
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/event/listener/PortfolioEventListener.java
@@ -25,13 +25,13 @@ public class PortfolioEventListener {
 
 	@EventListener
 	public void handleMessage(PortfolioEvent event) {
-		SseEmitter emitter = manager.get(event.getPortfolioId());
+		SseEmitter emitter = manager.get(event.getKey());
 		log.info("emitter 전송준비 : {}", emitter);
 		try {
 			emitter.send(SseEmitter.event()
 				.data(event.getResponse())
 				.name(EVENT_NAME));
-			log.info("emitter{} 포트폴리오 전송", event.getPortfolioId());
+			log.info("포트폴리오 이벤트 전송 : {}", event);
 
 			if (!stockMarketChecker.isMarketOpen(event.getEventDateTime())) {
 				Thread.sleep(2000L);

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/manager/SseEmitterKey.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/manager/SseEmitterKey.java
@@ -1,0 +1,22 @@
+package codesquad.fineants.spring.api.portfolio_stock.manager;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@EqualsAndHashCode(of = "eventId")
+@RequiredArgsConstructor
+public class SseEmitterKey {
+	private final Long eventId;
+	private final Long portfolioId;
+
+	public static SseEmitterKey create(Long portfolioId) {
+		return new SseEmitterKey(
+			System.currentTimeMillis(),
+			portfolioId
+		);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/manager/SseEmitterManager.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/manager/SseEmitterManager.java
@@ -9,25 +9,25 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @Component
 public class SseEmitterManager {
-	private final Map<Long, SseEmitter> clients = new ConcurrentHashMap<>();
+	private final Map<SseEmitterKey, SseEmitter> clients = new ConcurrentHashMap<>();
 
-	public void add(Long portfolioId, SseEmitter emitter) {
-		clients.put(portfolioId, emitter);
+	public void add(SseEmitterKey key, SseEmitter emitter) {
+		clients.put(key, emitter);
 	}
 
-	public void remove(Long portfolioId) {
-		clients.remove(portfolioId);
+	public void remove(SseEmitterKey key) {
+		clients.remove(key);
 	}
 
 	public int size() {
 		return clients.size();
 	}
 
-	public SseEmitter get(Long id) {
-		return clients.get(id);
+	public SseEmitter get(SseEmitterKey key) {
+		return clients.get(key);
 	}
 
-	public Set<Long> keys() {
+	public Set<SseEmitterKey> keys() {
 		return clients.keySet();
 	}
 }

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/event/publisher/PortfolioEventPublisherTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/event/publisher/PortfolioEventPublisherTest.java
@@ -36,6 +36,7 @@ import codesquad.fineants.domain.stock_dividend.StockDividendRepository;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
 import codesquad.fineants.spring.api.kis.manager.LastDayClosingPriceManager;
 import codesquad.fineants.spring.api.kis.response.CurrentPriceResponse;
+import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterKey;
 import codesquad.fineants.spring.api.portfolio_stock.manager.SseEmitterManager;
 import codesquad.fineants.spring.api.portfolio_stock.service.PortfolioStockService;
 import lombok.extern.slf4j.Slf4j;
@@ -106,9 +107,10 @@ class PortfolioEventPublisherTest {
 		lastDayClosingPriceManager.addPrice("005930", 50000);
 
 		SseEmitter emitter = mock(SseEmitter.class);
-		emitter.onTimeout(() -> manager.remove(portfolio.getId()));
-		emitter.onCompletion(() -> manager.remove(portfolio.getId()));
-		manager.add(portfolio.getId(), emitter);
+		SseEmitterKey key = SseEmitterKey.create(portfolio.getId());
+		emitter.onTimeout(() -> manager.remove(key));
+		emitter.onCompletion(() -> manager.remove(key));
+		manager.add(key, emitter);
 
 		// when
 		publisher.sendEventToPortfolio(LocalDateTime.of(2023, 12, 22, 10, 0, 0));
@@ -132,10 +134,11 @@ class PortfolioEventPublisherTest {
 		given(portfolioStockService.readMyPortfolioStocksInRealTime(anyLong()))
 			.willThrow(new IllegalArgumentException("005930 종목에 대한 가격을 찾을 수 없습니다."));
 
-		SseEmitter emitter = new SseEmitter();
-		emitter.onTimeout(() -> manager.remove(portfolio.getId()));
-		emitter.onCompletion(() -> manager.remove(portfolio.getId()));
-		manager.add(portfolio.getId(), emitter);
+		SseEmitter emitter = mock(SseEmitter.class);
+		SseEmitterKey key = SseEmitterKey.create(portfolio.getId());
+		emitter.onTimeout(() -> manager.remove(key));
+		emitter.onCompletion(() -> manager.remove(key));
+		manager.add(key, emitter);
 
 		// when
 		publisher.sendEventToPortfolio(LocalDateTime.of(2023, 12, 22, 10, 0, 0));


### PR DESCRIPTION
## 구현한 것

- SseEmitterManager 객체의 키값 형태를 포트폴리오 등록번호에서 SseEmitterKey 객체로 변경하였습니다.
    - 서로 다른 클라이언트에서 동일한 포트폴리오 번호를 이용하여 sse 요청시 기존 SseEmitter가 제거되는 문제를 해결하였습니다.
- 포트폴리오 이벤트 리스너에서 모든 Exception에 대하여 emitter.completeWithError() 메소드를 수행하도록 변경하였습니다.
     - 기존 일부 예외에 대해서만 completeWithError 처리를 하였지만 IllegalStateException 예외 발생시에는 complete 처리가 되지 않아서 제거되지 않은 문제를 해결하였습니다. 
