### PR TITLE
#244 fix: 포트폴리오의 예산이 0원인 경우 포트폴리오 차트 문제 해결

### DIFF
--- a/src/main/java/codesquad/fineants/domain/notification_preference/NotificationPreference.java
+++ b/src/main/java/codesquad/fineants/domain/notification_preference/NotificationPreference.java
@@ -49,9 +49,9 @@ public class NotificationPreference extends BaseEntity {
 	public static NotificationPreference defaultSetting(Member member) {
 		return NotificationPreference.builder()
 			.browserNotify(false)
-			.targetGainNotify(true)
-			.maxLossNotify(true)
-			.targetPriceNotify(true)
+			.targetGainNotify(false)
+			.maxLossNotify(false)
+			.targetPriceNotify(false)
 			.member(member)
 			.build();
 	}

--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -286,7 +286,9 @@ public class Portfolio extends BaseEntity {
 
 	// 현금 비중 계산, 현금 비중 = 잔고 / 총자산
 	public Double calculateCashWeight() {
-		return calculateBalance().doubleValue() / calculateTotalAsset().doubleValue() * 100;
+		double balance = calculateBalance().doubleValue();
+		double totalAsset = calculateTotalAsset().doubleValue();
+		return totalAsset != 0.0 ? balance / totalAsset * 100 : 0.0;
 	}
 
 	// 포트폴리오 종목 비중 계산, 종목 비중 = 종목 평가 금액 / 총자산
@@ -295,7 +297,8 @@ public class Portfolio extends BaseEntity {
 	}
 
 	private Double calculateWeightBy(Double currentValuation) {
-		return currentValuation / calculateTotalAsset().doubleValue() * 100;
+		double totalAsset = calculateTotalAsset().doubleValue();
+		return totalAsset != 0.0 ? currentValuation / totalAsset * 100 : 0.0;
 	}
 
 	// 배당금 차트 생성

--- a/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHolding.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHolding.java
@@ -218,7 +218,7 @@ public class PortfolioHolding extends BaseEntity {
 	}
 
 	public Double calculateWeightBy(Double portfolioAsset) {
-		return calculateCurrentValuation().doubleValue() / portfolioAsset * 100;
+		return portfolioAsset != 0.0 ? calculateCurrentValuation().doubleValue() / portfolioAsset * 100 : 0.0;
 	}
 
 	public PortfolioPieChartItem createPieChartItem(Double weight) {

--- a/src/test/java/codesquad/fineants/spring/api/member/service/MemberNotificationPreferenceServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/member/service/MemberNotificationPreferenceServiceTest.java
@@ -55,7 +55,7 @@ class MemberNotificationPreferenceServiceTest extends AbstractContainerBaseTest 
 		assertAll(
 			() -> assertThat(response)
 				.extracting("browserNotify", "targetGainNotify", "maxLossNotify", "targetPriceNotify")
-				.containsExactly(false, true, true, true),
+				.containsExactly(false, false, false, false),
 			() -> assertThat(repository.findByMemberId(member.getId()).isPresent())
 				.isTrue()
 		);
@@ -125,10 +125,10 @@ class MemberNotificationPreferenceServiceTest extends AbstractContainerBaseTest 
 		assertAll(
 			() -> assertThat(response)
 				.extracting("browserNotify", "targetGainNotify", "maxLossNotify", "targetPriceNotify")
-				.containsExactly(false, true, true, true),
+				.containsExactly(false, false, false, false),
 			() -> assertThat(preference)
 				.extracting("browserNotify", "targetGainNotify", "maxLossNotify", "targetPriceNotify")
-				.containsExactly(false, true, true, true)
+				.containsExactly(false, false, false, false)
 		);
 	}
 

--- a/src/test/java/codesquad/fineants/spring/api/member/service/MemberServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/member/service/MemberServiceTest.java
@@ -589,7 +589,7 @@ public class MemberServiceTest extends AbstractContainerBaseTest {
 		assertThat(response)
 			.extracting("user.notificationPreferences")
 			.extracting("browserNotify", "targetGainNotify", "maxLossNotify", "targetPriceNotify")
-			.containsExactlyInAnyOrder(false, true, true, true);
+			.containsExactlyInAnyOrder(false, false, false, false);
 	}
 
 	@DisplayName("사용자는 계정을 삭제한다")


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 예산이 0원인 경우 포트폴리오 차트 조회 문제 해결
- 신규 회원가입시 계정 알림 설정을 모두 비활성화로 변경