### PR TITLE
[fix] 알림 설정 수정 API 문제 해결

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/member/controller/MemberNotificationRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/controller/MemberNotificationRestController.java
@@ -90,7 +90,7 @@ public class MemberNotificationRestController {
 		@Valid @RequestBody MemberNotificationPreferenceRequest request) {
 		MemberNotificationPreferenceResponse response = preferenceService.updateNotificationPreference(memberId,
 			request);
-		log.info("회원 알림 설정 수정 처리 결과 : memberId={}, response={}", memberId, request);
+		log.info("회원 알림 설정 수정 처리 결과 : memberId={}, response={}", memberId, response);
 		return ApiResponse.success(MemberSuccessCode.OK_UPDATE_NOTIFICATION_PREFERENCE);
 	}
 }

--- a/src/test/java/codesquad/fineants/spring/api/member/service/MemberNotificationPreferenceServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/member/service/MemberNotificationPreferenceServiceTest.java
@@ -101,6 +101,33 @@ class MemberNotificationPreferenceServiceTest {
 		);
 	}
 
+	@DisplayName("사용자가 계정 설정시 기존 설정이 없다면 새로 등록한다")
+	@Test
+	void updateNotificationPreference_whenNotExistPreference_thenRegisterPreference() {
+		// given
+		Member member = memberRepository.save(createMember());
+		MemberNotificationPreferenceRequest request = MemberNotificationPreferenceRequest.builder()
+			.browserNotify(false)
+			.targetGainNotify(true)
+			.maxLossNotify(true)
+			.targetPriceNotify(true)
+			.build();
+
+		// when
+		MemberNotificationPreferenceResponse response = service.updateNotificationPreference(member.getId(), request);
+
+		// then
+		NotificationPreference preference = repository.findByMemberId(member.getId()).orElseThrow();
+		assertAll(
+			() -> assertThat(response)
+				.extracting("browserNotify", "targetGainNotify", "maxLossNotify", "targetPriceNotify")
+				.containsExactly(false, true, true, true),
+			() -> assertThat(preference)
+				.extracting("browserNotify", "targetGainNotify", "maxLossNotify", "targetPriceNotify")
+				.containsExactly(false, true, true, true)
+		);
+	}
+
 	private Member createMember() {
 		return Member.builder()
 			.nickname("일개미1234")


### PR DESCRIPTION
## 구현한 것

- 기존 로컬 회원들도 알림 설정 수정시 데이터가 없어도 새로 생성하여 성공할 수 있도록 변경
