### PR TITLE
[feat] FCM 토큰 등록 로직 변경

### DIFF
--- a/src/main/java/codesquad/fineants/domain/fcm_token/FcmRepository.java
+++ b/src/main/java/codesquad/fineants/domain/fcm_token/FcmRepository.java
@@ -13,7 +13,7 @@ public interface FcmRepository extends JpaRepository<FcmToken, Long> {
 	List<FcmToken> findAllByMemberId(@Param("memberId") Long memberId);
 
 	@Query("select f from FcmToken f where f.token = :token and f.member.id = :memberId")
-	Optional<FcmToken> findByToken(@Param("token") String token, @Param("memberId") Long memberId);
+	Optional<FcmToken> findByTokenAndMemberId(@Param("token") String token, @Param("memberId") Long memberId);
 
 	@Modifying
 	@Query("delete from FcmToken f where f.token in (:tokens)")

--- a/src/main/java/codesquad/fineants/domain/fcm_token/FcmToken.java
+++ b/src/main/java/codesquad/fineants/domain/fcm_token/FcmToken.java
@@ -41,4 +41,8 @@ public class FcmToken extends BaseEntity {
 		this.token = token;
 		this.latestActivationTime = latestActivationTime;
 	}
+
+	public void refreshLatestActivationTime() {
+		this.latestActivationTime = LocalDateTime.now();
+	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/fcm/response/FcmRegisterResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/response/FcmRegisterResponse.java
@@ -14,7 +14,7 @@ import lombok.NoArgsConstructor;
 public class FcmRegisterResponse {
 	private Long fcmTokenId;
 
-	public static FcmRegisterResponse from(FcmToken fcmTOkenn) {
-		return new FcmRegisterResponse(fcmTOkenn.getId());
+	public static FcmRegisterResponse from(FcmToken fcmToken) {
+		return new FcmRegisterResponse(fcmToken.getId());
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
@@ -37,7 +37,11 @@ public class FcmService {
 	public FcmRegisterResponse registerToken(FcmRegisterRequest request, AuthMember authMember) {
 		Member member = findMember(authMember);
 		verifyFcmToken(request.getFcmToken());
-		FcmToken saveFcmToken = fcmRepository.save(request.toEntity(member));
+
+		FcmToken fcmToken = fcmRepository.findByTokenAndMemberId(request.getFcmToken(), authMember.getMemberId())
+			.orElseGet(() -> request.toEntity(member));
+		fcmToken.refreshLatestActivationTime();
+		FcmToken saveFcmToken = fcmRepository.save(fcmToken);
 		return FcmRegisterResponse.from(saveFcmToken);
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
@@ -16,7 +16,6 @@ import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.spring.api.errors.errorcode.FcmErrorCode;
 import codesquad.fineants.spring.api.errors.errorcode.MemberErrorCode;
 import codesquad.fineants.spring.api.errors.exception.BadRequestException;
-import codesquad.fineants.spring.api.errors.exception.ConflictException;
 import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
 import codesquad.fineants.spring.api.fcm.request.FcmRegisterRequest;
 import codesquad.fineants.spring.api.fcm.response.FcmDeleteResponse;
@@ -37,7 +36,6 @@ public class FcmService {
 	@Transactional
 	public FcmRegisterResponse registerToken(FcmRegisterRequest request, AuthMember authMember) {
 		Member member = findMember(authMember);
-		verifyUniqueFcmToken(request.getFcmToken(), authMember.getMemberId());
 		verifyFcmToken(request.getFcmToken());
 		FcmToken saveFcmToken = fcmRepository.save(request.toEntity(member));
 		return FcmRegisterResponse.from(saveFcmToken);
@@ -53,7 +51,6 @@ public class FcmService {
 			firebaseMessaging.send(message, true);
 		} catch (FirebaseMessagingException e) {
 			log.info(e.getMessage(), e);
-			
 			throw new BadRequestException(FcmErrorCode.BAD_REQUEST_FCM_TOKEN);
 		}
 	}
@@ -63,12 +60,6 @@ public class FcmService {
 			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 	}
 
-	private void verifyUniqueFcmToken(String fcmToken, Long memberId) {
-		if (fcmRepository.findByToken(fcmToken, memberId).isPresent()) {
-			throw new ConflictException(FcmErrorCode.CONFLICT_FCM_TOKEN);
-		}
-	}
-  
 	@Transactional
 	public FcmDeleteResponse deleteToken(Long fcmTokenId) {
 		int deleteCount = fcmRepository.deleteByFcmTokenId(fcmTokenId);


### PR DESCRIPTION
## 구현한 것

- FCM 토큰 등록 서비스시 기존에 이미 FCM 토큰이 존재하면 최신 활성화 시간을 갱신하는 것으로 로직을 변경하였습니다.
