### PR TITLE
[feat] 포트폴리 알림 수정

### DIFF
--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -448,4 +448,12 @@ public class Portfolio extends BaseEntity {
 			name
 		);
 	}
+
+	public Boolean isTargetGainSet() {
+		return !targetGain.isZero();
+	}
+
+	public Boolean isMaximumLossSet() {
+		return !maximumLoss.isZero();
+	}
 }

--- a/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/Portfolio.java
@@ -287,12 +287,34 @@ public class Portfolio extends BaseEntity {
 
 	// 목표수익금액 알림 변경
 	public void changeTargetGainNotification(Boolean isActive) {
+		validateTargetGainNotification();
 		this.targetGainIsActive = isActive;
+	}
+
+	/**
+	 * 목표 수익 금액에 따른 변경이 가능한 상태인지 검증
+	 * - 목표 수익 금액이 0원인 경우 변경 불가능
+	 */
+	private void validateTargetGainNotification() {
+		if (targetGain.isZero()) {
+			throw new FineAntsException(PortfolioErrorCode.TARGET_GAIN_IS_ZERO_WITH_NOTIFY_UPDATE);
+		}
 	}
 
 	// 최대손실금액의 알림 변경
 	public void changeMaximumLossNotification(Boolean isActive) {
+		validateMaxLossNotification();
 		this.maximumLossIsActive = isActive;
+	}
+
+	/**
+	 * 최대 손실 금액에 따른 변경이 가능한 상태인지 검증
+	 * - 최대 손실 금액이 0원인 경우 변경 불가능
+	 */
+	private void validateMaxLossNotification() {
+		if (maximumLoss.isZero()) {
+			throw new FineAntsException(PortfolioErrorCode.MAX_LOSS_IS_ZERO_WITH_NOTIFY_UPDATE);
+		}
 	}
 
 	// 포트폴리오가 목표수익금액에 도달했는지 검사 (평가금액이 목표수익금액보다 같거나 큰 경우)

--- a/src/main/java/codesquad/fineants/spring/api/common/errors/errorcode/PortfolioErrorCode.java
+++ b/src/main/java/codesquad/fineants/spring/api/common/errors/errorcode/PortfolioErrorCode.java
@@ -15,8 +15,10 @@ public enum PortfolioErrorCode implements ErrorCode {
 	DUPLICATE_NAME(HttpStatus.CONFLICT, "포트폴리오 이름이 중복되었습니다"),
 	NOT_FOUND_PORTFOLIO(HttpStatus.NOT_FOUND, "포트폴리오를 찾을 수 없습니다"),
 	NOT_HAVE_AUTHORIZATION(HttpStatus.FORBIDDEN, "포트폴리오에 대한 권한이 없습니다"),
-	TOTAL_INVESTMENT_PRICE_EXCEEDS_BUDGET(HttpStatus.BAD_REQUEST, "매입 실패, 현금이 부족합니다");
-
+	TOTAL_INVESTMENT_PRICE_EXCEEDS_BUDGET(HttpStatus.BAD_REQUEST, "매입 실패, 현금이 부족합니다"),
+	TARGET_GAIN_IS_ZERO_WITH_NOTIFY_UPDATE(HttpStatus.BAD_REQUEST, "목표 수익금액이 0원이어서 알림을 수정할 수 없습니다"),
+	MAX_LOSS_IS_ZERO_WITH_NOTIFY_UPDATE(HttpStatus.BAD_REQUEST, "최대 손실금액이 0원이어서 알림을 수정할 수 없습니다");
+	
 	private final HttpStatus httpStatus;
 	private final String message;
 

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_notification/request/PortfolioNotificationUpdateRequest.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_notification/request/PortfolioNotificationUpdateRequest.java
@@ -4,13 +4,26 @@ import javax.validation.constraints.NotNull;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
 public class PortfolioNotificationUpdateRequest {
 	@JsonProperty("isActive")
 	@NotNull(message = "활성화/비활성 정보는 필수정보입니다.")
 	private Boolean isActive;
+
+	public static PortfolioNotificationUpdateRequest active() {
+		return new PortfolioNotificationUpdateRequest(true);
+	}
+
+	public static PortfolioNotificationUpdateRequest inactive() {
+		return new PortfolioNotificationUpdateRequest(false);
+	}
 }

--- a/src/main/java/codesquad/fineants/spring/api/portfolio_notification_setting/response/PortfolioNotificationSettingSearchItem.java
+++ b/src/main/java/codesquad/fineants/spring/api/portfolio_notification_setting/response/PortfolioNotificationSettingSearchItem.java
@@ -21,6 +21,8 @@ public class PortfolioNotificationSettingSearchItem {
 	private String name;
 	private Boolean targetGainNotify;
 	private Boolean maxLossNotify;
+	private Boolean isTargetGainSet;
+	private Boolean isMaxLossSet;
 	private LocalDateTime createdAt;
 
 	public static PortfolioNotificationSettingSearchItem from(Portfolio portfolio) {
@@ -30,6 +32,8 @@ public class PortfolioNotificationSettingSearchItem {
 			.name(portfolio.getName())
 			.targetGainNotify(portfolio.getTargetGainIsActive())
 			.maxLossNotify(portfolio.getMaximumLossIsActive())
+			.isTargetGainSet(portfolio.isTargetGainSet())
+			.isMaxLossSet(portfolio.isMaximumLossSet())
 			.createdAt(portfolio.getCreateAt())
 			.build();
 	}

--- a/src/test/java/codesquad/fineants/spring/api/portfolio_notification/service/PortfolioNotificationServiceTest.java
+++ b/src/test/java/codesquad/fineants/spring/api/portfolio_notification/service/PortfolioNotificationServiceTest.java
@@ -1,4 +1,4 @@
-package codesquad.fineants.spring.api.portfolio_notification;
+package codesquad.fineants.spring.api.portfolio_notification.service;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -31,12 +31,13 @@ import codesquad.fineants.domain.stock.Market;
 import codesquad.fineants.domain.stock.Stock;
 import codesquad.fineants.domain.stock.StockRepository;
 import codesquad.fineants.spring.AbstractContainerBaseTest;
+import codesquad.fineants.spring.api.common.errors.errorcode.PortfolioErrorCode;
+import codesquad.fineants.spring.api.common.errors.exception.FineAntsException;
 import codesquad.fineants.spring.api.kis.manager.CurrentPriceManager;
 import codesquad.fineants.spring.api.mail.service.MailService;
 import codesquad.fineants.spring.api.portfolio_notification.manager.MailRedisManager;
 import codesquad.fineants.spring.api.portfolio_notification.request.PortfolioNotificationUpdateRequest;
 import codesquad.fineants.spring.api.portfolio_notification.response.PortfolioNotificationUpdateResponse;
-import codesquad.fineants.spring.api.portfolio_notification.service.PortfolioNotificationService;
 
 class PortfolioNotificationServiceTest extends AbstractContainerBaseTest {
 
@@ -111,6 +112,23 @@ class PortfolioNotificationServiceTest extends AbstractContainerBaseTest {
 		);
 	}
 
+	@DisplayName("사용자는 포트폴리오의 목표수익금액이 0원인 경우 알림을 수정할 수 없다")
+	@Test
+	void updateNotificationTargetGain_whenTargetGainIsZero_thenNotUpdate() {
+		// given
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member, 1000000L, 0L, 0L));
+
+		PortfolioNotificationUpdateRequest request = PortfolioNotificationUpdateRequest.active();
+		// when
+		Throwable throwable = catchThrowable(() -> service.updateNotificationTargetGain(request, portfolio.getId()));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(FineAntsException.class)
+			.hasMessage(PortfolioErrorCode.TARGET_GAIN_IS_ZERO_WITH_NOTIFY_UPDATE.getMessage());
+	}
+
 	@DisplayName("사용자는 포트폴리오 최대손실금액 알림을 활성화한다")
 	@Test
 	void modifyPortfolioMaximumLossNotification() throws JsonProcessingException {
@@ -139,6 +157,23 @@ class PortfolioNotificationServiceTest extends AbstractContainerBaseTest {
 		);
 	}
 
+	@DisplayName("사용자는 포트폴리오의 최대손실금액이 0원이어서 알림을 수정할 수 없다")
+	@Test
+	void updateNotificationMaximumLoss() {
+		// given
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member, 1000000L, 1500000L, 0L));
+
+		PortfolioNotificationUpdateRequest request = PortfolioNotificationUpdateRequest.active();
+		// when
+		Throwable throwable = catchThrowable(() -> service.updateNotificationMaximumLoss(request, portfolio.getId()));
+
+		// then
+		assertThat(throwable)
+			.isInstanceOf(FineAntsException.class)
+			.hasMessage(PortfolioErrorCode.MAX_LOSS_IS_ZERO_WITH_NOTIFY_UPDATE.getMessage());
+	}
+
 	private Member createMember() {
 		return Member.builder()
 			.nickname("일개미1234")
@@ -153,16 +188,17 @@ class PortfolioNotificationServiceTest extends AbstractContainerBaseTest {
 	}
 
 	private Portfolio createPortfolio(Member member, Long budget, Long targetGain, Long maximumLoss) {
-		return Portfolio.builder()
-			.name("내꿈은 워렌버핏")
-			.securitiesFirm("토스")
-			.budget(Money.from(budget))
-			.targetGain(Money.from(targetGain))
-			.maximumLoss(Money.from(maximumLoss))
-			.member(member)
-			.targetGainIsActive(true)
-			.maximumLossIsActive(true)
-			.build();
+		return new Portfolio(
+			null,
+			"내꿈은 워렌버핏",
+			"토스증권",
+			Money.from(budget),
+			Money.from(targetGain),
+			Money.from(maximumLoss),
+			true,
+			true,
+			member
+		);
 	}
 
 	private Stock createStock() {

--- a/src/test/java/codesquad/fineants/spring/docs/portfolio/PortfolioNotificationSettingRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/spring/docs/portfolio/PortfolioNotificationSettingRestControllerDocsTest.java
@@ -47,6 +47,8 @@ public class PortfolioNotificationSettingRestControllerDocsTest extends RestDocs
 						.name("포트폴리오 1")
 						.targetGainNotify(true)
 						.maxLossNotify(false)
+						.isTargetGainSet(true)
+						.isMaxLossSet(true)
 						.createdAt(now)
 						.build(),
 					PortfolioNotificationSettingSearchItem.builder()
@@ -55,6 +57,8 @@ public class PortfolioNotificationSettingRestControllerDocsTest extends RestDocs
 						.name("포트폴리오 2")
 						.targetGainNotify(true)
 						.maxLossNotify(false)
+						.isTargetGainSet(true)
+						.isMaxLossSet(true)
 						.createdAt(now)
 						.build()))
 				.build());
