### PR TITLE
[docs] Rest Docs 설명 수정

### DIFF
--- a/src/test/java/codesquad/fineants/docs/member/MemberRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/docs/member/MemberRestControllerDocsTest.java
@@ -29,7 +29,6 @@ import org.springframework.restdocs.snippet.Attributes;
 
 import codesquad.fineants.docs.RestDocsSupport;
 import codesquad.fineants.domain.jwt.domain.Jwt;
-import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.controller.MemberRestController;
 import codesquad.fineants.domain.member.domain.dto.request.LoginRequest;
 import codesquad.fineants.domain.member.domain.dto.request.OauthMemberLoginRequest;
@@ -43,6 +42,7 @@ import codesquad.fineants.domain.member.domain.dto.response.OauthSaveUrlResponse
 import codesquad.fineants.domain.member.domain.dto.response.ProfileChangeResponse;
 import codesquad.fineants.domain.member.domain.dto.response.ProfileResponse;
 import codesquad.fineants.domain.member.domain.dto.response.SignUpServiceResponse;
+import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.service.MemberService;
 import codesquad.fineants.domain.oauth.support.AuthMember;
 import codesquad.fineants.global.util.ObjectMapperUtil;
@@ -394,7 +394,7 @@ public class MemberRestControllerDocsTest extends RestDocsSupport {
 						fieldWithPath("data.user.email").type(JsonFieldType.STRING)
 							.description("회원 이메일"),
 						fieldWithPath("data.user.profileUrl").type(JsonFieldType.STRING)
-							.description("회원 프로필 URL"),
+							.description("회원 프로필 URL (NULL 허용)"),
 						fieldWithPath("data.user.provider").type(JsonFieldType.STRING)
 							.description("회원 가입 플랫폼"),
 						fieldWithPath("data.user.notificationPreferences").type(JsonFieldType.OBJECT)
@@ -630,7 +630,7 @@ public class MemberRestControllerDocsTest extends RestDocsSupport {
 						fieldWithPath("data.user.email").type(JsonFieldType.STRING)
 							.description("회원 이메일"),
 						fieldWithPath("data.user.profileUrl").type(JsonFieldType.STRING)
-							.description("회원 프로필 URL"),
+							.description("회원 프로필 URL (NULL 허용)"),
 						fieldWithPath("data.user.provider").type(JsonFieldType.STRING)
 							.description("회원 가입 플랫폼")
 					)

--- a/src/test/java/codesquad/fineants/docs/portfolio_holding/PortfolioHoldingRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/docs/portfolio_holding/PortfolioHoldingRestControllerDocsTest.java
@@ -108,7 +108,7 @@ public class PortfolioHoldingRestControllerDocsTest extends RestDocsSupport {
 						fieldWithPath("purchaseHistory.numShares").type(JsonFieldType.NUMBER).description("매입 개수"),
 						fieldWithPath("purchaseHistory.purchasePricePerShare").type(JsonFieldType.NUMBER)
 							.description("평균 매입가"),
-						fieldWithPath("purchaseHistory.memo").type(JsonFieldType.STRING).description("메모")
+						fieldWithPath("purchaseHistory.memo").type(JsonFieldType.STRING).description("메모").isOptional(),
 					),
 					responseFields(
 						fieldWithPath("code").type(JsonFieldType.NUMBER)
@@ -306,7 +306,7 @@ public class PortfolioHoldingRestControllerDocsTest extends RestDocsSupport {
 						.description("매입가"),
 					fieldWithPath("data.portfolioHoldings[].purchaseHistory[].memo")
 						.type(JsonFieldType.STRING)
-						.description("메모")
+						.description("메모 (NULL 허용)")
 				)
 			)
 		);


### PR DESCRIPTION
## 구현한 것

- 응답 프로퍼티로 값이 NULL이 올수있는 프로퍼티명의 설명을 수정하였습니다.
- 포트폴리오 종목 생성 API의 memo 리퀘스트 정보의 optional을 "Y"로 수정 (NULL 허용)
