### PR TITLE
[fix] 프로필 조회 및 종목 지정가 알림 특정 조회 로직 수정

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/member/response/ProfileResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/member/response/ProfileResponse.java
@@ -15,20 +15,13 @@ public class ProfileResponse {
 
 	private MemberProfile user;
 
-	public static ProfileResponse from(Member member) {
+	public static ProfileResponse from(Member member, NotificationPreference preference) {
 		MemberProfile user = MemberProfile.builder()
 			.id(member.getId())
 			.nickname(member.getNickname())
 			.email(member.getEmail())
 			.profileUrl(member.getProfileUrl())
-			.notificationPreferences(
-				NotificationPreference.builder()
-					.browserNotify(false)
-					.targetGainNotify(true)
-					.maxLossNotify(true)
-					.targetPriceNotify(true)
-					.build()
-			)
+			.notificationPreferences(preference)
 			.build();
 		return ProfileResponse.builder()
 			.user(user)
@@ -56,5 +49,15 @@ public class ProfileResponse {
 		private Boolean targetGainNotify;
 		private Boolean maxLossNotify;
 		private Boolean targetPriceNotify;
+
+		public static NotificationPreference from(
+			codesquad.fineants.domain.notification_preference.NotificationPreference preference) {
+			return NotificationPreference.builder()
+				.browserNotify(preference.isBrowserNotify())
+				.targetGainNotify(preference.isTargetGainNotify())
+				.maxLossNotify(preference.isMaxLossNotify())
+				.targetPriceNotify(preference.isTargetPriceNotify())
+				.build();
+		}
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/stock/StockTargetPriceNotificationService.java
+++ b/src/main/java/codesquad/fineants/spring/api/stock/StockTargetPriceNotificationService.java
@@ -215,9 +215,8 @@ public class StockTargetPriceNotificationService {
 	) {
 		List<TargetPriceNotificationSpecificItem> targetPrices = repository.findByTickerSymbolAndMemberIdUsingFetchJoin(
 				tickerSymbol, memberId)
-			.orElseThrow(() -> new NotFoundResourceException(StockErrorCode.NOT_FOUND_STOCK_TARGET_PRICE))
-			.getTargetPriceNotifications()
 			.stream()
+			.flatMap(stockTargetPrice -> stockTargetPrice.getTargetPriceNotifications().stream())
 			.map(TargetPriceNotificationSpecificItem::from)
 			.collect(Collectors.toList());
 		TargetPriceNotificationSpecifiedSearchResponse response = TargetPriceNotificationSpecifiedSearchResponse.from(

--- a/src/test/java/codesquad/fineants/spring/api/stock/StockTargetPriceNotificationServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/stock/StockTargetPriceNotificationServiceTest.java
@@ -203,6 +203,24 @@ class StockTargetPriceNotificationServiceTest extends AbstractContainerBaseTest 
 				Tuple.tuple(targetPriceNotifications.get(1).getId(), 70000L));
 	}
 
+	@DisplayName("사용자가 없는 종목을 대상으로 지정가 알림 목록 조회시 빈 리스트를 반환받는다")
+	@Test
+	void searchTargetPriceNotifications_whenNotExistStock_thenResponseEmptyList() {
+		// given
+		Member member = memberRepository.save(createMember());
+		Stock stock = stockRepository.save(createStock());
+
+		// when
+		TargetPriceNotificationSpecifiedSearchResponse response = service.searchTargetPriceNotifications(
+			stock.getTickerSymbol(), member.getId());
+
+		// then
+		assertThat(response)
+			.extracting("targetPrices")
+			.asList()
+			.isEmpty();
+	}
+
 	@DisplayName("사용자는 종목 지정가 알림을 수정한다")
 	@Test
 	void updateStockTargetPriceNotification() {


### PR DESCRIPTION
## 구현한 것

- 프로필 조회시 알림 설정이 더미 데이터에서 실제 회원의 알림 설정 데이터가 반영되도록 변경하였습니다.
- 종목 지정가 알림 특정 조회시 회원이 가지고 있지 않은 종목인 경우에는 빈 리스트를 반환합니다.
