### PR TITLE
[feat] 회원 알림 API 변경

### DIFF
--- a/src/main/java/codesquad/fineants/domain/notification/Notification.java
+++ b/src/main/java/codesquad/fineants/domain/notification/Notification.java
@@ -2,31 +2,33 @@ package codesquad.fineants.domain.notification;
 
 import java.time.LocalDateTime;
 
+import javax.persistence.DiscriminatorColumn;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import codesquad.fineants.domain.BaseEntity;
 import codesquad.fineants.domain.member.Member;
 import lombok.AccessLevel;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "DTYPE")
 @Entity
-public class Notification extends BaseEntity {
+public abstract class Notification extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
-
 	private String title;
-	private String content;
 	private Boolean isRead;
 	private String type;
 	private String referenceId;
@@ -35,13 +37,11 @@ public class Notification extends BaseEntity {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	@Builder
-	public Notification(LocalDateTime createAt, LocalDateTime modifiedAt, Long id, String title, String content,
-		Boolean isRead, String type, String referenceId, Member member) {
+	public Notification(LocalDateTime createAt, LocalDateTime modifiedAt, Long id, String title, Boolean isRead,
+		String type, String referenceId, Member member) {
 		super(createAt, modifiedAt);
 		this.id = id;
 		this.title = title;
-		this.content = content;
 		this.isRead = isRead;
 		this.type = type;
 		this.referenceId = referenceId;
@@ -52,4 +52,8 @@ public class Notification extends BaseEntity {
 	public void readNotification() {
 		this.isRead = true;
 	}
+
+	public abstract NotificationBody createNotificationBody();
+
+	public abstract String createNotificationContent();
 }

--- a/src/main/java/codesquad/fineants/domain/notification/NotificationBody.java
+++ b/src/main/java/codesquad/fineants/domain/notification/NotificationBody.java
@@ -1,0 +1,18 @@
+package codesquad.fineants.domain.notification;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@ToString
+public class NotificationBody {
+	private String name;
+	private String target;
+}

--- a/src/main/java/codesquad/fineants/domain/notification/PortfolioNotification.java
+++ b/src/main/java/codesquad/fineants/domain/notification/PortfolioNotification.java
@@ -1,0 +1,50 @@
+package codesquad.fineants.domain.notification;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+import codesquad.fineants.domain.member.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("P")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PortfolioNotification extends Notification {
+	private String portfolioName;
+	@Enumerated(value = EnumType.STRING)
+	@Column(name = "portfolio_notification_type")
+	private PortfolioNotificationType notificationType;
+
+	@Builder
+	public PortfolioNotification(LocalDateTime createAt, LocalDateTime modifiedAt, Long id, String title,
+		Boolean isRead,
+		String type, String referenceId, Member member, String portfolioName,
+		PortfolioNotificationType notificationType) {
+		super(createAt, modifiedAt, id, title, isRead, type, referenceId, member);
+		this.portfolioName = portfolioName;
+		this.notificationType = notificationType;
+	}
+
+	@Override
+	public NotificationBody createNotificationBody() {
+		return NotificationBody.builder()
+			.name(portfolioName)
+			.target(notificationType.getName())
+			.build();
+	}
+
+	@Override
+	public String createNotificationContent() {
+		if (notificationType == PortfolioNotificationType.TARGET_GAIN) {
+			return String.format("%s의 목표 수익율을 달성했습니다", portfolioName);
+		}
+		return String.format("%s이(가) 최대 손실율에 도달했습니다", portfolioName);
+	}
+}

--- a/src/main/java/codesquad/fineants/domain/notification/PortfolioNotificationType.java
+++ b/src/main/java/codesquad/fineants/domain/notification/PortfolioNotificationType.java
@@ -1,0 +1,23 @@
+package codesquad.fineants.domain.notification;
+
+import lombok.Getter;
+
+@Getter
+public enum PortfolioNotificationType {
+	TARGET_GAIN("목표 수익률"), MAX_LOSS("최대 손실율");
+
+	private final String name;
+
+	PortfolioNotificationType(String name) {
+		this.name = name;
+	}
+
+	public static PortfolioNotificationType from(String target) {
+		for (PortfolioNotificationType type : values()) {
+			if (type.name.equals(target)) {
+				return type;
+			}
+		}
+		throw new IllegalArgumentException("잘못된 매개변수입니다. target=" + target);
+	}
+}

--- a/src/main/java/codesquad/fineants/domain/notification/StockTargetPriceNotification.java
+++ b/src/main/java/codesquad/fineants/domain/notification/StockTargetPriceNotification.java
@@ -1,0 +1,41 @@
+package codesquad.fineants.domain.notification;
+
+import java.time.LocalDateTime;
+
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+
+import codesquad.fineants.domain.member.Member;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+@Entity
+@DiscriminatorValue("S")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StockTargetPriceNotification extends Notification {
+	private String stockName;
+	private Long targetPrice;
+
+	@Builder
+	public StockTargetPriceNotification(LocalDateTime createAt, LocalDateTime modifiedAt, Long id,
+		String title, Boolean isRead, String type, String referenceId,
+		Member member, String stockName, Long targetPrice) {
+		super(createAt, modifiedAt, id, title, isRead, type, referenceId, member);
+		this.stockName = stockName;
+		this.targetPrice = targetPrice;
+	}
+
+	@Override
+	public NotificationBody createNotificationBody() {
+		return NotificationBody.builder()
+			.name(stockName)
+			.target(targetPrice.toString())
+			.build();
+	}
+
+	@Override
+	public String createNotificationContent() {
+		return String.format("%s(이)가 지정가 KRW%s에 도달했습니다", stockName, targetPrice);
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/member/request/MemberNotificationSendRequest.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/request/MemberNotificationSendRequest.java
@@ -4,6 +4,9 @@ import javax.validation.constraints.NotBlank;
 
 import codesquad.fineants.domain.member.Member;
 import codesquad.fineants.domain.notification.Notification;
+import codesquad.fineants.domain.notification.PortfolioNotification;
+import codesquad.fineants.domain.notification.PortfolioNotificationType;
+import codesquad.fineants.domain.notification.StockTargetPriceNotification;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,20 +21,35 @@ public class MemberNotificationSendRequest {
 	@NotBlank(message = "필수 정보입니다")
 	private String title;
 	@NotBlank(message = "필수 정보입니다")
-	private String body;
+	private String name;
+	@NotBlank(message = "필수 정보입니다")
+	private String target;
 	@NotBlank(message = "필수 정보입니다")
 	private String type;
 	@NotBlank(message = "필수 정보입니다")
 	private String referenceId;
 
 	public Notification toEntity(Member member) {
-		return Notification.builder()
+		if (type.equals("portfolio")) {
+
+			return PortfolioNotification.builder()
+				.title(title)
+				.isRead(false)
+				.type(type)
+				.referenceId(referenceId)
+				.member(member)
+				.portfolioName(name)
+				.notificationType(PortfolioNotificationType.from(target))
+				.build();
+		}
+		return StockTargetPriceNotification.builder()
 			.title(title)
-			.content(body)
 			.isRead(false)
 			.type(type)
 			.referenceId(referenceId)
 			.member(member)
+			.stockName(name)
+			.targetPrice(Long.valueOf(target))
 			.build();
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/member/response/MemberNotification.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/response/MemberNotification.java
@@ -3,6 +3,7 @@ package codesquad.fineants.spring.api.member.response;
 import java.time.LocalDateTime;
 
 import codesquad.fineants.domain.notification.Notification;
+import codesquad.fineants.domain.notification.NotificationBody;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -20,7 +21,7 @@ import lombok.ToString;
 public class MemberNotification {
 	private Long notificationId;
 	private String title;
-	private String body;
+	private NotificationBody body;
 	private LocalDateTime timestamp;
 	private Boolean isRead;
 	private String type;
@@ -30,7 +31,7 @@ public class MemberNotification {
 		return MemberNotification.builder()
 			.notificationId(notification.getId())
 			.title(notification.getTitle())
-			.body(notification.getContent())
+			.body(notification.createNotificationBody())
 			.timestamp(notification.getCreateAt())
 			.isRead(notification.getIsRead())
 			.type(notification.getType())

--- a/src/main/java/codesquad/fineants/spring/api/member/response/MemberNotificationSendResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/response/MemberNotificationSendResponse.java
@@ -30,7 +30,7 @@ public class MemberNotificationSendResponse {
 		return MemberNotificationSendResponse.builder()
 			.notificationId(notification.getId())
 			.title(notification.getTitle())
-			.content(notification.getContent())
+			.content(notification.createNotificationContent())
 			.timestamp(notification.getCreateAt())
 			.isRead(notification.getIsRead())
 			.type(notification.getType())

--- a/src/main/java/codesquad/fineants/spring/api/member/service/MemberNotificationService.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/service/MemberNotificationService.java
@@ -120,7 +120,7 @@ public class MemberNotificationService {
 				.setNotification(
 					com.google.firebase.messaging.Notification.builder()
 						.setTitle(notification.getTitle())
-						.setBody(notification.getContent())
+						.setBody(notification.createNotificationContent())
 						.build())
 				.build();
 			try {

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -83,11 +83,13 @@ INSERT INTO fineAnts.purchase_history (id, create_at, modified_at, memo, num_sha
                                        purchase_price_per_share, portfolio_holding_id)
 VALUES (1, '2023-10-26 15:26:11.219793', '2023-10-26 15:26:11.219793', null, 3, '2023-10-23 13:00:00.000000', 50000, 1);
 
-INSERT INTO fineAnts.notification(id, create_at, title, content, is_read, type, reference_id, member_id)
-VALUES (1, '2024-01-22 10:10:10.0', '지정가', '삼성전자가 지정가 KRW60000에 도달했습니다', true, 'stock', '005930', 1);
+INSERT INTO fineAnts.notification(id, create_at, title, is_read, type, reference_id, dtype, stock_name, target_price,
+                                  member_id)
+VALUES (1, '2024-01-22 10:10:10.0', '지정가', true, 'stock', '005930', 'S', '삼성전자보통주', 60000, 1);
 
-INSERT INTO fineAnts.notification(id, create_at, title, content, is_read, type, reference_id, member_id)
-VALUES (2, '2024-01-23 10:10:10.0', '포트폴리오', '내꿈은 워렌버핏의 목표 수익률을 달성했습니다', false, 'portfolio', '1', 1);
+INSERT INTO fineAnts.notification(id, create_at, title, is_read, type, reference_id, dtype, portfolio_name,
+                                  portfolio_notification_type, member_id)
+VALUES (2, '2024-01-23 10:10:10.0', '포트폴리오', false, 'portfolio', '1', 'P', '내꿈은 워렌버핏', 'TARGET_GAIN', 1);
 
 INSERT INTO fineAnts.notification_preference(id, create_at, browser_notify, max_loss_notify, target_gain_notify,
                                              target_price_notify, member_id)

--- a/src/main/resources/db/mysql/init-schema.sql
+++ b/src/main/resources/db/mysql/init-schema.sql
@@ -195,16 +195,20 @@ create table if not exists fineAnts.target_price_notification
 
 create table if not exists fineAnts.notification
 (
-    id           bigint auto_increment
+    dtype                       varchar(31)  not null,
+    id                          bigint auto_increment
         primary key,
-    create_at    datetime(6)  null,
-    modified_at  datetime(6)  null,
-    content      varchar(255) null,
-    is_read      bit          null,
-    reference_id varchar(255) null,
-    title        varchar(255) null,
-    type         varchar(255) null,
-    member_id    bigint       null,
+    create_at                   datetime(6)  null,
+    modified_at                 datetime(6)  null,
+    is_read                     bit          null,
+    reference_id                varchar(255) null,
+    title                       varchar(255) null,
+    type                        varchar(255) null,
+    portfolio_notification_type varchar(255) null,
+    portfolio_name              varchar(255) null,
+    stock_name                  varchar(255) null,
+    target_price                bigint       null,
+    member_id                   bigint       null,
     constraint FK1xep8o2ge7if6diclyyx53v4q
         foreign key (member_id) references fineAnts.member (id)
 );

--- a/src/test/java/codesquad/fineants/spring/api/member/controller/MemberNotificationRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/member/controller/MemberNotificationRestControllerTest.java
@@ -30,6 +30,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import codesquad.fineants.domain.member.Member;
+import codesquad.fineants.domain.notification.NotificationBody;
 import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.domain.oauth.support.AuthPrincipalArgumentResolver;
 import codesquad.fineants.spring.api.errors.handler.GlobalExceptionHandler;
@@ -190,7 +191,10 @@ class MemberNotificationRestControllerTest {
 		MemberNotification mockNotification = MemberNotification.builder()
 			.notificationId(3L)
 			.title("포트폴리오")
-			.body("포트폴리오2의 최대 손실율을 초과했습니다")
+			.body(NotificationBody.builder()
+				.name("포트폴리오2")
+				.target("최대 손실율")
+				.build())
 			.timestamp(LocalDateTime.of(2024, 1, 24, 10, 10, 10))
 			.isRead(false)
 			.type("portfolio")
@@ -242,7 +246,10 @@ class MemberNotificationRestControllerTest {
 		MemberNotification mockNotification = MemberNotification.builder()
 			.notificationId(3L)
 			.title("포트폴리오")
-			.body("포트폴리오2의 최대 손실율을 초과했습니다")
+			.body(NotificationBody.builder()
+				.name("포트폴리오2")
+				.target("최대 손실율")
+				.build())
 			.timestamp(LocalDateTime.of(2024, 1, 24, 10, 10, 10))
 			.isRead(false)
 			.type("portfolio")
@@ -268,7 +275,8 @@ class MemberNotificationRestControllerTest {
 		Member member = createMember();
 		MemberNotificationSendRequest request = MemberNotificationSendRequest.builder()
 			.title("포트폴리오")
-			.body("포트폴리오1의 최대 손실율을 초과했습니다")
+			.name("포트폴리오1")
+			.target("최대 손실율")
 			.type("portfolio")
 			.referenceId("1")
 			.build();
@@ -310,7 +318,10 @@ class MemberNotificationRestControllerTest {
 		return List.of(MemberNotification.builder()
 				.notificationId(3L)
 				.title("포트폴리오")
-				.body("포트폴리오2의 최대 손실율을 초과했습니다")
+				.body(NotificationBody.builder()
+					.name("포트폴리오2")
+					.target("최대 손실율")
+					.build())
 				.timestamp(LocalDateTime.of(2024, 1, 24, 10, 10, 10))
 				.isRead(false)
 				.type("portfolio")
@@ -319,7 +330,10 @@ class MemberNotificationRestControllerTest {
 			MemberNotification.builder()
 				.notificationId(2L)
 				.title("포트폴리오")
-				.body("포트폴리오1의 목표 수익률을 달성했습니다")
+				.body(NotificationBody.builder()
+					.name("포트폴리오1")
+					.target("목표 수익률")
+					.build())
 				.timestamp(LocalDateTime.of(2024, 1, 23, 10, 10, 10))
 				.isRead(false)
 				.type("portfolio")
@@ -328,7 +342,10 @@ class MemberNotificationRestControllerTest {
 			MemberNotification.builder()
 				.notificationId(1L)
 				.title("지정가")
-				.body("삼성전자가 지정가 KRW60000에 도달했습니다")
+				.body(NotificationBody.builder()
+					.name("삼성전자")
+					.target("65000")
+					.build())
 				.timestamp(LocalDateTime.of(2024, 1, 22, 10, 10, 10))
 				.isRead(true)
 				.type("stock")


### PR DESCRIPTION
## 구현한 것

- 회원 알림 메시지 발송 API의 RequestBody 구조 변경을 하였습니다.
- 회원 알림 목록 조회 API의 ResponseBody 구조를 변경하였습니다.
- Notification 엔티티를 상속 관계로 변경하였습니다.
