### PR TITLE
[feat] 포트폴리오 추가 및 수정시 입력정보 변경

### DIFF
--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -323,4 +323,8 @@ public class Portfolio extends BaseEntity {
 		return this.name.equals(changePortfolio.name);
 	}
 
+	// 예산이 0원인지 검사합니다.
+	public boolean isBudgetEmpty() {
+		return this.budget == 0;
+	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
@@ -68,13 +68,13 @@ public class PortFolioService {
 	}
 
 	private void validateTargetGainIsEqualLessThanBudget(Long targetGain, Long budget) {
-		if (targetGain <= budget) {
+		if (budget > 0 && targetGain <= budget) {
 			throw new BadRequestException(PortfolioErrorCode.TARGET_GAIN_LOSS_IS_EQUAL_LESS_THAN_BUDGET);
 		}
 	}
 
 	private void validateMaximumLossIsEqualGraterThanBudget(Long maximumLoss, Long budget) {
-		if (maximumLoss >= budget) {
+		if (budget > 0 && maximumLoss >= budget) {
 			throw new BadRequestException(PortfolioErrorCode.MAXIMUM_LOSS_IS_EQUAL_GREATER_THAN_BUDGET);
 		}
 	}

--- a/src/main/java/codesquad/fineants/spring/api/portfolio/request/PortfolioCreateRequest.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio/request/PortfolioCreateRequest.java
@@ -2,7 +2,7 @@ package codesquad.fineants.spring.api.portfolio.request;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 
 import codesquad.fineants.domain.member.Member;
 import codesquad.fineants.domain.portfolio.Portfolio;
@@ -20,15 +20,15 @@ public class PortfolioCreateRequest {
 	private String securitiesFirm;
 
 	@NotNull(message = "예산은 필수 정보입니다.")
-	@Positive(message = "예산은 양수여야 합니다")
+	@PositiveOrZero(message = "예산은 양수여야 합니다")
 	private Long budget;
 
 	@NotNull(message = "목표 수익 금액은 필수 정보입니다.")
-	@Positive(message = "목표 수익 금액은 양수여야 합니다")
+	@PositiveOrZero(message = "목표 수익 금액은 양수여야 합니다")
 	private Long targetGain;
 
 	@NotNull(message = "최대 손실 금액은 필수 정보입니다.")
-	@Positive(message = "최대 손실 금액은 양수여야 합니다")
+	@PositiveOrZero(message = "최대 손실 금액은 양수여야 합니다")
 	private Long maximumLoss;
 
 	public Portfolio toEntity(Member member) {

--- a/src/main/java/codesquad/fineants/spring/api/portfolio/request/PortfolioModifyRequest.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio/request/PortfolioModifyRequest.java
@@ -2,7 +2,7 @@ package codesquad.fineants.spring.api.portfolio.request;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Positive;
+import javax.validation.constraints.PositiveOrZero;
 
 import codesquad.fineants.domain.member.Member;
 import codesquad.fineants.domain.portfolio.Portfolio;
@@ -20,15 +20,15 @@ public class PortfolioModifyRequest {
 	private String securitiesFirm;
 
 	@NotNull(message = "예산은 필수 정보입니다.")
-	@Positive(message = "예산은 양수여야 합니다")
+	@PositiveOrZero(message = "예산은 양수여야 합니다")
 	private Long budget;
 
 	@NotNull(message = "목표 수익 금액은 필수 정보입니다.")
-	@Positive(message = "목표 수익 금액은 양수여야 합니다")
+	@PositiveOrZero(message = "목표 수익 금액은 양수여야 합니다")
 	private Long targetGain;
 
 	@NotNull(message = "최대 손실 금액은 필수 정보입니다.")
-	@Positive(message = "최대 손실 금액은 양수여야 합니다")
+	@PositiveOrZero(message = "최대 손실 금액은 양수여야 합니다")
 	private Long maximumLoss;
 
 	public Portfolio toEntity(Member member) {

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_notification/PortfolioNotificationService.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_notification/PortfolioNotificationService.java
@@ -1,10 +1,8 @@
 package codesquad.fineants.spring.api.portfolio_notification;
 
-import java.time.Duration;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,6 +12,7 @@ import codesquad.fineants.domain.portfolio.PortfolioRepository;
 import codesquad.fineants.spring.api.errors.errorcode.PortfolioErrorCode;
 import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
+import codesquad.fineants.spring.api.portfolio_notification.manager.MailRedisManager;
 import codesquad.fineants.spring.api.portfolio_notification.request.PortfolioNotificationModifyRequest;
 import codesquad.fineants.spring.api.portfolio_notification.response.PortfolioNotificationModifyResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +26,7 @@ public class PortfolioNotificationService {
 
 	private final PortfolioRepository portfolioRepository;
 	private final MailService mailService;
-	private final RedisTemplate<String, String> redisTemplate;
+	private final MailRedisManager manager;
 	private final CurrentPriceManager currentPriceManager;
 
 	@Transactional
@@ -60,13 +59,13 @@ public class PortfolioNotificationService {
 	// 주기적으로 포트폴리오를 확인하여 목표수익금액에 도달하면 메일을 보낸다
 	@Scheduled(fixedRate = 120000L, initialDelay = 30000L)
 	public void notifyTargetGain() {
-		log.info("notifyTargetGain");
 		List<Portfolio> portfolios = portfolioRepository.findAll();
 		portfolios.forEach(portfolio -> portfolio.changeCurrentPriceFromHoldings(currentPriceManager));
 
 		List<Portfolio> reachedTargetGainPortfolios = portfolios.stream()
-			.filter(portfolio -> !hasMailSentHistoryForTargetGain(portfolio))
+			.filter(portfolio -> !manager.hasMailSentHistoryForTargetGain(portfolio))
 			.filter(Portfolio::getTargetGainIsActive)
+			.filter(portfolio -> !portfolio.isBudgetEmpty())
 			.filter(Portfolio::reachedTargetGain)
 			.collect(Collectors.toList());
 		log.info("포트폴리오 목표수익금액 도달 포트폴리오 : {}개", reachedTargetGainPortfolios.size());
@@ -76,27 +75,8 @@ public class PortfolioNotificationService {
 			String subject = String.format("%s 포트폴리오 목표수익금액 도달 안내 메일입니다", portfolio.getName());
 			String content = createMailContent(portfolio);
 			mailService.sendEmail(to, subject, content);
-			setMailSentHistoryForTargetGain(portfolio);
+			manager.setMailSentHistoryForTargetGain(portfolio);
 		});
-	}
-
-	private boolean hasMailSentHistoryForTargetGain(Portfolio portfolio) {
-		String value = redisTemplate.opsForValue().get(createMailSentHistoryKeyForTargetGain(portfolio));
-		return value != null;
-	}
-
-	private String createMailSentHistoryKeyForTargetGain(Portfolio portfolio) {
-		return String.format("targetGainMail:%d", portfolio.getId());
-	}
-
-	private boolean hasMailSentHistoryForMaximumLoss(Portfolio portfolio) {
-		String value = redisTemplate.opsForValue().get(createMailSentHistoryKeyForMaximumLoss(portfolio));
-		log.info("hasMailSentHistoryForMaximumLoss value={}", value);
-		return value != null;
-	}
-
-	private String createMailSentHistoryKeyForMaximumLoss(Portfolio portfolio) {
-		return String.format("MaximumLossMail:%d", portfolio.getId());
 	}
 
 	private String createMailContent(Portfolio portfolio) {
@@ -107,30 +87,16 @@ public class PortfolioNotificationService {
 		return String.join("\n", title, targetGain, maximumLoss, totalGain);
 	}
 
-	private void setMailSentHistoryForTargetGain(Portfolio portfolio) {
-		redisTemplate.opsForValue().set(
-			createMailSentHistoryKeyForTargetGain(portfolio),
-			Boolean.TRUE.toString(),
-			Duration.ofDays(1));
-	}
-
-	private void setMailSentHistoryMaximumLoss(Portfolio portfolio) {
-		redisTemplate.opsForValue().set(
-			createMailSentHistoryKeyForMaximumLoss(portfolio),
-			Boolean.TRUE.toString(),
-			Duration.ofDays(1));
-	}
-
 	// 1분마다 포트폴리오를 확인하여 최대손실금액에 도달하면 메일을 보낸다
 	@Scheduled(fixedRate = 120000L, initialDelay = 30000L)
 	public void notifyMaximumLoss() {
-		log.info("notifyMaximumLoss");
 		List<Portfolio> portfolios = portfolioRepository.findAll();
 		portfolios.forEach(portfolio -> portfolio.changeCurrentPriceFromHoldings(currentPriceManager));
 
 		List<Portfolio> reachedMaximumLossPortfolios = portfolios.stream()
-			.filter(portfolio -> !hasMailSentHistoryForMaximumLoss(portfolio))
+			.filter(portfolio -> !manager.hasMailSentHistoryForMaximumLoss(portfolio))
 			.filter(Portfolio::getMaximumIsActive)
+			.filter(portfolio -> !portfolio.isBudgetEmpty())
 			.filter(Portfolio::reachedMaximumLoss)
 			.collect(Collectors.toList());
 		log.info("포트폴리오 최대손실금액 도달 포트폴리오 : {}개", reachedMaximumLossPortfolios.size());
@@ -140,7 +106,7 @@ public class PortfolioNotificationService {
 			String subject = String.format("%s 포트폴리오 최대손실금액 도달 안내 메일입니다", portfolio.getName());
 			String content = createMailContent(portfolio);
 			mailService.sendEmail(to, subject, content);
-			setMailSentHistoryMaximumLoss(portfolio);
+			manager.setMailSentHistoryMaximumLoss(portfolio);
 		});
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_notification/manager/MailRedisManager.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_notification/manager/MailRedisManager.java
@@ -1,0 +1,47 @@
+package codesquad.fineants.spring.api.portfolio_notification.manager;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import codesquad.fineants.domain.portfolio.Portfolio;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class MailRedisManager {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public boolean hasMailSentHistoryForTargetGain(Portfolio portfolio) {
+		String value = redisTemplate.opsForValue().get(createMailSentHistoryKeyForTargetGain(portfolio));
+		return value != null;
+	}
+
+	private String createMailSentHistoryKeyForTargetGain(Portfolio portfolio) {
+		return String.format("targetGainMail:%d", portfolio.getId());
+	}
+
+	public boolean hasMailSentHistoryForMaximumLoss(Portfolio portfolio) {
+		String value = redisTemplate.opsForValue().get(createMailSentHistoryKeyForMaximumLoss(portfolio));
+		return value != null;
+	}
+
+	private String createMailSentHistoryKeyForMaximumLoss(Portfolio portfolio) {
+		return String.format("MaximumLossMail:%d", portfolio.getId());
+	}
+
+	public void setMailSentHistoryForTargetGain(Portfolio portfolio) {
+		redisTemplate.opsForValue().set(
+			createMailSentHistoryKeyForTargetGain(portfolio),
+			Boolean.TRUE.toString(),
+			Duration.ofDays(1));
+	}
+
+	public void setMailSentHistoryMaximumLoss(Portfolio portfolio) {
+		redisTemplate.opsForValue().set(
+			createMailSentHistoryKeyForMaximumLoss(portfolio),
+			Boolean.TRUE.toString(),
+			Duration.ofDays(1));
+	}
+}

--- a/src/test/java/codesquad/fineants/spring/api/portfolio/PortFolioRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio/PortFolioRestControllerTest.java
@@ -85,7 +85,7 @@ class PortFolioRestControllerTest {
 	}
 
 	@DisplayName("사용자는 포트폴리오 추가를 요청한다")
-	@CsvSource(value = {"1000000,1500000,900000", "0,0,0"})
+	@CsvSource(value = {"1000000,1500000,900000", "0,0,0", "0,1500000,900000"})
 	@ParameterizedTest
 	void addPortfolio(Long budget, Long targetGain, Long maximumLoss) throws Exception {
 		// given
@@ -139,8 +139,9 @@ class PortFolioRestControllerTest {
 	}
 
 	@DisplayName("사용자는 포트폴리오 수정을 요청한다")
-	@Test
-	void modifyPortfolio() throws Exception {
+	@CsvSource(value = {"1000000,1500000,900000", "0,0,0", "0,1500000,900000"})
+	@ParameterizedTest
+	void modifyPortfolio(Long budget, Long targetGain, Long maximumLoss) throws Exception {
 		// given
 		Portfolio portfolio = createPortfolio(Portfolio.builder(), 1000000L, 1500000L, 900000L);
 		PortfolioModifyResponse response = PortfolioModifyResponse.from(portfolio);
@@ -152,9 +153,9 @@ class PortFolioRestControllerTest {
 		Map<String, Object> requestBodyMap = new HashMap<>();
 		requestBodyMap.put("name", "내꿈은 찰리몽거");
 		requestBodyMap.put("securitiesFirm", "토스");
-		requestBodyMap.put("budget", 1000000L);
-		requestBodyMap.put("targetGain", 1500000L);
-		requestBodyMap.put("maximumLoss", 900000L);
+		requestBodyMap.put("budget", budget);
+		requestBodyMap.put("targetGain", targetGain);
+		requestBodyMap.put("maximumLoss", maximumLoss);
 
 		String body = ObjectMapperUtil.serialize(requestBodyMap);
 		// when & then
@@ -169,7 +170,8 @@ class PortFolioRestControllerTest {
 	}
 
 	@DisplayName("사용자는 포트폴리오 수정시 유효하지 않은 입력 정보로 추가할 수 없다")
-	@Test
+	@MethodSource("invalidPortfolioInput")
+	@ParameterizedTest
 	void modifyPortfolioWithInvalidInput() throws Exception {
 		// given
 		Map<String, Object> requestBodyMap = new HashMap<>();

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_notification/PortfolioNotificationServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_notification/PortfolioNotificationServiceTest.java
@@ -10,9 +10,10 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -34,6 +35,7 @@ import codesquad.fineants.domain.stock.Market;
 import codesquad.fineants.domain.stock.Stock;
 import codesquad.fineants.domain.stock.StockRepository;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
+import codesquad.fineants.spring.api.portfolio_notification.manager.MailRedisManager;
 import codesquad.fineants.spring.api.portfolio_notification.request.PortfolioNotificationModifyRequest;
 import codesquad.fineants.spring.api.portfolio_notification.response.PortfolioNotificationModifyResponse;
 
@@ -71,52 +73,8 @@ class PortfolioNotificationServiceTest {
 	@MockBean
 	private MailService mailService;
 
-	private Portfolio portfolio;
-
-	private PortfolioHolding portfolioHolding;
-
-	@BeforeEach
-	void init() {
-		Member member = Member.builder()
-			.nickname("일개미1234")
-			.email("kim1234@gmail.com")
-			.password("kim1234@")
-			.provider("local")
-			.build();
-		member = memberRepository.save(member);
-
-		Portfolio portfolio = Portfolio.builder()
-			.name("내꿈은 워렌버핏")
-			.securitiesFirm("토스")
-			.budget(1000000L)
-			.targetGain(1500000L)
-			.maximumLoss(900000L)
-			.member(member)
-			.targetGainIsActive(true)
-			.maximumIsActive(true)
-			.build();
-		this.portfolio = portfolioRepository.save(portfolio);
-
-		Stock stock = Stock.builder()
-			.companyName("삼성전자보통주")
-			.tickerSymbol("005930")
-			.companyNameEng("SamsungElectronics")
-			.stockCode("KR7005930003")
-			.market(Market.KOSPI)
-			.build();
-		stockRepository.save(stock);
-
-		PortfolioHolding portfolioHolding = PortfolioHolding.empty(portfolio, stock);
-		this.portfolioHolding = portFolioHoldingRepository.save(portfolioHolding);
-
-		purchaseHistoryRepository.save(PurchaseHistory.builder()
-			.purchaseDate(LocalDateTime.now())
-			.numShares(3L)
-			.purchasePricePerShare(50000.0)
-			.memo("첫구매")
-			.portfolioHolding(this.portfolioHolding)
-			.build());
-	}
+	@MockBean
+	private MailRedisManager manager;
 
 	@AfterEach
 	void tearDown() {
@@ -132,21 +90,27 @@ class PortfolioNotificationServiceTest {
 	@Test
 	void modifyPortfolioTargetGainNotification() throws JsonProcessingException {
 		// given
-		long portfolioId = portfolio.getId();
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding portfolioHolding = portFolioHoldingRepository.save(createPortfolioHolding(portfolio, stock));
+		purchaseHistoryRepository.save(createPurchaseHistory(portfolioHolding));
+
 		Map<String, Boolean> requestBodyMap = new HashMap<>();
 		requestBodyMap.put("isActive", true);
 		PortfolioNotificationModifyRequest request = objectMapper.readValue(
 			objectMapper.writeValueAsString(requestBodyMap), PortfolioNotificationModifyRequest.class);
 
 		// when
-		PortfolioNotificationModifyResponse response = service.modifyPortfolioTargetGainNotification(
-			request, portfolioId);
+		PortfolioNotificationModifyResponse response = service.modifyPortfolioTargetGainNotification(request,
+			portfolio.getId());
 
 		// then
 		assertAll(
 			() -> assertThat(response).extracting("portfolioId", "isActive")
-				.containsExactlyInAnyOrder(portfolioId, true),
-			() -> assertThat(portfolioRepository.findById(portfolioId).orElseThrow().getTargetGainIsActive()).isTrue()
+				.containsExactlyInAnyOrder(portfolio.getId(), true),
+			() -> assertThat(
+				portfolioRepository.findById(portfolio.getId()).orElseThrow().getTargetGainIsActive()).isTrue()
 		);
 	}
 
@@ -154,6 +118,12 @@ class PortfolioNotificationServiceTest {
 	@Test
 	void modifyPortfolioMaximumLossNotification() throws JsonProcessingException {
 		// given
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding portfolioHolding = portFolioHoldingRepository.save(createPortfolioHolding(portfolio, stock));
+		purchaseHistoryRepository.save(createPurchaseHistory(portfolioHolding));
+
 		long portfolioId = portfolio.getId();
 		Map<String, Boolean> requestBodyMap = new HashMap<>();
 		requestBodyMap.put("isActive", true);
@@ -176,6 +146,12 @@ class PortfolioNotificationServiceTest {
 	@Test
 	void notifyTargetGain() {
 		// given
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding portfolioHolding = portFolioHoldingRepository.save(createPortfolioHolding(portfolio, stock));
+		purchaseHistoryRepository.save(createPurchaseHistory(portfolioHolding));
+
 		purchaseHistoryRepository.save(PurchaseHistory.builder()
 			.purchaseDate(LocalDateTime.now())
 			.numShares(100L)
@@ -186,12 +162,86 @@ class PortfolioNotificationServiceTest {
 
 		given(currentPriceManager.hasCurrentPrice("005930")).willReturn(true);
 		given(currentPriceManager.getCurrentPrice("005930")).willReturn(100000L);
-		doNothing().when(mailService).sendEmail(anyString(),
-			anyString(),
-			anyString());
+		given(manager.hasMailSentHistoryForTargetGain(any(Portfolio.class))).willReturn(false);
+
 		// when
 		service.notifyTargetGain();
+
 		// then
+		verify(mailService, times(1))
+			.sendEmail(anyString(), anyString(), anyString());
 	}
 
+	@DisplayName("예산이 0원이라서 사용자에게 최대손익금액 도달 안내 메일을 전송하지 않는다")
+	@CsvSource(value = {"0,0,0", "0,1500000,900000"})
+	@ParameterizedTest
+	void notifyTargetGain_whenBudgetIsZero_thenNotSendMail(Long budget, Long targetGain, Long maximumLoss) {
+		// given
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member, budget, targetGain, maximumLoss));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding portfolioHolding = portFolioHoldingRepository.save(createPortfolioHolding(portfolio, stock));
+		purchaseHistoryRepository.save(createPurchaseHistory(portfolioHolding));
+
+		given(currentPriceManager.hasCurrentPrice("005930")).willReturn(true);
+		given(currentPriceManager.getCurrentPrice("005930")).willReturn(100000L);
+		given(manager.hasMailSentHistoryForTargetGain(any(Portfolio.class))).willReturn(false);
+
+		// when
+		service.notifyTargetGain();
+
+		// then
+		verify(mailService, times(0))
+			.sendEmail(anyString(), anyString(), anyString());
+	}
+
+	private Member createMember() {
+		return Member.builder()
+			.nickname("일개미1234")
+			.email("kim1234@gmail.com")
+			.password("kim1234@")
+			.provider("local")
+			.build();
+	}
+
+	private Portfolio createPortfolio(Member member) {
+		return createPortfolio(member, 1000000L, 1500000L, 900000L);
+	}
+
+	private Portfolio createPortfolio(Member member, Long budget, Long targetGain, Long maximumLoss) {
+		return Portfolio.builder()
+			.name("내꿈은 워렌버핏")
+			.securitiesFirm("토스")
+			.budget(budget)
+			.targetGain(targetGain)
+			.maximumLoss(maximumLoss)
+			.member(member)
+			.targetGainIsActive(true)
+			.maximumIsActive(true)
+			.build();
+	}
+
+	private Stock createStock() {
+		return Stock.builder()
+			.companyName("삼성전자보통주")
+			.tickerSymbol("005930")
+			.companyNameEng("SamsungElectronics")
+			.stockCode("KR7005930003")
+			.market(Market.KOSPI)
+			.build();
+	}
+
+	private PortfolioHolding createPortfolioHolding(Portfolio portfolio, Stock stock) {
+		return PortfolioHolding.empty(portfolio, stock);
+	}
+
+	private PurchaseHistory createPurchaseHistory(PortfolioHolding portfolioHolding) {
+		return PurchaseHistory.builder()
+			.purchaseDate(LocalDateTime.now())
+			.numShares(3L)
+			.purchasePricePerShare(50000.0)
+			.memo("첫구매")
+			.portfolioHolding(portfolioHolding)
+			.build();
+	}
 }

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/service/PortfolioStockServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/service/PortfolioStockServiceTest.java
@@ -125,7 +125,7 @@ class PortfolioStockServiceTest {
 					"provisionalLossBalance",
 					"targetGainNotification", "maxLossNotification")
 				.containsExactlyInAnyOrder("토스", "내꿈은 워렌버핏", 1000000L, 1500000L, 50, 900000L, 10, 150000L, 30000L,
-					20, 30000L, 20, 850000L, 3249L, 1, 0L, false, false),
+					20, 30000L, 20, 850000L, 4332L, 2, 0L, false, false),
 			() -> assertThat(response).extracting("portfolioHoldings")
 				.asList()
 				.hasSize(1)


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 추가 및 수정시 예산, 목표수익금액, 최대손실금액은 0원도 입력받을 수 있도록 변경하였습니다.
- 메일 알림 서비스에서 예산이 0원인 경우 전송하지 않도록 변경하였습니다.
