### PR TITLE
[fix] 알림 모두 읽음 API에 권한 검사 AOP 추가

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/member/controller/MemberNotificationRestController.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/controller/MemberNotificationRestController.java
@@ -44,6 +44,7 @@ public class MemberNotificationRestController {
 	}
 
 	// 회원의 알림 모두 읽기
+	@HasNotificationAuthorization
 	@PatchMapping("/notifications")
 	public ApiResponse<Void> readAllNotifications(
 		@PathVariable Long memberId,


### PR DESCRIPTION
## 구현한 것

- 알림 모두 읽음 API에 권한 검사 AOP 추가
