### PR TITLE
[fix] 매입 이력 이벤트에 따른 Notification 저장 문제 해결

### DIFF
--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -361,4 +361,9 @@ public class Portfolio extends BaseEntity {
 	public boolean isBudgetEmpty() {
 		return this.budget == 0;
 	}
+
+	// 매입 이력을 포트폴리오에 추가시 현금이 충분한지 판단
+	public boolean isCashSufficientForPurchase(long investmentAmount) {
+		return calculateTotalInvestmentAmount() + investmentAmount > budget;
+	}
 }

--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -24,6 +24,7 @@ import codesquad.fineants.domain.BaseEntity;
 import codesquad.fineants.domain.member.Member;
 import codesquad.fineants.domain.portfolio_gain_history.PortfolioGainHistory;
 import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
+import codesquad.fineants.domain.purchase_history.PurchaseHistory;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
 import codesquad.fineants.spring.api.portfolio_stock.response.PortfolioDividendChartItem;
 import codesquad.fineants.spring.api.portfolio_stock.response.PortfolioPieChartItem;
@@ -265,6 +266,14 @@ public class Portfolio extends BaseEntity {
 	// 포트폴리오가 목표수익금액에 도달했는지 검사
 	public boolean reachedTargetGain() {
 		return budget + calculateTotalGain() >= targetGain;
+	}
+
+	// 포트폴리오가 목표수익금액에 도달했는지 검사
+	public boolean reachedTargetGain(List<PurchaseHistory> histories) {
+		long totalGain = histories.stream()
+			.mapToLong(PurchaseHistory::calculateGain)
+			.sum();
+		return budget + totalGain >= targetGain;
 	}
 
 	// 포트폴리오가 최대손실금액에 도달했는지 검사

--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -273,6 +273,7 @@ public class Portfolio extends BaseEntity {
 		long totalGain = histories.stream()
 			.mapToLong(PurchaseHistory::calculateGain)
 			.sum();
+		log.info("totalGain : {}", totalGain);
 		return budget + totalGain >= targetGain;
 	}
 

--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -264,22 +264,19 @@ public class Portfolio extends BaseEntity {
 	}
 
 	// 포트폴리오가 목표수익금액에 도달했는지 검사
-	public boolean reachedTargetGain() {
-		return budget + calculateTotalGain() >= targetGain;
-	}
-
-	// 포트폴리오가 목표수익금액에 도달했는지 검사
 	public boolean reachedTargetGain(List<PurchaseHistory> histories) {
 		long totalGain = histories.stream()
 			.mapToLong(PurchaseHistory::calculateGain)
 			.sum();
-		log.info("totalGain : {}", totalGain);
 		return budget + totalGain >= targetGain;
 	}
 
 	// 포트폴리오가 최대손실금액에 도달했는지 검사
-	public boolean reachedMaximumLoss() {
-		return budget + calculateTotalGain() <= maximumLoss;
+	public boolean reachedMaximumLoss(List<PurchaseHistory> histories) {
+		long totalGain = histories.stream()
+			.mapToLong(PurchaseHistory::calculateGain)
+			.sum();
+		return budget + totalGain <= maximumLoss;
 	}
 
 	// 파이 차트 생성

--- a/src/main/java/codesquad/fineants/domain/portfolio/PortfolioRepository.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/PortfolioRepository.java
@@ -19,9 +19,6 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
 	@Query("select p from Portfolio p where p.member.id = :memberId")
 	List<Portfolio> findAllByMemberId(@Param("memberId") Long memberId);
 	
-	@Query("select distinct p from Portfolio p join fetch p.member join fetch p.portfolioHoldings holding join fetch holding.stock where p.id = :id")
-	Optional<Portfolio> findByPortfolioId(@Param("id") Long id);
-
 	@Query("select p from Portfolio p where p.id = :id")
 	@EntityGraph(value = "Portfolio.withAll", type = EntityGraph.EntityGraphType.LOAD)
 	Optional<Portfolio> findByPortfolioIdWithAll(@Param("id") Long id);

--- a/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHolding.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHolding.java
@@ -51,7 +51,7 @@ public class PortfolioHolding extends BaseEntity {
 	@JoinColumn(name = "ticker_symbol")
 	private Stock stock;
 
-	@BatchSize(size = 100)
+	@BatchSize(size = 1000)
 	@OneToMany(mappedBy = "portfolioHolding", fetch = FetchType.LAZY)
 	private final List<PurchaseHistory> purchaseHistory = new ArrayList<>();
 

--- a/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHoldingRepository.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHoldingRepository.java
@@ -11,26 +11,25 @@ import codesquad.fineants.domain.portfolio.Portfolio;
 
 public interface PortfolioHoldingRepository extends JpaRepository<PortfolioHolding, Long> {
 
-	int deleteAllByPortfolioId(Long portFolioId);
-
 	List<PortfolioHolding> findAllByPortfolio(Portfolio portfolio);
 
 	@Query("select distinct s.tickerSymbol from PortfolioHolding p inner join Stock s on p.stock.tickerSymbol = s.tickerSymbol")
 	List<String> findAllTickerSymbol();
 
-	@Query("DELETE FROM PortfolioHolding p WHERE p.stock.tickerSymbol = :tickerSymbol")
-	void deleteByTickerSymbol(@Param("tickerSymbol") String tickerSymbol);
-
 	@Query("SELECT p FROM PortfolioHolding p WHERE p.stock.tickerSymbol = :tickerSymbol")
 	Optional<PortfolioHolding> findByTickerSymbol(@Param("tickerSymbol") String tickerSymbol);
 
-	int deleteAllByIdIn(List<Long> portfolioHoldingIds);
+	@Query("select p from PortfolioHolding p where p.portfolio.id = :portfolioId and p.stock.tickerSymbol = :tickerSymbol")
+	Optional<PortfolioHolding> findByPortfolioIdAndTickerSymbol(
+		@Param("portfolioId") Long portfolioId,
+		@Param("tickerSymbol") String tickerSymbol);
 
 	@Query("select count(p) > 0 from PortfolioHolding p where p.id = :portfolioHoldingId and p.portfolio.member.id = :memberId")
-	boolean existsByIdAndMemberId(@Param("portfolioHoldingId") Long portfolioHoldingId,
+	boolean existsByIdAndMemberId(
+		@Param("portfolioHoldingId") Long portfolioHoldingId,
 		@Param("memberId") Long memberId);
 
-	@Query("select p from PortfolioHolding p where p.portfolio.id = :portfolioId and p.stock.tickerSymbol = :tickerSymbol")
-	Optional<PortfolioHolding> findByPortfolioIdAndTickerSymbol(@Param("portfolioId") Long portfolioId,
-		@Param("tickerSymbol") String tickerSymbol);
+	int deleteAllByPortfolioId(Long portFolioId);
+
+	int deleteAllByIdIn(List<Long> portfolioHoldingIds);
 }

--- a/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHoldingRepository.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio_holding/PortfolioHoldingRepository.java
@@ -24,6 +24,11 @@ public interface PortfolioHoldingRepository extends JpaRepository<PortfolioHoldi
 		@Param("portfolioId") Long portfolioId,
 		@Param("tickerSymbol") String tickerSymbol);
 
+	@Query("select p from PortfolioHolding p join fetch p.portfolio where p.id = :portfolioHoldingId and p.portfolio.id = :portfolioId")
+	Optional<PortfolioHolding> findByPortfolioHoldingIdAndPortfolioIdWithPortfolio(
+		@Param("portfolioHoldingId") Long portfolioHoldingId,
+		@Param("portfolioId") Long portfolioId);
+
 	@Query("select count(p) > 0 from PortfolioHolding p where p.id = :portfolioHoldingId and p.portfolio.member.id = :memberId")
 	boolean existsByIdAndMemberId(
 		@Param("portfolioHoldingId") Long portfolioHoldingId,

--- a/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistory.java
+++ b/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistory.java
@@ -67,7 +67,7 @@ public class PurchaseHistory extends BaseEntity {
 
 	// 손익 = (현재가 - 평균 매입가) * 주식개수
 	public long calculateGain() {
-		return portfolioHolding.getCurrentPrice() - purchasePricePerShare.longValue() * numShares;
+		return (portfolioHolding.getCurrentPrice() - purchasePricePerShare.longValue()) * numShares;
 	}
 
 	public PurchaseHistory change(PurchaseHistory history) {

--- a/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistory.java
+++ b/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistory.java
@@ -65,6 +65,11 @@ public class PurchaseHistory extends BaseEntity {
 		return purchasePricePerShare.longValue() * numShares;
 	}
 
+	// 손익 = (현재가 - 평균 매입가) * 주식개수
+	public long calculateGain() {
+		return portfolioHolding.getCurrentPrice() - purchasePricePerShare.longValue() * numShares;
+	}
+
 	public PurchaseHistory change(PurchaseHistory history) {
 		this.purchaseDate = history.getPurchaseDate();
 		this.purchasePricePerShare = history.getPurchasePricePerShare();
@@ -83,4 +88,5 @@ public class PurchaseHistory extends BaseEntity {
 		return purcahseLocalDate.equals(exDividendDate)
 			|| purcahseLocalDate.isBefore(exDividendDate);
 	}
+
 }

--- a/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistoryRepository.java
+++ b/src/main/java/codesquad/fineants/domain/purchase_history/PurchaseHistoryRepository.java
@@ -3,12 +3,18 @@ package codesquad.fineants.domain.purchase_history;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PurchaseHistoryRepository extends JpaRepository<PurchaseHistory, Long> {
 
-	int deleteAllByPortfolioHoldingIdIn(List<Long> portfolioId);
+	@Query("select p from PurchaseHistory p where p.portfolioHolding.id in(:holdingIds)")
+	List<PurchaseHistory> findAllByHoldingIds(@Param("holdingIds") List<Long> holdingIds);
 
 	List<PurchaseHistory> findAllByPortfolioHoldingId(Long portfolioStockId);
 
+	int deleteAllByPortfolioHoldingIdIn(List<Long> portfolioId);
+
 	void deleteByPortfolioHoldingId(Long portfolioHoldingId);
+
 }

--- a/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
+++ b/src/main/java/codesquad/fineants/spring/api/fcm/service/FcmService.java
@@ -19,7 +19,6 @@ import codesquad.fineants.domain.member.MemberRepository;
 import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.spring.api.errors.errorcode.FcmErrorCode;
 import codesquad.fineants.spring.api.errors.errorcode.MemberErrorCode;
-import codesquad.fineants.spring.api.errors.exception.BadRequestException;
 import codesquad.fineants.spring.api.errors.exception.FineAntsException;
 import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
 import codesquad.fineants.spring.api.fcm.request.FcmRegisterRequest;
@@ -66,8 +65,7 @@ public class FcmService {
 			firebaseMessaging.send(message, true);
 		} catch (FirebaseMessagingException e) {
 			log.info(e.getMessage(), e);
-
-			throw new BadRequestException(FcmErrorCode.BAD_REQUEST_FCM_TOKEN);
+			throw new FineAntsException(FcmErrorCode.BAD_REQUEST_FCM_TOKEN);
 		}
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/notification/response/NotifyMessageItem.java
+++ b/src/main/java/codesquad/fineants/spring/api/notification/response/NotifyMessageItem.java
@@ -13,10 +13,8 @@ import lombok.ToString;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @ToString
-public class NotifyPortfolioMessageItem {
-	private Long notificationId;
+public class NotifyMessageItem {
 	private String title;
-	private Boolean isRead;
 	private NotificationType type;
 	private String referenceId;
 	private String messageId;

--- a/src/main/java/codesquad/fineants/spring/api/notification/response/NotifyPortfolioMessagesResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/notification/response/NotifyPortfolioMessagesResponse.java
@@ -16,10 +16,10 @@ import lombok.ToString;
 @Builder
 @ToString
 public class NotifyPortfolioMessagesResponse {
-	private List<NotifyPortfolioMessageItem> notifications;
+	private List<NotifyMessageItem> notifications;
 
 	public static NotifyPortfolioMessagesResponse from(
-		List<NotifyPortfolioMessageItem> notifications) {
+		List<NotifyMessageItem> notifications) {
 		return NotifyPortfolioMessagesResponse.builder()
 			.notifications(notifications)
 			.build();

--- a/src/main/java/codesquad/fineants/spring/api/notification/service/NotificationService.java
+++ b/src/main/java/codesquad/fineants/spring/api/notification/service/NotificationService.java
@@ -63,7 +63,8 @@ public class NotificationService {
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 		codesquad.fineants.domain.notification.Notification saveNotification = notificationRepository.save(
-			request.toEntity(member));
+			request.toEntity(member)
+		);
 		return NotificationCreateResponse.from(saveNotification);
 	}
 
@@ -114,15 +115,15 @@ public class NotificationService {
 		);
 		return firebaseMessagingService.sendNotification(message)
 			.map(messageId -> {
-				NotificationCreateResponse response = this.createNotification(NotificationCreateRequest.builder()
+				NotificationCreateResponse createResponse = this.createNotification(NotificationCreateRequest.builder()
 						.portfolioName(portfolio.getName())
 						.title(title)
 						.type(NotificationType.PORTFOLIO_TARGET_GAIN)
 						.referenceId(referenceId)
 						.build(),
 					portfolio.getMember().getId());
-				log.info("알림 저장 결과 : response={}", response);
-				return createNotifyPortfolioMessageItem(messageId, response);
+				log.info("알리 저장 결과 : response={}", createResponse);
+				return createNotifyPortfolioMessageItem(messageId, createResponse);
 			});
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/notification/service/NotificationService.java
+++ b/src/main/java/codesquad/fineants/spring/api/notification/service/NotificationService.java
@@ -154,7 +154,11 @@ public class NotificationService {
 
 		Portfolio portfolio = portfolioService.findPortfolioUsingJoin(portfolioId);
 		portfolio.applyCurrentPriceAllHoldingsBy(currentPriceManager);
-		if (!portfolio.reachedMaximumLoss()) {
+		List<Long> holdingIds = portfolio.getPortfolioHoldings().stream()
+			.map(PortfolioHolding::getId)
+			.collect(Collectors.toList());
+		List<PurchaseHistory> histories = purchaseHistoryRepository.findAllByHoldingIds(holdingIds);
+		if (!portfolio.reachedMaximumLoss(histories)) {
 			log.info("최대 손실율 미달로 인한 빈 리스트 반환");
 			return NotifyPortfolioMessagesResponse.empty();
 		}

--- a/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
@@ -168,7 +168,7 @@ public class PortFolioService {
 	}
 
 	public Portfolio findPortfolioUsingJoin(Long portfolioId) {
-		return portfolioRepository.findByPortfolioId(portfolioId)
+		return portfolioRepository.findByPortfolioIdWithAll(portfolioId)
 			.orElseThrow(() -> new NotFoundResourceException(PortfolioErrorCode.NOT_FOUND_PORTFOLIO));
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio/PortFolioService.java
@@ -167,11 +167,6 @@ public class PortFolioService {
 			.orElseThrow(() -> new NotFoundResourceException(PortfolioErrorCode.NOT_FOUND_PORTFOLIO));
 	}
 
-	public Portfolio findPortfolioUsingJoin(Long portfolioId) {
-		return portfolioRepository.findByPortfolioIdWithAll(portfolioId)
-			.orElseThrow(() -> new NotFoundResourceException(PortfolioErrorCode.NOT_FOUND_PORTFOLIO));
-	}
-
 	public PortfoliosResponse readMyAllPortfolio(AuthMember authMember) {
 		List<Portfolio> portfolios = portfolioRepository.findAllByMemberIdOrderByIdDesc(
 			authMember.getMemberId());

--- a/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryService.java
+++ b/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryService.java
@@ -13,6 +13,8 @@ import codesquad.fineants.spring.api.errors.errorcode.PortfolioHoldingErrorCode;
 import codesquad.fineants.spring.api.errors.errorcode.PurchaseHistoryErrorCode;
 import codesquad.fineants.spring.api.errors.exception.FineAntsException;
 import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
+import codesquad.fineants.spring.api.notification.service.NotificationService;
+import codesquad.fineants.spring.api.purchase_history.event.NotificationEventPublisher;
 import codesquad.fineants.spring.api.purchase_history.event.PublishEvent;
 import codesquad.fineants.spring.api.purchase_history.event.PushNotificationEvent;
 import codesquad.fineants.spring.api.purchase_history.request.PurchaseHistoryCreateRequest;
@@ -30,6 +32,8 @@ import lombok.extern.slf4j.Slf4j;
 public class PurchaseHistoryService {
 	private final PurchaseHistoryRepository repository;
 	private final PortfolioHoldingRepository portfolioHoldingRepository;
+	private final NotificationEventPublisher publisher;
+	private final NotificationService notificationService;
 
 	@Transactional
 	@PublishEvent(eventType = PushNotificationEvent.class, params = "#{T(codesquad.fineants.spring.api.purchase_history.event.SendableParameter).create(portfolioId, memberId)}")
@@ -54,6 +58,10 @@ public class PurchaseHistoryService {
 		PurchaseHistory newPurchaseHistory = repository.save(request.toEntity(portfolioHolding));
 		log.info("매입이력 저장 결과 : newPurchaseHistory={}", newPurchaseHistory);
 
+		// publisher.publishEvent(portfolioId, memberId);
+		// NotifyPortfolioMessagesResponse response = notificationService.notifyPortfolioTargetGainMessages(portfolioId,
+		// 	memberId);
+		// log.info("알림 저장 결과 : {}", response);
 		return PurchaseHistoryCreateResponse.from(newPurchaseHistory, portfolioId, memberId);
 	}
 

--- a/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryService.java
+++ b/src/main/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryService.java
@@ -12,9 +12,6 @@ import codesquad.fineants.spring.api.errors.errorcode.PortfolioErrorCode;
 import codesquad.fineants.spring.api.errors.errorcode.PortfolioHoldingErrorCode;
 import codesquad.fineants.spring.api.errors.errorcode.PurchaseHistoryErrorCode;
 import codesquad.fineants.spring.api.errors.exception.FineAntsException;
-import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
-import codesquad.fineants.spring.api.notification.service.NotificationService;
-import codesquad.fineants.spring.api.purchase_history.event.NotificationEventPublisher;
 import codesquad.fineants.spring.api.purchase_history.event.PublishEvent;
 import codesquad.fineants.spring.api.purchase_history.event.PushNotificationEvent;
 import codesquad.fineants.spring.api.purchase_history.request.PurchaseHistoryCreateRequest;
@@ -32,8 +29,6 @@ import lombok.extern.slf4j.Slf4j;
 public class PurchaseHistoryService {
 	private final PurchaseHistoryRepository repository;
 	private final PortfolioHoldingRepository portfolioHoldingRepository;
-	private final NotificationEventPublisher publisher;
-	private final NotificationService notificationService;
 
 	@Transactional
 	@PublishEvent(eventType = PushNotificationEvent.class, params = "#{T(codesquad.fineants.spring.api.purchase_history.event.SendableParameter).create(portfolioId, memberId)}")
@@ -44,25 +39,20 @@ public class PurchaseHistoryService {
 		Long memberId) {
 		log.info("매입이력 추가 서비스 요청 : request={}, portfolioHoldingId={}", request, portfolioHoldingId);
 
-		PortfolioHolding portfolioHolding = findPortfolioHolding(portfolioHoldingId);
+		PortfolioHolding portfolioHolding = findPortfolioHolding(portfolioHoldingId, portfolioId);
+		PurchaseHistory history = request.toEntity(portfolioHolding);
 		Portfolio portfolio = portfolioHolding.getPortfolio();
-		if (!portfolio.getId().equals(portfolioId)) {
-			throw new NotFoundResourceException(PortfolioHoldingErrorCode.NOT_FOUND_PORTFOLIO_HOLDING);
-		}
+		verifyCashSufficientForPurchase(portfolio, history.calculateInvestmentAmount());
 
-		Double purchasedPrice = request.getNumShares() * request.getPurchasePricePerShare();
-		if (portfolio.calculateTotalInvestmentAmount() + purchasedPrice > portfolio.getBudget()) {
+		PurchaseHistory newPurchaseHistory = repository.save(history);
+		log.info("매입이력 저장 결과 : newPurchaseHistory={}", newPurchaseHistory);
+		return PurchaseHistoryCreateResponse.from(newPurchaseHistory, portfolioId, memberId);
+	}
+
+	private void verifyCashSufficientForPurchase(Portfolio portfolio, long investmentAmount) {
+		if (portfolio.isCashSufficientForPurchase(investmentAmount)) {
 			throw new FineAntsException(PortfolioErrorCode.TOTAL_INVESTMENT_PRICE_EXCEEDS_BUDGET);
 		}
-
-		PurchaseHistory newPurchaseHistory = repository.save(request.toEntity(portfolioHolding));
-		log.info("매입이력 저장 결과 : newPurchaseHistory={}", newPurchaseHistory);
-
-		// publisher.publishEvent(portfolioId, memberId);
-		// NotifyPortfolioMessagesResponse response = notificationService.notifyPortfolioTargetGainMessages(portfolioId,
-		// 	memberId);
-		// log.info("알림 저장 결과 : {}", response);
-		return PurchaseHistoryCreateResponse.from(newPurchaseHistory, portfolioId, memberId);
 	}
 
 	@Transactional
@@ -71,7 +61,7 @@ public class PurchaseHistoryService {
 		Long portfolioHoldingId, Long purchaseHistoryId, Long portfolioId, Long memberId) {
 		log.info("매입 내역 수정 서비스 요청 : request={}, portfolioHoldingId={}, purchaseHistoryId={}", request,
 			portfolioHoldingId, purchaseHistoryId);
-		PortfolioHolding portfolioHolding = findPortfolioHolding(portfolioHoldingId);
+		PortfolioHolding portfolioHolding = findPortfolioHolding(portfolioHoldingId, portfolioId);
 		PurchaseHistory originalPurchaseHistory = findPurchaseHistory(purchaseHistoryId);
 		PurchaseHistory changePurchaseHistory = request.toEntity(portfolioHolding);
 
@@ -96,13 +86,14 @@ public class PurchaseHistoryService {
 		return PurchaseHistoryDeleteResponse.from(deletePurchaseHistory, portfolioId, memberId);
 	}
 
-	private PortfolioHolding findPortfolioHolding(Long portfolioHoldingId) {
-		return portfolioHoldingRepository.findById(portfolioHoldingId)
-			.orElseThrow(() -> new NotFoundResourceException(PortfolioHoldingErrorCode.NOT_FOUND_PORTFOLIO_HOLDING));
+	private PortfolioHolding findPortfolioHolding(Long portfolioHoldingId, Long portfolioId) {
+		return portfolioHoldingRepository.findByPortfolioHoldingIdAndPortfolioIdWithPortfolio(portfolioHoldingId,
+				portfolioId)
+			.orElseThrow(() -> new FineAntsException(PortfolioHoldingErrorCode.NOT_FOUND_PORTFOLIO_HOLDING));
 	}
 
 	private PurchaseHistory findPurchaseHistory(Long purchaseHistoryId) {
 		return repository.findById(purchaseHistoryId)
-			.orElseThrow(() -> new NotFoundResourceException(PurchaseHistoryErrorCode.NOT_FOUND_PURCHASE_HISTORY));
+			.orElseThrow(() -> new FineAntsException(PurchaseHistoryErrorCode.NOT_FOUND_PURCHASE_HISTORY));
 	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/purchase_history/event/NotificationEventListener.java
+++ b/src/main/java/codesquad/fineants/spring/api/purchase_history/event/NotificationEventListener.java
@@ -1,9 +1,8 @@
 package codesquad.fineants.spring.api.purchase_history.event;
 
+import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.event.TransactionPhase;
-import org.springframework.transaction.event.TransactionalEventListener;
 
 import codesquad.fineants.spring.api.notification.response.NotifyPortfolioMessagesResponse;
 import codesquad.fineants.spring.api.notification.service.NotificationService;
@@ -19,7 +18,7 @@ public class NotificationEventListener {
 
 	// 매입 이력 이벤트가 발생하면 포트폴리오 목표수익률에 달성하면 푸시 알림
 	@Async
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = PushNotificationEvent.class)
+	@EventListener
 	public void notifyPortfolioTargetGainMessages(PushNotificationEvent event) {
 		SendableParameter parameter = event.getValue();
 		NotifyPortfolioMessagesResponse response = notificationService.notifyPortfolioTargetGainMessages(
@@ -29,7 +28,7 @@ public class NotificationEventListener {
 
 	// 매입 이력 이벤트가 발생하면 포트폴리오 최대손실율에 도달하면 푸시 알림
 	@Async
-	@TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, classes = PushNotificationEvent.class)
+	@EventListener
 	public void notifyPortfolioMaxLossMessages(PushNotificationEvent event) {
 		SendableParameter parameter = event.getValue();
 		NotifyPortfolioMessagesResponse response = notificationService.notifyPortfolioMaxLossMessages(

--- a/src/main/java/codesquad/fineants/spring/api/purchase_history/event/NotificationEventPublisher.java
+++ b/src/main/java/codesquad/fineants/spring/api/purchase_history/event/NotificationEventPublisher.java
@@ -1,0 +1,17 @@
+package codesquad.fineants.spring.api.purchase_history.event;
+
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationEventPublisher {
+	private final ApplicationEventPublisher publisher;
+
+	public void publishEvent(Long portfolioId, Long memberId) {
+		SendableParameter value = SendableParameter.create(portfolioId, memberId);
+		publisher.publishEvent(new PushNotificationEvent(value));
+	}
+}

--- a/src/main/java/codesquad/fineants/spring/api/purchase_history/request/PurchaseHistoryCreateRequest.java
+++ b/src/main/java/codesquad/fineants/spring/api/purchase_history/request/PurchaseHistoryCreateRequest.java
@@ -8,13 +8,17 @@ import javax.validation.constraints.Positive;
 import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
 import codesquad.fineants.domain.purchase_history.PurchaseHistory;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@ToString
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@ToString
 public class PurchaseHistoryCreateRequest {
 	@NotNull(message = "매입날짜는 날짜 형식의 필수 정보입니다")
 	private LocalDateTime purchaseDate;

--- a/src/main/java/codesquad/fineants/spring/api/purchase_history/request/PurchaseHistoryModifyRequest.java
+++ b/src/main/java/codesquad/fineants/spring/api/purchase_history/request/PurchaseHistoryModifyRequest.java
@@ -8,13 +8,17 @@ import javax.validation.constraints.Positive;
 import codesquad.fineants.domain.portfolio_holding.PortfolioHolding;
 import codesquad.fineants.domain.purchase_history.PurchaseHistory;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
-@ToString
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@ToString
 public class PurchaseHistoryModifyRequest {
 	@NotNull(message = "매입날짜는 날짜 형식의 필수 정보입니다")
 	private LocalDateTime purchaseDate;

--- a/src/test/java/codesquad/fineants/spring/api/fcm/service/FcmServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/fcm/service/FcmServiceTest.java
@@ -29,7 +29,6 @@ import codesquad.fineants.domain.member.MemberRepository;
 import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.spring.AbstractContainerBaseTest;
 import codesquad.fineants.spring.api.errors.errorcode.FcmErrorCode;
-import codesquad.fineants.spring.api.errors.exception.BadRequestException;
 import codesquad.fineants.spring.api.errors.exception.FineAntsException;
 import codesquad.fineants.spring.api.fcm.request.FcmRegisterRequest;
 import codesquad.fineants.spring.api.fcm.response.FcmDeleteResponse;
@@ -120,7 +119,7 @@ class FcmServiceTest extends AbstractContainerBaseTest {
 
 		// then
 		assertThat(throwable)
-			.isInstanceOf(BadRequestException.class)
+			.isInstanceOf(FineAntsException.class)
 			.hasMessage(FcmErrorCode.BAD_REQUEST_FCM_TOKEN.getMessage());
 	}
 

--- a/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryServiceTest.java
@@ -116,6 +116,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	void addPurchaseHistory() throws JsonProcessingException {
 		// given
 		Member member = memberRepository.save(createMember());
+		notificationPreferenceRepository.save(createNotificationPreference(member));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createStock());
 		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
@@ -153,13 +154,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	void addPurchaseHistory_whenAchieveTargetGain_thenSaveNotification() throws FirebaseMessagingException {
 		// given
 		Member member = memberRepository.save(createMember());
-		notificationPreferenceRepository.save(NotificationPreference.builder()
-			.browserNotify(true)
-			.targetGainNotify(true)
-			.maxLossNotify(true)
-			.targetPriceNotify(true)
-			.member(member)
-			.build());
+		notificationPreferenceRepository.save(createNotificationPreference(member));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createStock());
 		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
@@ -201,6 +196,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	void addPurchaseHistoryFailsWhenTotalInvestmentExceedsBudget() {
 		// given
 		Member member = memberRepository.save(createMember());
+		notificationPreferenceRepository.save(createNotificationPreference(member));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createStock());
 		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
@@ -227,6 +223,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	void modifyPurchaseHistory() {
 		// given
 		Member member = memberRepository.save(createMember());
+		notificationPreferenceRepository.save(createNotificationPreference(member));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createStock());
 		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
@@ -262,6 +259,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	void deletePurchaseHistory() {
 		// given
 		Member member = memberRepository.save(createMember());
+		notificationPreferenceRepository.save(createNotificationPreference(member));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createStock());
 		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
@@ -287,6 +285,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	void deletePurchaseHistoryWithNotExistPurchaseHistoryId() {
 		// given
 		Member member = memberRepository.save(createMember());
+		notificationPreferenceRepository.save(createNotificationPreference(member));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createStock());
 		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
@@ -433,5 +432,15 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 				LocalDate.of(2024, 11, 20),
 				stock)
 		);
+	}
+
+	private NotificationPreference createNotificationPreference(Member member) {
+		return NotificationPreference.builder()
+			.browserNotify(true)
+			.targetGainNotify(true)
+			.maxLossNotify(true)
+			.targetPriceNotify(true)
+			.member(member)
+			.build();
 	}
 }

--- a/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryServiceTest.java
@@ -163,6 +163,11 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.latestActivationTime(LocalDateTime.now())
 			.member(member)
 			.build());
+		fcmRepository.save(FcmToken.builder()
+			.token("token2")
+			.latestActivationTime(LocalDateTime.now())
+			.member(member)
+			.build());
 
 		PurchaseHistoryCreateRequest request = PurchaseHistoryCreateRequest.builder()
 			.purchaseDate(LocalDateTime.now())

--- a/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/purchase_history/PurchaseHistoryServiceTest.java
@@ -2,23 +2,34 @@ package codesquad.fineants.spring.api.purchase_history;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
 
+import codesquad.fineants.domain.fcm_token.FcmRepository;
+import codesquad.fineants.domain.fcm_token.FcmToken;
 import codesquad.fineants.domain.member.Member;
 import codesquad.fineants.domain.member.MemberRepository;
+import codesquad.fineants.domain.notification.NotificationRepository;
+import codesquad.fineants.domain.notification_preference.NotificationPreference;
+import codesquad.fineants.domain.notification_preference.NotificationPreferenceRepository;
 import codesquad.fineants.domain.portfolio.Portfolio;
 import codesquad.fineants.domain.portfolio.PortfolioRepository;
 import codesquad.fineants.domain.portfolio_gain_history.PortfolioGainHistoryRepository;
@@ -29,10 +40,13 @@ import codesquad.fineants.domain.purchase_history.PurchaseHistoryRepository;
 import codesquad.fineants.domain.stock.Market;
 import codesquad.fineants.domain.stock.Stock;
 import codesquad.fineants.domain.stock.StockRepository;
+import codesquad.fineants.domain.stock_dividend.StockDividend;
 import codesquad.fineants.domain.stock_dividend.StockDividendRepository;
 import codesquad.fineants.spring.AbstractContainerBaseTest;
+import codesquad.fineants.spring.api.errors.errorcode.PortfolioErrorCode;
+import codesquad.fineants.spring.api.errors.errorcode.PurchaseHistoryErrorCode;
 import codesquad.fineants.spring.api.errors.exception.FineAntsException;
-import codesquad.fineants.spring.api.errors.exception.NotFoundResourceException;
+import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
 import codesquad.fineants.spring.api.purchase_history.request.PurchaseHistoryCreateRequest;
 import codesquad.fineants.spring.api.purchase_history.request.PurchaseHistoryModifyRequest;
 import codesquad.fineants.spring.api.purchase_history.response.PurchaseHistoryCreateResponse;
@@ -68,58 +82,26 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	@Autowired
 	private PurchaseHistoryService service;
 
-	private Member member;
+	@Autowired
+	private NotificationRepository notificationRepository;
 
-	private Portfolio portfolio;
+	@Autowired
+	private NotificationPreferenceRepository notificationPreferenceRepository;
 
-	private Stock stock;
+	@Autowired
+	private FcmRepository fcmRepository;
 
-	private PortfolioHolding portfolioHolding;
+	@MockBean
+	private CurrentPriceManager currentPriceManager;
 
-	private PurchaseHistory purchaseHistory;
-
-	@BeforeEach
-	void init() {
-		Member member = Member.builder()
-			.nickname("일개미1234")
-			.email("kim1234@gmail.com")
-			.password("kim1234@")
-			.provider("local")
-			.build();
-		this.member = memberRepository.save(member);
-
-		Portfolio portfolio = Portfolio.builder()
-			.name("내꿈은 워렌버핏")
-			.securitiesFirm("토스")
-			.budget(1000000L)
-			.targetGain(1500000L)
-			.maximumLoss(900000L)
-			.member(member)
-			.build();
-		this.portfolio = portfolioRepository.save(portfolio);
-
-		Stock stock = Stock.builder()
-			.companyName("삼성전자보통주")
-			.tickerSymbol("005930")
-			.companyNameEng("SamsungElectronics")
-			.stockCode("KR7005930003")
-			.market(Market.KOSPI)
-			.build();
-		this.stock = stockRepository.save(stock);
-
-		PortfolioHolding portfolioHolding = PortfolioHolding.empty(portfolio, stock);
-		this.portfolioHolding = portFolioHoldingRepository.save(portfolioHolding);
-
-		this.purchaseHistory = purchaseHistoryRepository.save(PurchaseHistory.builder()
-			.purchaseDate(LocalDateTime.now())
-			.numShares(3L)
-			.purchasePricePerShare(50000.0)
-			.memo("첫구매")
-			.build());
-	}
+	@MockBean
+	private FirebaseMessaging firebaseMessaging;
 
 	@AfterEach
 	void tearDown() {
+		fcmRepository.deleteAllInBatch();
+		notificationPreferenceRepository.deleteAllInBatch();
+		notificationRepository.deleteAllInBatch();
 		purchaseHistoryRepository.deleteAllInBatch();
 		portFolioHoldingRepository.deleteAllInBatch();
 		portfolioGainHistoryRepository.deleteAllInBatch();
@@ -133,20 +115,25 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	@Test
 	void addPurchaseHistory() throws JsonProcessingException {
 		// given
-		Map<String, Object> requestBody = new HashMap<>();
-		requestBody.put("purchaseDate", LocalDateTime.now());
-		requestBody.put("numShares", 3L);
-		requestBody.put("purchasePricePerShare", 50000);
-		requestBody.put("memo", "첫구매");
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
 
-		PurchaseHistoryCreateRequest request = objectMapper.readValue(
-			objectMapper.writeValueAsString(requestBody), PurchaseHistoryCreateRequest.class);
-		Long portfolioId = portfolio.getId();
-		Long portfolioHoldingId = portfolioHolding.getId();
+		PurchaseHistoryCreateRequest request = PurchaseHistoryCreateRequest.builder()
+			.purchaseDate(LocalDateTime.now())
+			.numShares(3L)
+			.purchasePricePerShare(50000.0)
+			.memo("첫구매")
+			.build();
 
 		// when
-		PurchaseHistoryCreateResponse response = service.addPurchaseHistory(request, portfolioId, portfolioHoldingId,
-			member.getId());
+		PurchaseHistoryCreateResponse response = service.addPurchaseHistory(
+			request,
+			portfolio.getId(),
+			holding.getId(),
+			member.getId()
+		);
 
 		TypeReference<Map<String, Object>> typeReference = new TypeReference<>() {
 		};
@@ -161,50 +148,108 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		);
 	}
 
+	@DisplayName("사용자는 매입 이력 추가시 목표 수익률을 달성하여 알림을 받는다")
+	@Test
+	void addPurchaseHistory_whenAchieveTargetGain_thenSaveNotification() throws FirebaseMessagingException {
+		// given
+		Member member = memberRepository.save(createMember());
+		notificationPreferenceRepository.save(NotificationPreference.builder()
+			.browserNotify(true)
+			.targetGainNotify(true)
+			.maxLossNotify(true)
+			.targetPriceNotify(true)
+			.member(member)
+			.build());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		fcmRepository.save(FcmToken.builder()
+			.token("token")
+			.latestActivationTime(LocalDateTime.now())
+			.member(member)
+			.build());
+
+		PurchaseHistoryCreateRequest request = PurchaseHistoryCreateRequest.builder()
+			.purchaseDate(LocalDateTime.now())
+			.numShares(100L)
+			.purchasePricePerShare(100.0)
+			.memo("첫구매")
+			.build();
+
+		given(currentPriceManager.getCurrentPrice(anyString()))
+			.willReturn(50000L);
+		given(firebaseMessaging.send(any(Message.class)))
+			.willReturn("send messageId");
+
+		// when
+		PurchaseHistoryCreateResponse response = service.addPurchaseHistory(
+			request,
+			portfolio.getId(),
+			holding.getId(),
+			member.getId()
+		);
+
+		// then
+		assertAll(
+			() -> assertThat(response.getId()).isNotNull(),
+			() -> assertThat(notificationRepository.findAllByMemberId(member.getId())).hasSize(1)
+		);
+	}
+
 	@DisplayName("사용자가 매입 이력을 추가할 때 예산이 부족해 실패한다.")
 	@Test
-	void addPurchaseHistoryFailsWhenTotalInvestmentExceedsBudget() throws JsonProcessingException {
+	void addPurchaseHistoryFailsWhenTotalInvestmentExceedsBudget() {
 		// given
-		Map<String, Object> requestBody = new HashMap<>();
-		requestBody.put("purchaseDate", LocalDateTime.now());
-		requestBody.put("numShares", 3L);
-		requestBody.put("purchasePricePerShare", 500000);
-		requestBody.put("memo", "첫구매");
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
 
-		PurchaseHistoryCreateRequest request = objectMapper.readValue(
-			objectMapper.writeValueAsString(requestBody), PurchaseHistoryCreateRequest.class);
-		Long portfolioId = portfolio.getId();
-		Long portfolioHoldingId = portfolioHolding.getId();
+		PurchaseHistoryCreateRequest request = PurchaseHistoryCreateRequest.builder()
+			.purchaseDate(LocalDateTime.now())
+			.numShares(3L)
+			.purchasePricePerShare(500000.0)
+			.memo("첫구매")
+			.build();
 
-		// 예산을 초과하는 조건 설정
+		// when
+		Throwable throwable = catchThrowable(() ->
+			service.addPurchaseHistory(request, portfolio.getId(), holding.getId(), member.getId()));
 
-		// when & then
-		assertThrows(FineAntsException.class, () -> {
-			service.addPurchaseHistory(request, portfolioId, portfolioHoldingId, member.getId());
-		});
+		// then
+		assertThat(throwable)
+			.isInstanceOf(FineAntsException.class)
+			.hasMessage(PortfolioErrorCode.TOTAL_INVESTMENT_PRICE_EXCEEDS_BUDGET.getMessage());
 	}
 
 	@DisplayName("사용자는 매입 이력을 수정한다")
 	@Test
-	void modifyPurchaseHistory() throws JsonProcessingException {
+	void modifyPurchaseHistory() {
 		// given
-		Map<String, Object> requestBody = new HashMap<>();
-		requestBody.put("purchaseDate", LocalDateTime.now());
-		requestBody.put("numShares", 4L);
-		requestBody.put("purchasePricePerShare", 50000);
-		requestBody.put("memo", "첫구매");
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PurchaseHistory history = purchaseHistoryRepository.save(createPurchaseHistory(holding));
 
-		PurchaseHistoryModifyRequest request = objectMapper.readValue(
-			objectMapper.writeValueAsString(requestBody), PurchaseHistoryModifyRequest.class);
-		Long portfolioHoldingId = portfolioHolding.getId();
-		Long purchaseHistoryId = purchaseHistory.getId();
+		PurchaseHistoryModifyRequest request = PurchaseHistoryModifyRequest.builder()
+			.purchaseDate(LocalDateTime.now())
+			.numShares(4L)
+			.purchasePricePerShare(50000.0)
+			.memo("첫구매")
+			.build();
 
 		// when
-		PurchaseHistoryModifyResponse response = service.modifyPurchaseHistory(request,
-			portfolioHoldingId, purchaseHistoryId, portfolio.getId(), member.getId());
+		PurchaseHistoryModifyResponse response = service.modifyPurchaseHistory(
+			request,
+			holding.getId(),
+			history.getId(),
+			portfolio.getId(),
+			member.getId()
+		);
 
 		// then
-		PurchaseHistory changePurchaseHistory = purchaseHistoryRepository.findById(purchaseHistoryId).orElseThrow();
+		PurchaseHistory changePurchaseHistory = purchaseHistoryRepository.findById(history.getId()).orElseThrow();
 		assertAll(
 			() -> assertThat(response).extracting("id").isNotNull(),
 			() -> assertThat(response).extracting("numShares").isEqualTo(4L),
@@ -216,18 +261,24 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	@Test
 	void deletePurchaseHistory() {
 		// given
-		Long portfolioHoldingId = portfolioHolding.getId();
-		Long purchaseHistoryId = purchaseHistory.getId();
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PurchaseHistory history = purchaseHistoryRepository.save(createPurchaseHistory(holding));
 
 		// when
-		PurchaseHistoryDeleteResponse response = service.deletePurchaseHistory(portfolioHoldingId, purchaseHistoryId,
+		PurchaseHistoryDeleteResponse response = service.deletePurchaseHistory(
+			holding.getId(),
+			history.getId(),
 			portfolio.getId(),
-			member.getId());
+			member.getId()
+		);
 
 		// then
 		assertAll(
 			() -> assertThat(response).extracting("id").isNotNull(),
-			() -> assertThat(purchaseHistoryRepository.findById(purchaseHistoryId).isEmpty()).isTrue()
+			() -> assertThat(purchaseHistoryRepository.findById(history.getId())).isEmpty()
 		);
 	}
 
@@ -235,18 +286,152 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	@Test
 	void deletePurchaseHistoryWithNotExistPurchaseHistoryId() {
 		// given
-		Long portfolioHoldingId = portfolioHolding.getId();
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createStock());
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PurchaseHistory history = purchaseHistoryRepository.save(createPurchaseHistory(holding));
+
 		Long purchaseHistoryId = 9999L;
 
 		// when
 		Throwable throwable = catchThrowable(
-			() -> service.deletePurchaseHistory(portfolioHoldingId, purchaseHistoryId, portfolio.getId(),
-				member.getId()));
+			() -> service.deletePurchaseHistory(
+				holding.getId(),
+				purchaseHistoryId,
+				portfolio.getId(),
+				member.getId())
+		);
 
 		// then
 		assertThat(throwable)
-			.isInstanceOf(NotFoundResourceException.class)
-			.extracting("message")
-			.isEqualTo("매입 이력을 찾을 수 없습니다.");
+			.isInstanceOf(FineAntsException.class)
+			.hasMessage(PurchaseHistoryErrorCode.NOT_FOUND_PURCHASE_HISTORY.getMessage());
+	}
+
+	private Member createMember() {
+		return Member.builder()
+			.nickname("일개미1234")
+			.email("kim1234@gmail.com")
+			.password("kim1234@")
+			.provider("local")
+			.build();
+	}
+
+	private Portfolio createPortfolio(Member member) {
+		return Portfolio.builder()
+			.name("내꿈은 워렌버핏")
+			.securitiesFirm("토스")
+			.budget(1000000L)
+			.targetGain(1500000L)
+			.maximumLoss(900000L)
+			.member(member)
+			.targetGainIsActive(false)
+			.maximumIsActive(false)
+			.build();
+	}
+
+	private Portfolio createPortfolioWithZero(Member member) {
+		return Portfolio.builder()
+			.name("내꿈은 워렌버핏")
+			.securitiesFirm("토스")
+			.budget(0L)
+			.targetGain(0L)
+			.maximumLoss(0L)
+			.member(member)
+			.targetGainIsActive(false)
+			.maximumIsActive(false)
+			.build();
+	}
+
+	private Stock createStock() {
+		return Stock.builder()
+			.companyName("삼성전자보통주")
+			.tickerSymbol("005930")
+			.companyNameEng("SamsungElectronics")
+			.stockCode("KR7005930003")
+			.sector("전기전자")
+			.market(Market.KOSPI)
+			.build();
+	}
+
+	private Stock createStock(String companyName, String tickerSymbol, String companyNameEng, String stockCode,
+		String sector, Market market) {
+		return Stock.builder()
+			.companyName(companyName)
+			.tickerSymbol(tickerSymbol)
+			.companyNameEng(companyNameEng)
+			.stockCode(stockCode)
+			.sector(sector)
+			.market(market)
+			.build();
+	}
+
+	private StockDividend createStockDividend(LocalDate exDividendDate, LocalDate recordDate, LocalDate paymentDate,
+		Stock stock) {
+		return StockDividend.builder()
+			.dividend(361L)
+			.exDividendDate(exDividendDate)
+			.recordDate(recordDate)
+			.paymentDate(paymentDate)
+			.stock(stock)
+			.build();
+	}
+
+	private PortfolioHolding createPortfolioHolding(Portfolio portfolio, Stock stock) {
+		return PortfolioHolding.builder()
+			.portfolio(portfolio)
+			.stock(stock)
+			.build();
+	}
+
+	private PurchaseHistory createPurchaseHistory(PortfolioHolding portfolioHolding) {
+		return PurchaseHistory.builder()
+			.purchaseDate(LocalDateTime.of(2023, 9, 26, 9, 30, 0))
+			.numShares(3L)
+			.purchasePricePerShare(50000.0)
+			.memo("첫구매")
+			.portfolioHolding(portfolioHolding)
+			.build();
+	}
+
+	private List<StockDividend> createStockDividendWith(Stock stock) {
+		return List.of(
+			createStockDividend(
+				LocalDate.of(2022, 12, 30),
+				LocalDate.of(2022, 12, 31),
+				LocalDate.of(2023, 4, 14),
+				stock),
+			createStockDividend(
+				LocalDate.of(2023, 3, 30),
+				LocalDate.of(2023, 3, 31),
+				LocalDate.of(2023, 5, 17),
+				stock),
+			createStockDividend(
+				LocalDate.of(2023, 6, 29),
+				LocalDate.of(2023, 6, 30),
+				LocalDate.of(2023, 8, 16),
+				stock),
+			createStockDividend(
+				LocalDate.of(2023, 9, 27),
+				LocalDate.of(2023, 9, 30),
+				LocalDate.of(2023, 11, 20),
+				stock),
+			createStockDividend(
+				LocalDate.of(2024, 3, 29),
+				LocalDate.of(2024, 3, 31),
+				LocalDate.of(2024, 5, 17),
+				stock),
+			createStockDividend(
+				LocalDate.of(2024, 6, 28),
+				LocalDate.of(2024, 6, 30),
+				LocalDate.of(2024, 8, 16),
+				stock),
+			createStockDividend(
+				LocalDate.of(2024, 9, 27),
+				LocalDate.of(2024, 9, 30),
+				LocalDate.of(2024, 11, 20),
+				stock)
+		);
 	}
 }

--- a/src/test/java/codesquad/fineants/spring/docs/notification/NotificationRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/spring/docs/notification/NotificationRestControllerDocsTest.java
@@ -25,7 +25,7 @@ import codesquad.fineants.domain.notification.type.NotificationType;
 import codesquad.fineants.spring.api.notification.controller.NotificationRestController;
 import codesquad.fineants.spring.api.notification.request.NotificationCreateRequest;
 import codesquad.fineants.spring.api.notification.response.NotificationCreateResponse;
-import codesquad.fineants.spring.api.notification.response.NotifyPortfolioMessageItem;
+import codesquad.fineants.spring.api.notification.response.NotifyMessageItem;
 import codesquad.fineants.spring.api.notification.response.NotifyPortfolioMessagesResponse;
 import codesquad.fineants.spring.api.notification.service.NotificationService;
 import codesquad.fineants.spring.docs.RestDocsSupport;
@@ -133,7 +133,6 @@ class NotificationRestControllerDocsTest extends RestDocsSupport {
 		// given
 		Long notificationId = 1L;
 		String title = "포트폴리오";
-		boolean isRead = false;
 		NotificationType type = NotificationType.PORTFOLIO_TARGET_GAIN;
 		String referenceId = "1";
 		String messageId = "projects/fineants-404407/messages/4754d355-5d5d-4f14-a642-75fecdb91fa5";
@@ -142,10 +141,8 @@ class NotificationRestControllerDocsTest extends RestDocsSupport {
 			anyLong()))
 			.willReturn(NotifyPortfolioMessagesResponse.builder()
 				.notifications(List.of(
-					NotifyPortfolioMessageItem.builder()
-						.notificationId(notificationId)
+					NotifyMessageItem.builder()
 						.title(title)
-						.isRead(isRead)
 						.type(type)
 						.referenceId(referenceId)
 						.messageId(messageId)
@@ -160,9 +157,7 @@ class NotificationRestControllerDocsTest extends RestDocsSupport {
 			.andExpect(jsonPath("code").value(equalTo(200)))
 			.andExpect(jsonPath("status").value(equalTo("OK")))
 			.andExpect(jsonPath("message").value(equalTo("포트폴리오 목표 수익률 알림 메시지가 전송되었습니다")))
-			.andExpect(jsonPath("data.notifications[0].notificationId").value(equalTo(notificationId.intValue())))
 			.andExpect(jsonPath("data.notifications[0].title").value(equalTo(title)))
-			.andExpect(jsonPath("data.notifications[0].isRead").value(equalTo(false)))
 			.andExpect(jsonPath("data.notifications[0].type").value(equalTo(type.name())))
 			.andExpect(jsonPath("data.notifications[0].referenceId").value(equalTo(referenceId)))
 			.andExpect(jsonPath("data.notifications[0].messageId").value(equalTo(messageId)))
@@ -183,12 +178,8 @@ class NotificationRestControllerDocsTest extends RestDocsSupport {
 							.description("메시지"),
 						fieldWithPath("data").type(JsonFieldType.OBJECT)
 							.description("응답 데이터"),
-						fieldWithPath("data.notifications[].notificationId").type(JsonFieldType.NUMBER)
-							.description("알림 등록번호"),
 						fieldWithPath("data.notifications[].title").type(JsonFieldType.STRING)
 							.description("알림 제목"),
-						fieldWithPath("data.notifications[].isRead").type(JsonFieldType.BOOLEAN)
-							.description("읽음 여부"),
 						fieldWithPath("data.notifications[].type").type(JsonFieldType.STRING)
 							.description("알림 타입"),
 						fieldWithPath("data.notifications[].referenceId").type(JsonFieldType.STRING)
@@ -206,7 +197,6 @@ class NotificationRestControllerDocsTest extends RestDocsSupport {
 		// given
 		Long notificationId = 1L;
 		String title = "포트폴리오";
-		boolean isRead = false;
 		NotificationType type = NotificationType.PORTFOLIO_MAX_LOSS;
 		String referenceId = "1";
 		String messageId = "projects/fineants-404407/messages/4754d355-5d5d-4f14-a642-75fecdb91fa5";
@@ -215,10 +205,8 @@ class NotificationRestControllerDocsTest extends RestDocsSupport {
 			anyLong()))
 			.willReturn(NotifyPortfolioMessagesResponse.builder()
 				.notifications(List.of(
-					NotifyPortfolioMessageItem.builder()
-						.notificationId(notificationId)
+					NotifyMessageItem.builder()
 						.title(title)
-						.isRead(isRead)
 						.type(type)
 						.referenceId(referenceId)
 						.messageId(messageId)
@@ -233,9 +221,7 @@ class NotificationRestControllerDocsTest extends RestDocsSupport {
 			.andExpect(jsonPath("code").value(equalTo(200)))
 			.andExpect(jsonPath("status").value(equalTo("OK")))
 			.andExpect(jsonPath("message").value(equalTo("포트폴리오 최대 손실율 알림 메시지가 전송되었습니다")))
-			.andExpect(jsonPath("data.notifications[0].notificationId").value(equalTo(notificationId.intValue())))
 			.andExpect(jsonPath("data.notifications[0].title").value(equalTo(title)))
-			.andExpect(jsonPath("data.notifications[0].isRead").value(equalTo(false)))
 			.andExpect(jsonPath("data.notifications[0].type").value(equalTo(type.name())))
 			.andExpect(jsonPath("data.notifications[0].referenceId").value(equalTo(referenceId)))
 			.andExpect(jsonPath("data.notifications[0].messageId").value(equalTo(messageId)))
@@ -256,12 +242,8 @@ class NotificationRestControllerDocsTest extends RestDocsSupport {
 							.description("메시지"),
 						fieldWithPath("data").type(JsonFieldType.OBJECT)
 							.description("응답 데이터"),
-						fieldWithPath("data.notifications[].notificationId").type(JsonFieldType.NUMBER)
-							.description("알림 등록번호"),
 						fieldWithPath("data.notifications[].title").type(JsonFieldType.STRING)
 							.description("알림 제목"),
-						fieldWithPath("data.notifications[].isRead").type(JsonFieldType.BOOLEAN)
-							.description("읽음 여부"),
 						fieldWithPath("data.notifications[].type").type(JsonFieldType.STRING)
 							.description("알림 타입"),
 						fieldWithPath("data.notifications[].referenceId").type(JsonFieldType.STRING)


### PR DESCRIPTION
## 구현한 것

- 매입 이력 이벤트 발생시 Notification 저장 문제를 해결하였습니다.
- 한 회원의 여러 디바이스에 알림을 발송하고 실제 알림 데이터는 1개만 저장되도록 변경하였습니다.
