### PR TITLE
[fix] 종목 지정가 알림 버그 수정

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/notification/response/NotifyMessageItem.java
+++ b/src/main/java/codesquad/fineants/spring/api/notification/response/NotifyMessageItem.java
@@ -4,6 +4,7 @@ import codesquad.fineants.domain.notification.type.NotificationType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -13,6 +14,7 @@ import lombok.ToString;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
 @ToString
+@EqualsAndHashCode(of = "messageId")
 public class NotifyMessageItem {
 	private String title;
 	private NotificationType type;

--- a/src/main/java/codesquad/fineants/spring/api/stock_target_price/service/StockTargetPriceNotificationService.java
+++ b/src/main/java/codesquad/fineants/spring/api/stock_target_price/service/StockTargetPriceNotificationService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
@@ -225,10 +226,10 @@ public class StockTargetPriceNotificationService {
 					.exceptionally(throwable -> null))
 				.collect(Collectors.toList());
 
-			List<NotifyMessageItem> items = notifyMessageItemFutures.stream()
+			Set<NotifyMessageItem> items = notifyMessageItemFutures.stream()
 				.map(CompletableFuture::join)
 				.filter(Objects::nonNull)
-				.collect(Collectors.toList());
+				.collect(Collectors.toSet());
 
 			List<CompletableFuture<TargetPriceNotificationSendItem>> sendItemFutures = items.stream()
 				// 알림 저장

--- a/src/test/java/codesquad/fineants/spring/api/stock_target_price/service/StockTargetPriceNotificationServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/stock_target_price/service/StockTargetPriceNotificationServiceTest.java
@@ -258,6 +258,7 @@ class StockTargetPriceNotificationServiceTest extends AbstractContainerBaseTest 
 			.member(member)
 			.build());
 		fcmRepository.save(createFcmToken(member, "token"));
+		fcmRepository.save(createFcmToken(member, "token2"));
 		Stock stock = stockRepository.save(createStock());
 		Stock stock2 = stockRepository.save(createStock2());
 		StockTargetPrice stockTargetPrice = repository.save(createStockTargetPrice(member, stock));


### PR DESCRIPTION
## 구현한 것

- notification 엔티티 데이터가 토큰이 여러개더라도 messageId를 기준으로 고유하게 1개만 저장하도록 저장

## 기타

- 내용
