### PR TITLE
[fix] 회원 랜덤 닉네임 길이 변경

### DIFF
--- a/src/main/resources/member.yml
+++ b/src/main/resources/member.yml
@@ -1,4 +1,4 @@
 member:
   nickname:
     prefix: 일개미
-    len: 8
+    len: 7

--- a/src/test/java/codesquad/fineants/spring/api/member/service/NicknameGeneratorTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/member/service/NicknameGeneratorTest.java
@@ -1,0 +1,29 @@
+package codesquad.fineants.spring.api.member.service;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class NicknameGeneratorTest {
+
+	@Autowired
+	private NicknameGenerator generator;
+
+	@DisplayName("회원의 랜덤 닉네임을 생성합니다")
+	@Test
+	void generate() {
+		// given
+		int expectedLength = 10;
+
+		// when
+		String nickname = generator.generate();
+
+		// then
+		Assertions.assertThat(nickname.length()).isEqualTo(expectedLength);
+	}
+}


### PR DESCRIPTION
## 구현한 것

- 회원의 랜덤 닉네임 길이를 10자로 변경
