### PR TITLE
[fix] 포트폴리오 활성 목록 조회 응답 변경

### DIFF
--- a/src/main/java/codesquad/fineants/spring/api/portfolio_notification_setting/response/PortfolioNotificationSettingSearchItem.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_notification_setting/response/PortfolioNotificationSettingSearchItem.java
@@ -21,7 +21,7 @@ public class PortfolioNotificationSettingSearchItem {
 	private String name;
 	private Boolean targetGainNotify;
 	private Boolean maxLossNotify;
-	private LocalDateTime lastUpdated;
+	private LocalDateTime createdAt;
 
 	public static PortfolioNotificationSettingSearchItem from(Portfolio portfolio) {
 		return PortfolioNotificationSettingSearchItem.builder()
@@ -30,7 +30,7 @@ public class PortfolioNotificationSettingSearchItem {
 			.name(portfolio.getName())
 			.targetGainNotify(portfolio.getTargetGainIsActive())
 			.maxLossNotify(portfolio.getMaximumLossIsActive())
-			.lastUpdated(portfolio.getModifiedAt())
+			.createdAt(portfolio.getCreateAt())
 			.build();
 	}
 }

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_notification_setting/controller/PortfolioNotificationSettingRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_notification_setting/controller/PortfolioNotificationSettingRestControllerTest.java
@@ -1,4 +1,4 @@
-package codesquad.fineants.spring.api.portfolio;
+package codesquad.fineants.spring.api.portfolio_notification_setting.controller;
 
 import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -27,7 +27,6 @@ import codesquad.fineants.domain.member.Member;
 import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.domain.oauth.support.AuthPrincipalArgumentResolver;
 import codesquad.fineants.spring.api.common.errors.handler.GlobalExceptionHandler;
-import codesquad.fineants.spring.api.portfolio_notification_setting.controller.PortfolioNotificationSettingRestController;
 import codesquad.fineants.spring.api.portfolio_notification_setting.response.PortfolioNotificationSettingSearchItem;
 import codesquad.fineants.spring.api.portfolio_notification_setting.response.PortfolioNotificationSettingSearchResponse;
 import codesquad.fineants.spring.api.portfolio_notification_setting.service.PortfolioNotificationSettingService;
@@ -79,7 +78,7 @@ class PortfolioNotificationSettingRestControllerTest {
 						.name("포트폴리오 1")
 						.targetGainNotify(true)
 						.maxLossNotify(false)
-						.lastUpdated(now)
+						.createdAt(now)
 						.build(),
 					PortfolioNotificationSettingSearchItem.builder()
 						.portfolioId(2L)
@@ -87,7 +86,7 @@ class PortfolioNotificationSettingRestControllerTest {
 						.name("포트폴리오 2")
 						.targetGainNotify(true)
 						.maxLossNotify(false)
-						.lastUpdated(now)
+						.createdAt(now)
 						.build()))
 				.build());
 
