### PR TITLE
[feat] 회원 알림 권한 검사 AOP 추가

### DIFF
--- a/src/main/java/codesquad/fineants/domain/oauth/support/AuthMember.java
+++ b/src/main/java/codesquad/fineants/domain/oauth/support/AuthMember.java
@@ -6,8 +6,10 @@ import codesquad.fineants.domain.member.Member;
 import io.jsonwebtoken.Claims;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class AuthMember {
 
 	private Long memberId;

--- a/src/main/java/codesquad/fineants/spring/api/member/controller/MemberNotificationRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/controller/MemberNotificationRestController.java
@@ -22,6 +22,7 @@ import codesquad.fineants.spring.api.member.service.MemberNotificationPreference
 import codesquad.fineants.spring.api.member.service.MemberNotificationService;
 import codesquad.fineants.spring.api.response.ApiResponse;
 import codesquad.fineants.spring.api.success.code.MemberSuccessCode;
+import codesquad.fineants.spring.auth.HasNotificationAuthorization;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,6 +36,7 @@ public class MemberNotificationRestController {
 	private final MemberNotificationPreferenceService preferenceService;
 
 	// 회원의 알림 목록 조회
+	@HasNotificationAuthorization
 	@GetMapping("/notifications")
 	public ApiResponse<MemberNotificationResponse> fetchNotifications(@PathVariable Long memberId) {
 		return ApiResponse.success(MemberSuccessCode.OK_READ_NOTIFICATIONS,
@@ -51,6 +53,7 @@ public class MemberNotificationRestController {
 		return ApiResponse.success(MemberSuccessCode.OK_FETCH_ALL_NOTIFICATIONS);
 	}
 
+	@HasNotificationAuthorization
 	@PatchMapping("/notifications/{notificationId}")
 	public ApiResponse<Void> readNotification(
 		@PathVariable Long memberId,
@@ -60,6 +63,7 @@ public class MemberNotificationRestController {
 		return ApiResponse.success(MemberSuccessCode.OK_FETCH_ALL_NOTIFICATIONS);
 	}
 
+	@HasNotificationAuthorization
 	@DeleteMapping("/notifications")
 	public ApiResponse<Void> deleteAllNotifications(
 		@PathVariable Long memberId,
@@ -72,6 +76,7 @@ public class MemberNotificationRestController {
 		return ApiResponse.success(MemberSuccessCode.OK_DELETED_ALL_NOTIFICATIONS);
 	}
 
+	@HasNotificationAuthorization
 	@DeleteMapping("/notifications/{notificationId}")
 	public ApiResponse<Void> deleteNotification(
 		@PathVariable Long memberId,
@@ -84,6 +89,7 @@ public class MemberNotificationRestController {
 		return ApiResponse.success(MemberSuccessCode.OK_DELETED_NOTIFICATION);
 	}
 
+	@HasNotificationAuthorization
 	@PutMapping("/notification/settings")
 	public ApiResponse<Void> updateNotificationPreference(
 		@PathVariable Long memberId,

--- a/src/main/java/codesquad/fineants/spring/auth/HasNotificationAuthorization.java
+++ b/src/main/java/codesquad/fineants/spring/auth/HasNotificationAuthorization.java
@@ -1,0 +1,16 @@
+package codesquad.fineants.spring.auth;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public @interface HasNotificationAuthorization {
+
+}

--- a/src/main/java/codesquad/fineants/spring/auth/HasNotificationAuthorizationAspect.java
+++ b/src/main/java/codesquad/fineants/spring/auth/HasNotificationAuthorizationAspect.java
@@ -1,0 +1,33 @@
+package codesquad.fineants.spring.auth;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import codesquad.fineants.domain.oauth.support.AuthMember;
+import codesquad.fineants.domain.oauth.support.AuthenticationContext;
+import codesquad.fineants.spring.api.errors.errorcode.MemberErrorCode;
+import codesquad.fineants.spring.api.errors.exception.ForBiddenException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Aspect
+@Component
+public class HasNotificationAuthorizationAspect {
+
+	private final AuthenticationContext authenticationContext;
+
+	@Before(value = "within(@org.springframework.web.bind.annotation.RestController *) && @annotation(hasNotificationAuthorization) && args(memberId, ..)", argNames = "hasNotificationAuthorization,memberId")
+	public void hasAuthorization(final HasNotificationAuthorization hasNotificationAuthorization,
+		@PathVariable final Long memberId) {
+		AuthMember authMember = authenticationContext.getAuthMember();
+		log.info("알림 권한 확인 시작, memberId={}, authMember : {}", memberId, authMember);
+		if (!memberId.equals(authMember.getMemberId())) {
+			throw new ForBiddenException(MemberErrorCode.FORBIDDEN_MEMBER);
+		}
+	}
+}
+


### PR DESCRIPTION
## 구현한 것

- 회원 알림 관련 API 요청시 API 경로상의 memberId와 로그인한 회원의 memberId가 불일치하는 경우 403 응답을 하도록 구현하였습니다.