### PR TITLE
[fix] 회원 알람 설정 수정 스펙 변경

### DIFF
--- a/src/main/java/codesquad/fineants/domain/fcm_token/FcmRepository.java
+++ b/src/main/java/codesquad/fineants/domain/fcm_token/FcmRepository.java
@@ -14,4 +14,8 @@ public interface FcmRepository extends JpaRepository<FcmToken, Long> {
 	@Modifying
 	@Query("delete from FcmToken f where f.token in (:tokens)")
 	int deleteAllByTokens(@Param("tokens") List<String> tokens);
+
+	@Modifying
+	@Query("delete from FcmToken f where f.id = :fcmTokenId")
+	int deleteByFcmTokenId(@Param("fcmTokenId") Long fcmTokenId);
 }

--- a/src/main/java/codesquad/fineants/domain/notification_preference/NotificationPreference.java
+++ b/src/main/java/codesquad/fineants/domain/notification_preference/NotificationPreference.java
@@ -62,4 +62,11 @@ public class NotificationPreference extends BaseEntity {
 		this.maxLossNotify = notificationPreference.maxLossNotify;
 		this.targetPriceNotify = notificationPreference.targetPriceNotify;
 	}
+
+	public boolean isAllInActive() {
+		return !this.browserNotify
+			&& !this.targetGainNotify
+			&& !this.maxLossNotify
+			&& !this.targetPriceNotify;
+	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/fcm/response/FcmDeleteResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/response/FcmDeleteResponse.java
@@ -1,0 +1,23 @@
+package codesquad.fineants.spring.api.fcm.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class FcmDeleteResponse {
+	private Long fcmTokenId;
+
+	public static FcmDeleteResponse from(Long fcmTokenId) {
+		return FcmDeleteResponse.builder()
+			.fcmTokenId(fcmTokenId)
+			.build();
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
@@ -18,6 +18,7 @@ import codesquad.fineants.spring.api.errors.errorcode.MemberErrorCode;
 import codesquad.fineants.spring.api.errors.exception.BadRequestException;
 import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
 import codesquad.fineants.spring.api.fcm.request.FcmRegisterRequest;
+import codesquad.fineants.spring.api.fcm.response.FcmDeleteResponse;
 import codesquad.fineants.spring.api.fcm.response.FcmRegisterResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -57,5 +58,12 @@ public class FcmService {
 	private Member findMember(AuthMember authMember) {
 		return memberRepository.findById(authMember.getMemberId())
 			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
+	}
+
+	@Transactional
+	public FcmDeleteResponse deleteToken(Long fcmTokenId) {
+		int deleteCount = fcmRepository.deleteByFcmTokenId(fcmTokenId);
+		log.info("FCM 토큰 삭제 개수 : deleteCount={}", deleteCount);
+		return FcmDeleteResponse.from(fcmTokenId);
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/member/request/MemberNotificationPreferenceRequest.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/request/MemberNotificationPreferenceRequest.java
@@ -22,6 +22,7 @@ public class MemberNotificationPreferenceRequest {
 	private Boolean maxLossNotify;
 	@NotNull(message = "필수 정보입니다")
 	private Boolean targetPriceNotify;
+	private Long fcmTokenId;
 
 	public NotificationPreference toEntity() {
 		return NotificationPreference.builder()

--- a/src/main/resources/db/mysql/init-schema.sql
+++ b/src/main/resources/db/mysql/init-schema.sql
@@ -170,15 +170,27 @@ create table if not exists fineAnts.stock_target_price
         primary key,
     create_at     datetime(6)  null,
     modified_at   datetime(6)  null,
-    target_price  bigint       null,
+    is_active bit null,
     member_id     bigint       null,
     ticker_symbol varchar(255) null,
-    constraint UKb01jhjkq681lpyfjx5glikxee
-        unique (member_id, ticker_symbol, target_price),
+    constraint UKhwlfu5x3iqpei19soxhmjcfs3
+        unique (member_id, ticker_symbol),
     constraint FK2r0grp1n205hnw3ysp179f5l3
         foreign key (member_id) references fineAnts.member (id),
     constraint FKcup8hchscft8jniri3wkk72kx
         foreign key (ticker_symbol) references fineAnts.stock (ticker_symbol)
+);
+
+create table if not exists fineAnts.target_price_notification
+(
+    id                    bigint auto_increment
+        primary key,
+    create_at             datetime(6) null,
+    modified_at           datetime(6) null,
+    target_price          bigint      null,
+    stock_target_price_id bigint      null,
+    constraint FKnds69ucw684g4c2a09g0fa5bq
+        foreign key (stock_target_price_id) references fineAnts.stock_target_price (id)
 );
 
 create table if not exists fineAnts.notification


### PR DESCRIPTION
## 구현한 것

- 회원 알람 설정 수정 API의 request body에 fcmTokenId 추가 (null 가능)
- 해당 API 요청시 모든 상태값이 false로 요청시 fcmTokenId에 해당하는 FCM 토큰 삭제