@@ -102,13 +101,13 @@ class PortfolioNotificationSettingRestControllerTest {
 			.andExpect(jsonPath("data.portfolios[0].name").value(equalTo("포트폴리오 1")))
 			.andExpect(jsonPath("data.portfolios[0].targetGainNotify").value(equalTo(true)))
 			.andExpect(jsonPath("data.portfolios[0].maxLossNotify").value(equalTo(false)))
-			.andExpect(jsonPath("data.portfolios[0].lastUpdated").isNotEmpty())
+			.andExpect(jsonPath("data.portfolios[0].createdAt").isNotEmpty())
 			.andExpect(jsonPath("data.portfolios[1].portfolioId").value(equalTo(2)))
 			.andExpect(jsonPath("data.portfolios[1].securitiesFirm").value(equalTo("토스증권")))
 			.andExpect(jsonPath("data.portfolios[1].name").value(equalTo("포트폴리오 2")))
 			.andExpect(jsonPath("data.portfolios[1].targetGainNotify").value(equalTo(true)))
 			.andExpect(jsonPath("data.portfolios[1].maxLossNotify").value(equalTo(false)))
-			.andExpect(jsonPath("data.portfolios[1].lastUpdated").isNotEmpty());
+			.andExpect(jsonPath("data.portfolios[1].createdAt").isNotEmpty());
 	}
 
 	private Member createMember() {

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_notification_setting/service/PortfolioNotificationSettingServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_notification_setting/service/PortfolioNotificationSettingServiceTest.java
@@ -1,4 +1,4 @@
-package codesquad.fineants.spring.api.portfolio;
+package codesquad.fineants.spring.api.portfolio_notification_setting.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -16,7 +16,6 @@ import codesquad.fineants.domain.portfolio.Portfolio;
 import codesquad.fineants.domain.portfolio.PortfolioRepository;
 import codesquad.fineants.spring.AbstractContainerBaseTest;
 import codesquad.fineants.spring.api.portfolio_notification_setting.response.PortfolioNotificationSettingSearchResponse;
-import codesquad.fineants.spring.api.portfolio_notification_setting.service.PortfolioNotificationSettingService;
 
 class PortfolioNotificationSettingServiceTest extends AbstractContainerBaseTest {
 	@Autowired

--- a/src/test/java/codesquad/fineants/spring/docs/portfolio/PortfolioNotificationSettingRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/spring/docs/portfolio/PortfolioNotificationSettingRestControllerDocsTest.java
@@ -47,7 +47,7 @@ public class PortfolioNotificationSettingRestControllerDocsTest extends RestDocs
 						.name("포트폴리오 1")
 						.targetGainNotify(true)
 						.maxLossNotify(false)
-						.lastUpdated(now)
+						.createdAt(now)
 						.build(),
 					PortfolioNotificationSettingSearchItem.builder()
 						.portfolioId(2L)
@@ -55,7 +55,7 @@ public class PortfolioNotificationSettingRestControllerDocsTest extends RestDocs
 						.name("포트폴리오 2")
 						.targetGainNotify(true)
 						.maxLossNotify(false)
-						.lastUpdated(now)
+						.createdAt(now)
 						.build()))
 				.build());
 
@@ -71,13 +71,13 @@ public class PortfolioNotificationSettingRestControllerDocsTest extends RestDocs
 			.andExpect(jsonPath("data.portfolios[0].name").value(equalTo("포트폴리오 1")))
 			.andExpect(jsonPath("data.portfolios[0].targetGainNotify").value(equalTo(true)))
 			.andExpect(jsonPath("data.portfolios[0].maxLossNotify").value(equalTo(false)))
-			.andExpect(jsonPath("data.portfolios[0].lastUpdated").isNotEmpty())
+			.andExpect(jsonPath("data.portfolios[0].createdAt").isNotEmpty())
 			.andExpect(jsonPath("data.portfolios[1].portfolioId").value(equalTo(2)))
 			.andExpect(jsonPath("data.portfolios[1].securitiesFirm").value(equalTo("토스증권")))
 			.andExpect(jsonPath("data.portfolios[1].name").value(equalTo("포트폴리오 2")))
 			.andExpect(jsonPath("data.portfolios[1].targetGainNotify").value(equalTo(true)))
 			.andExpect(jsonPath("data.portfolios[1].maxLossNotify").value(equalTo(false)))
-			.andExpect(jsonPath("data.portfolios[1].lastUpdated").isNotEmpty())
+			.andExpect(jsonPath("data.portfolios[1].createdAt").isNotEmpty())
 			.andDo(
 				document(
 					"portfolio_notification_settings-search",
@@ -105,8 +105,8 @@ public class PortfolioNotificationSettingRestControllerDocsTest extends RestDocs
 							.description("목표 수익률 알림 여부"),
 						fieldWithPath("data.portfolios[].maxLossNotify").type(JsonFieldType.BOOLEAN)
 							.description("최대 손실율 알림 여부"),
-						fieldWithPath("data.portfolios[].lastUpdated").type(JsonFieldType.STRING)
-							.description("최근 갱신 일자")
+						fieldWithPath("data.portfolios[].createdAt").type(JsonFieldType.STRING)
+							.description("생성 일자")
 					)
 				)
 			);


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 활성 알림 목록 조회의 응답에서 modifiedAt -> createdAt으로 변경

