### PR TITLE
[fix] 포트폴리오 상세 조회 response property 변경

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioDetailResponse.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_stock/response/PortfolioDetailResponse.java
@@ -35,8 +35,8 @@ public class PortfolioDetailResponse {
 	private Double annualDividendYield;
 	private Double annualInvestmentDividendYield;
 	private Money provisionalLossBalance;
-	private Boolean targetGainNotification;
-	private Boolean maxLossNotification;
+	private Boolean targetGainNotify;
+	private Boolean maxLossNotify;
 
 	public static PortfolioDetailResponse from(Portfolio portfolio, PortfolioGainHistory history) {
 		return PortfolioDetailResponse.builder()
@@ -59,8 +59,8 @@ public class PortfolioDetailResponse {
 			.annualDividendYield(portfolio.calculateAnnualDividendYield())
 			.annualInvestmentDividendYield(portfolio.calculateAnnualInvestmentDividendYield())
 			.provisionalLossBalance(Money.zero())
-			.targetGainNotification(portfolio.getTargetGainIsActive())
-			.maxLossNotification(portfolio.getMaximumLossIsActive())
+			.targetGainNotify(portfolio.getTargetGainIsActive())
+			.maxLossNotify(portfolio.getMaximumLossIsActive())
 			.build();
 	}
 

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioHoldingRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/controller/PortfolioHoldingRestControllerTest.java
@@ -182,8 +182,8 @@ class PortfolioHoldingRestControllerTest {
 			.andExpect(jsonPath("data.portfolioDetails.annualDividendYield").value(closeTo(2.41, 0.1)))
 			.andExpect(jsonPath("data.portfolioDetails.annualInvestmentDividendYield").value(closeTo(2.89, 0.1)))
 			.andExpect(jsonPath("data.portfolioDetails.provisionalLossBalance").value(equalTo(0)))
-			.andExpect(jsonPath("data.portfolioDetails.targetGainNotification").value(equalTo(false)))
-			.andExpect(jsonPath("data.portfolioDetails.maxLossNotification").value(equalTo(false)));
+			.andExpect(jsonPath("data.portfolioDetails.targetGainNotify").value(equalTo(false)))
+			.andExpect(jsonPath("data.portfolioDetails.maxLossNotify").value(equalTo(false)));
 
 		resultActions
 			.andExpect(jsonPath("data.portfolioHoldings[0].companyName").value(equalTo("삼성전자보통주")))

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_stock/service/PortfolioHoldingServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_stock/service/PortfolioHoldingServiceTest.java
@@ -133,8 +133,8 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 			() -> assertThat(details.getAnnualDividend()).isEqualByComparingTo(Money.from(4332L)),
 			() -> assertThat(details.getAnnualDividendYield()).isEqualByComparingTo(2.41),
 			() -> assertThat(details.getProvisionalLossBalance()).isEqualByComparingTo(Money.from(0L)),
-			() -> assertThat(details.getTargetGainNotification()).isFalse(),
-			() -> assertThat(details.getMaxLossNotification()).isFalse(),
+			() -> assertThat(details.getTargetGainNotify()).isFalse(),
+			() -> assertThat(details.getMaxLossNotify()).isFalse(),
 
 			() -> assertThat(response.getPortfolioHoldings())
 				.hasSize(1)

--- a/src/test/java/codesquad/fineants/spring/docs/holding/PortfolioHoldingRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/spring/docs/holding/PortfolioHoldingRestControllerDocsTest.java
@@ -171,8 +171,8 @@ public class PortfolioHoldingRestControllerDocsTest extends RestDocsSupport {
 			.andExpect(jsonPath("data.portfolioDetails.annualDividendYield").value(closeTo(2.41, 0.1)))
 			.andExpect(jsonPath("data.portfolioDetails.annualInvestmentDividendYield").value(closeTo(2.89, 0.1)))
 			.andExpect(jsonPath("data.portfolioDetails.provisionalLossBalance").value(equalTo(0)))
-			.andExpect(jsonPath("data.portfolioDetails.targetGainNotification").value(equalTo(true)))
-			.andExpect(jsonPath("data.portfolioDetails.maxLossNotification").value(equalTo(true)));
+			.andExpect(jsonPath("data.portfolioDetails.targetGainNotify").value(equalTo(true)))
+			.andExpect(jsonPath("data.portfolioDetails.maxLossNotify").value(equalTo(true)));
 
 		resultActions
 			.andExpect(jsonPath("data.portfolioHoldings[0].companyName").value(equalTo("삼성전자보통주")))
@@ -256,9 +256,9 @@ public class PortfolioHoldingRestControllerDocsTest extends RestDocsSupport {
 						.description("투자 대비 연간 배당율"),
 					fieldWithPath("data.portfolioDetails.provisionalLossBalance").type(JsonFieldType.NUMBER)
 						.description("잠정 손실 잔고"),
-					fieldWithPath("data.portfolioDetails.targetGainNotification").type(JsonFieldType.BOOLEAN)
+					fieldWithPath("data.portfolioDetails.targetGainNotify").type(JsonFieldType.BOOLEAN)
 						.description("목표 수익 금액 알림 여부"),
-					fieldWithPath("data.portfolioDetails.maxLossNotification").type(JsonFieldType.BOOLEAN)
+					fieldWithPath("data.portfolioDetails.maxLossNotify").type(JsonFieldType.BOOLEAN)
 						.description("최대 손실 금액 알림 여부"),
 
 					fieldWithPath("data.portfolioHoldings[].companyName").type(JsonFieldType.STRING)


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 상세 조회 API의 응답의 일부 프로퍼티명 변경하여 일관화
