### PR TITLE
[feat] FCM 토큰 등록

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:okhttp:4.12.0';
     testImplementation 'com.squareup.okhttp3:mockwebserver:4.12.0'
 
+    // firebase
+    implementation 'com.google.firebase:firebase-admin:9.1.1'
+
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
@@ -109,6 +112,11 @@ task copyPrivate(type: Copy) {
         from './secret'
         include "*.yml"
         into 'src/main/resources/secret'
+    }
+    copy {
+        from './secret'
+        include "*.json"
+        into 'src/main/resources/secret/firebase'
     }
 }
 

--- a/src/main/java/codesquad/fineants/domain/fcm_token/FcmRepository.java
+++ b/src/main/java/codesquad/fineants/domain/fcm_token/FcmRepository.java
@@ -1,0 +1,6 @@
+package codesquad.fineants.domain.fcm_token;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FcmRepository extends JpaRepository<FcmToken, Long> {
+}

--- a/src/main/java/codesquad/fineants/spring/api/fcm/controller/FcmRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/controller/FcmRestController.java
@@ -1,0 +1,36 @@
+package codesquad.fineants.spring.api.fcm.controller;
+
+import javax.validation.Valid;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.oauth.support.AuthPrincipalMember;
+import codesquad.fineants.spring.api.fcm.request.FcmRegisterRequest;
+import codesquad.fineants.spring.api.fcm.response.FcmRegisterResponse;
+import codesquad.fineants.spring.api.fcm.service.FcmService;
+import codesquad.fineants.spring.api.response.ApiResponse;
+import codesquad.fineants.spring.api.success.code.FcmSuccessCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/fcm")
+public class FcmRestController {
+	private final FcmService fcmService;
+
+	@ResponseStatus(HttpStatus.CREATED)
+	@PostMapping("/tokens")
+	public ApiResponse<FcmRegisterResponse> registerToken(
+		@Valid @RequestBody FcmRegisterRequest request,
+		@AuthPrincipalMember AuthMember authMember) {
+		return ApiResponse.success(FcmSuccessCode.CREATED_FCM, fcmService.registerToken(request, authMember));
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/fcm/request/FcmRegisterRequest.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/request/FcmRegisterRequest.java
@@ -7,11 +7,15 @@ import javax.validation.constraints.NotBlank;
 import codesquad.fineants.domain.fcm_token.FcmToken;
 import codesquad.fineants.domain.member.Member;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class FcmRegisterRequest {
 	@NotBlank(message = "FCM 토큰은 필수 정보입니다")
 	private String fcmToken;

--- a/src/main/java/codesquad/fineants/spring/api/fcm/request/FcmRegisterRequest.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/request/FcmRegisterRequest.java
@@ -1,0 +1,26 @@
+package codesquad.fineants.spring.api.fcm.request;
+
+import java.time.LocalDateTime;
+
+import javax.validation.constraints.NotBlank;
+
+import codesquad.fineants.domain.fcm_token.FcmToken;
+import codesquad.fineants.domain.member.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class FcmRegisterRequest {
+	@NotBlank(message = "FCM 토큰은 필수 정보입니다")
+	private String fcmToken;
+
+	public FcmToken toEntity(Member member) {
+		return FcmToken.builder()
+			.token(fcmToken)
+			.member(member)
+			.latestActivationTime(LocalDateTime.now())
+			.build();
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/fcm/response/FcmRegisterResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/response/FcmRegisterResponse.java
@@ -3,12 +3,14 @@ package codesquad.fineants.spring.api.fcm.response;
 import codesquad.fineants.domain.fcm_token.FcmToken;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class FcmRegisterResponse {
 	private Long fcmTokenId;
 

--- a/src/main/java/codesquad/fineants/spring/api/fcm/response/FcmRegisterResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/response/FcmRegisterResponse.java
@@ -1,0 +1,18 @@
+package codesquad.fineants.spring.api.fcm.response;
+
+import codesquad.fineants.domain.fcm_token.FcmToken;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class FcmRegisterResponse {
+	private Long fcmTokenId;
+
+	public static FcmRegisterResponse from(FcmToken fcmTOkenn) {
+		return new FcmRegisterResponse(fcmTOkenn.getId());
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
@@ -1,0 +1,36 @@
+package codesquad.fineants.spring.api.fcm.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import codesquad.fineants.domain.fcm_token.FcmRepository;
+import codesquad.fineants.domain.fcm_token.FcmToken;
+import codesquad.fineants.domain.member.Member;
+import codesquad.fineants.domain.member.MemberRepository;
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.spring.api.errors.errorcode.MemberErrorCode;
+import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
+import codesquad.fineants.spring.api.fcm.request.FcmRegisterRequest;
+import codesquad.fineants.spring.api.fcm.response.FcmRegisterResponse;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class FcmService {
+
+	private final FcmRepository fcmRepository;
+	private final MemberRepository memberRepository;
+
+	@Transactional
+	public FcmRegisterResponse registerToken(FcmRegisterRequest request, AuthMember authMember) {
+		Member member = findMember(authMember);
+		FcmToken saveFcmToken = fcmRepository.save(request.toEntity(member));
+		return FcmRegisterResponse.from(saveFcmToken);
+	}
+
+	private Member findMember(AuthMember authMember) {
+		return memberRepository.findById(authMember.getMemberId())
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/firebase/FirebaseMessagingService.java
+++ b/src/main/java/codesquad/fineants/spring/api/firebase/FirebaseMessagingService.java
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 public class FirebaseMessagingService {
 	private final FirebaseMessaging firebaseMessaging;
 
-	public String sendNotificationByToken(NotificationMessage notificationMessage) {
+	public String sendNotification(NotificationMessage notificationMessage) {
 		Notification notification = Notification
 			.builder()
 			.setTitle(notificationMessage.getTitle())
@@ -30,7 +30,8 @@ public class FirebaseMessagingService {
 			.build();
 
 		try {
-			firebaseMessaging.send(message);
+			String messageId = firebaseMessaging.send(message);
+			log.info("푸시 알림 전송, messageId={}", messageId);
 			return "Success Sending Notification";
 		} catch (FirebaseMessagingException e) {
 			log.error(e.getMessage(), e);

--- a/src/main/java/codesquad/fineants/spring/api/firebase/FirebaseMessagingService.java
+++ b/src/main/java/codesquad/fineants/spring/api/firebase/FirebaseMessagingService.java
@@ -8,7 +8,9 @@ import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class FirebaseMessagingService {
@@ -31,7 +33,7 @@ public class FirebaseMessagingService {
 			firebaseMessaging.send(message);
 			return "Success Sending Notification";
 		} catch (FirebaseMessagingException e) {
-			e.printStackTrace();
+			log.error(e.getMessage(), e);
 			return "Error Sending Notification";
 		}
 	}

--- a/src/main/java/codesquad/fineants/spring/api/firebase/FirebaseMessagingService.java
+++ b/src/main/java/codesquad/fineants/spring/api/firebase/FirebaseMessagingService.java
@@ -1,0 +1,38 @@
+package codesquad.fineants.spring.api.firebase;
+
+import org.springframework.stereotype.Service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class FirebaseMessagingService {
+	private final FirebaseMessaging firebaseMessaging;
+
+	public String sendNotificationByToken(NotificationMessage notificationMessage) {
+		Notification notification = Notification
+			.builder()
+			.setTitle(notificationMessage.getTitle())
+			.setBody(notificationMessage.getBody())
+			.build();
+
+		Message message = Message
+			.builder()
+			.setToken(notificationMessage.getRecipientToken())
+			.setNotification(notification)
+			.build();
+
+		try {
+			firebaseMessaging.send(message);
+			return "Success Sending Notification";
+		} catch (FirebaseMessagingException e) {
+			e.printStackTrace();
+			return "Error Sending Notification";
+		}
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/firebase/NotificationMessage.java
+++ b/src/main/java/codesquad/fineants/spring/api/firebase/NotificationMessage.java
@@ -1,11 +1,16 @@
 package codesquad.fineants.spring.api.firebase;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @ToString
 public class NotificationMessage {
 	private String recipientToken;

--- a/src/main/java/codesquad/fineants/spring/api/firebase/NotificationMessage.java
+++ b/src/main/java/codesquad/fineants/spring/api/firebase/NotificationMessage.java
@@ -1,0 +1,14 @@
+package codesquad.fineants.spring.api.firebase;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@ToString
+public class NotificationMessage {
+	private String recipientToken;
+	private String title;
+	private String body;
+}

--- a/src/main/java/codesquad/fineants/spring/api/success/code/FcmSuccessCode.java
+++ b/src/main/java/codesquad/fineants/spring/api/success/code/FcmSuccessCode.java
@@ -1,0 +1,25 @@
+package codesquad.fineants.spring.api.success.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FcmSuccessCode implements SuccessCode {
+
+	CREATED_FCM(HttpStatus.CREATED, "FCM 토큰을 성공적으로 등록하였습니다");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "FCM 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/config/FirebaseConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/FirebaseConfig.java
@@ -1,0 +1,27 @@
+package codesquad.fineants.spring.config;
+
+import java.io.IOException;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.google.firebase.messaging.FirebaseMessaging;
+
+@Configuration
+public class FirebaseConfig {
+	@Bean
+	public FirebaseMessaging firebaseMessaging() throws IOException {
+		GoogleCredentials googleCredentials = GoogleCredentials
+			.fromStream(new ClassPathResource("secret/firebase/fineants-firebase-adminsdk.json").getInputStream());
+		FirebaseOptions firebaseOptions = FirebaseOptions.builder()
+			.setCredentials(googleCredentials)
+			.build();
+		FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "fineants");
+		return FirebaseMessaging.getInstance(app);
+
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/config/FirebaseConfig.java
+++ b/src/main/java/codesquad/fineants/spring/config/FirebaseConfig.java
@@ -1,6 +1,9 @@
 package codesquad.fineants.spring.config;
 
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,13 +18,23 @@ import com.google.firebase.messaging.FirebaseMessaging;
 public class FirebaseConfig {
 	@Bean
 	public FirebaseMessaging firebaseMessaging() throws IOException {
-		GoogleCredentials googleCredentials = GoogleCredentials
-			.fromStream(new ClassPathResource("secret/firebase/fineants-firebase-adminsdk.json").getInputStream());
-		FirebaseOptions firebaseOptions = FirebaseOptions.builder()
-			.setCredentials(googleCredentials)
-			.build();
-		FirebaseApp app = FirebaseApp.initializeApp(firebaseOptions, "fineants");
-		return FirebaseMessaging.getInstance(app);
+		InputStream refreshToken = new ClassPathResource("secret/firebase/fineants-firebase-adminsdk.json")
+			.getInputStream();
+		FirebaseApp firebaseApp = null;
+		List<FirebaseApp> firebaseApps = FirebaseApp.getApps();
 
+		if (firebaseApps != null && !firebaseApps.isEmpty()) {
+			for (FirebaseApp app : firebaseApps) {
+				if (app.getName().equals(FirebaseApp.DEFAULT_APP_NAME)) {
+					firebaseApp = app;
+				}
+			}
+		} else {
+			FirebaseOptions options = FirebaseOptions.builder()
+				.setCredentials(GoogleCredentials.fromStream(refreshToken))
+				.build();
+			firebaseApp = FirebaseApp.initializeApp(options);
+		}
+		return FirebaseMessaging.getInstance(Objects.requireNonNull(firebaseApp));
 	}
 }

--- a/src/test/java/codesquad/fineants/spring/api/fcm/controller/FcmRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/fcm/controller/FcmRestControllerTest.java
@@ -1,0 +1,100 @@
+package codesquad.fineants.spring.api.fcm.controller;
+
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import codesquad.fineants.domain.member.Member;
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.oauth.support.AuthPrincipalArgumentResolver;
+import codesquad.fineants.spring.api.errors.handler.GlobalExceptionHandler;
+import codesquad.fineants.spring.api.fcm.request.FcmRegisterRequest;
+import codesquad.fineants.spring.api.fcm.response.FcmRegisterResponse;
+import codesquad.fineants.spring.api.fcm.service.FcmService;
+import codesquad.fineants.spring.config.JpaAuditingConfiguration;
+import codesquad.fineants.spring.util.ObjectMapperUtil;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = FcmRestController.class)
+@MockBean(JpaAuditingConfiguration.class)
+class FcmRestControllerTest {
+
+	private MockMvc mockMvc;
+
+	@Autowired
+	private FcmRestController fcmRestController;
+
+	@Autowired
+	private GlobalExceptionHandler globalExceptionHandler;
+
+	@MockBean
+	private AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
+
+	@MockBean
+	private FcmService fcmService;
+
+	@BeforeEach
+	void setup() {
+		mockMvc = MockMvcBuilders.standaloneSetup(fcmRestController)
+			.setControllerAdvice(globalExceptionHandler)
+			.setCustomArgumentResolvers(authPrincipalArgumentResolver)
+			.alwaysDo(print())
+			.build();
+
+		given(authPrincipalArgumentResolver.supportsParameter(ArgumentMatchers.any(MethodParameter.class)))
+			.willReturn(true);
+		given(authPrincipalArgumentResolver.resolveArgument(any(), any(), any(), any()))
+			.willReturn(AuthMember.from(createMember()));
+	}
+
+	@DisplayName("사용자는 FCM 토큰을 등록한다")
+	@Test
+	void FirebaseAuth() throws Exception {
+		// given
+		given(fcmService.registerToken(
+			any(FcmRegisterRequest.class),
+			any(AuthMember.class)))
+			.willReturn(FcmRegisterResponse.builder()
+				.fcmTokenId(1L)
+				.build());
+
+		Map<String, String> body = Map.of("fcmToken", "fcmToken");
+
+		// when & then
+		mockMvc.perform(post("/api/fcm/tokens")
+				.content(ObjectMapperUtil.serialize(body))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("code").value(equalTo(201)))
+			.andExpect(jsonPath("status").value(equalTo("Created")))
+			.andExpect(jsonPath("message").value(equalTo("FCM 토큰을 성공적으로 등록하였습니다")))
+			.andExpect(jsonPath("data.fcmTokenId").value(equalTo(1)));
+	}
+
+	private Member createMember() {
+		return Member.builder()
+			.nickname("nemo1234")
+			.email("dragonbead95@naver.com")
+			.password("nemo1234")
+			.provider("local")
+			.build();
+	}
+}

--- a/src/test/java/codesquad/fineants/spring/api/fcm/controller/FcmRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/fcm/controller/FcmRestControllerTest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -67,7 +68,7 @@ class FcmRestControllerTest {
 
 	@DisplayName("사용자는 FCM 토큰을 등록한다")
 	@Test
-	void FirebaseAuth() throws Exception {
+	void registerToken() throws Exception {
 		// given
 		given(fcmService.registerToken(
 			any(FcmRegisterRequest.class),
@@ -87,6 +88,23 @@ class FcmRestControllerTest {
 			.andExpect(jsonPath("status").value(equalTo("Created")))
 			.andExpect(jsonPath("message").value(equalTo("FCM 토큰을 성공적으로 등록하였습니다")))
 			.andExpect(jsonPath("data.fcmTokenId").value(equalTo(1)));
+	}
+
+	@DisplayName("사용자는 유효하지 않은 형식의 토큰을 전달하여 등록할 수 없다")
+	@Test
+	void registerToken_whenInvalidFcmToken_thenResponse400Error() throws Exception {
+		// given
+		Map<String, String> body = new HashMap<>();
+		body.put("fcmToken", null);
+
+		// when
+		mockMvc.perform(post("/api/fcm/tokens")
+				.content(ObjectMapperUtil.serialize(body))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("code").value(equalTo(400)))
+			.andExpect(jsonPath("status").value(equalTo("Bad Request")))
+			.andExpect(jsonPath("message").value(equalTo("잘못된 입력형식입니다")));
 	}
 
 	private Member createMember() {

--- a/src/test/java/codesquad/fineants/spring/api/fcm/service/FcmServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/fcm/service/FcmServiceTest.java
@@ -1,0 +1,62 @@
+package codesquad.fineants.spring.api.fcm.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import codesquad.fineants.domain.fcm_token.FcmRepository;
+import codesquad.fineants.domain.member.Member;
+import codesquad.fineants.domain.member.MemberRepository;
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.spring.api.fcm.request.FcmRegisterRequest;
+import codesquad.fineants.spring.api.fcm.response.FcmRegisterResponse;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class FcmServiceTest {
+
+	@Autowired
+	private FcmService fcmService;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private FcmRepository fcmRepository;
+
+	@AfterEach
+	void tearDown() {
+		fcmRepository.deleteAllInBatch();
+		memberRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("사용자는 FCM 토큰을 등록한다")
+	@Test
+	void registerToken() {
+		// given
+		Member member = memberRepository.save(createMember());
+		FcmRegisterRequest request = FcmRegisterRequest.builder()
+			.fcmToken("fcmToken")
+			.build();
+
+		// when
+		FcmRegisterResponse response = fcmService.registerToken(request, AuthMember.from(member));
+
+		// then
+		assertThat(response.getFcmTokenId()).isGreaterThan(0);
+	}
+
+	private Member createMember() {
+		return Member.builder()
+			.nickname("nemo1234")
+			.email("dragonbead95@naver.com")
+			.password("nemo1234")
+			.provider("local")
+			.build();
+	}
+}

--- a/src/test/java/codesquad/fineants/spring/api/firebase/FirebaseMessagingServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/firebase/FirebaseMessagingServiceTest.java
@@ -1,0 +1,47 @@
+package codesquad.fineants.spring.api.firebase;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.BDDMockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class FirebaseMessagingServiceTest {
+
+	@Autowired
+	private FirebaseMessagingService firebaseMessagingService;
+
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
+
+	@DisplayName("클라이언트에게 토큰을 이용하여 알림 메시지를 푸시한다")
+	@Test
+	void sendNotification() throws FirebaseMessagingException {
+		// given
+		NotificationMessage notificationMessage = NotificationMessage.builder()
+			.recipientToken("token")
+			.title("test title")
+			.body("message content")
+			.build();
+
+		BDDMockito.given(firebaseMessaging.send(ArgumentMatchers.any(Message.class)))
+			.willReturn("1");
+
+		// when
+		String result = firebaseMessagingService.sendNotification(notificationMessage);
+
+		// then
+		assertThat(result).isEqualTo("Success Sending Notification");
+	}
+}


### PR DESCRIPTION
## 구현한 것

- FCM 토큰 등록 API를 구현하였습니다. (POST /api/fcm/tokens)

## TO-BE

- 로그인 수행시 FCM 토큰도 선택적으로 같이 받아서 등록합니다.
- 로그아웃 수행시 FCM 토큰의 등록번호를 선택적으로 받아서 삭제합니다.
- 프론트와 협업하여 로그인 API의 포스트맨을 수정합니다.
- 토큰 등록시 FCM 서버에서 요청하여 유효한 토큰인지 검증하는 로직을 추가합니다.