@@ -71,12 +75,16 @@ public class PortfolioNotificationSettingRestControllerDocsTest extends RestDocs
 			.andExpect(jsonPath("data.portfolios[0].name").value(equalTo("포트폴리오 1")))
 			.andExpect(jsonPath("data.portfolios[0].targetGainNotify").value(equalTo(true)))
 			.andExpect(jsonPath("data.portfolios[0].maxLossNotify").value(equalTo(false)))
+			.andExpect(jsonPath("data.portfolios[0].isTargetGainSet").value(equalTo(true)))
+			.andExpect(jsonPath("data.portfolios[0].isMaxLossSet").value(equalTo(true)))
 			.andExpect(jsonPath("data.portfolios[0].createdAt").isNotEmpty())
 			.andExpect(jsonPath("data.portfolios[1].portfolioId").value(equalTo(2)))
 			.andExpect(jsonPath("data.portfolios[1].securitiesFirm").value(equalTo("토스증권")))
 			.andExpect(jsonPath("data.portfolios[1].name").value(equalTo("포트폴리오 2")))
 			.andExpect(jsonPath("data.portfolios[1].targetGainNotify").value(equalTo(true)))
 			.andExpect(jsonPath("data.portfolios[1].maxLossNotify").value(equalTo(false)))
+			.andExpect(jsonPath("data.portfolios[1].isTargetGainSet").value(equalTo(true)))
+			.andExpect(jsonPath("data.portfolios[1].isMaxLossSet").value(equalTo(true)))
 			.andExpect(jsonPath("data.portfolios[1].createdAt").isNotEmpty())
 			.andDo(
 				document(
@@ -105,6 +113,10 @@ public class PortfolioNotificationSettingRestControllerDocsTest extends RestDocs
 							.description("목표 수익률 알림 여부"),
 						fieldWithPath("data.portfolios[].maxLossNotify").type(JsonFieldType.BOOLEAN)
 							.description("최대 손실율 알림 여부"),
+						fieldWithPath("data.portfolios[].isTargetGainSet").type(JsonFieldType.BOOLEAN)
+							.description("목표 수익률 알림 설정 가능 여부"),
+						fieldWithPath("data.portfolios[].isMaxLossSet").type(JsonFieldType.BOOLEAN)
+							.description("최대 손실율 알림 설정 가능 여부"),
 						fieldWithPath("data.portfolios[].createdAt").type(JsonFieldType.STRING)
 							.description("생성 일자")
 					)


### PR DESCRIPTION
## 구현한 것

- 포트폴리오의 목표 수익금액이나 최대손실금액이 0원인 경우 해당 알림을 수정할 수 없도록 변경하였습니다.
- 포트폴리오 활성 알림 목록 조회(GET /portfolios/notification/settings) API에서 응답 프로퍼티에 isTargetGainSet, isMaxLossSet이 추가되었습니다. 
