### PR TITLE
[fix] 알림 수정

### DIFF
--- a/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
@@ -19,11 +19,11 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import codesquad.fineants.global.errors.exception.KisException;
-import codesquad.fineants.domain.kis.properties.OauthKisProperties;
 import codesquad.fineants.domain.kis.domain.dto.response.KisClosingPrice;
 import codesquad.fineants.domain.kis.domain.dto.response.KisDividend;
 import codesquad.fineants.domain.kis.domain.dto.response.KisDividendWrapper;
+import codesquad.fineants.domain.kis.properties.OauthKisProperties;
+import codesquad.fineants.global.errors.exception.KisException;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
@@ -52,12 +52,12 @@ public class KisClient {
 		requestBodyMap.put("appsecret", oauthKisProperties.getSecretkey());
 		return webClient
 			.post()
-			.uri(oauthKisProperties.getTokenURI())
+			.uri(oauthKisProperties.getTokenUrl())
 			.bodyValue(requestBodyMap)
 			.retrieve()
 			.onStatus(HttpStatus::isError, this::handleError)
 			.bodyToMono(KisAccessToken.class)
-			.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofMinutes(1)))
+			.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofSeconds(5)))
 			.log();
 	}
 
@@ -74,7 +74,7 @@ public class KisClient {
 		queryParamMap.add("fid_input_iscd", tickerSymbol);
 
 		return performGet(
-			oauthKisProperties.getCurrentPriceURI(),
+			oauthKisProperties.getCurrentPriceUrl(),
 			headerMap,
 			queryParamMap,
 			KisCurrentPrice.class
@@ -98,7 +98,7 @@ public class KisClient {
 		queryParamMap.add("FID_ORG_ADJ_PRC", "0");
 
 		return performGet(
-			oauthKisProperties.getLastDayClosingPriceURI(),
+			oauthKisProperties.getClosingPriceUrl(),
 			headerMap,
 			queryParamMap,
 			KisClosingPrice.class
@@ -124,7 +124,7 @@ public class KisClient {
 		queryParamMap.add("SHT_CD", tickerSymbol);
 
 		return performGet(
-			oauthKisProperties.getDividendURI(),
+			oauthKisProperties.getDividendUrl(),
 			headerMap,
 			queryParamMap,
 			String.class,
@@ -150,7 +150,7 @@ public class KisClient {
 		queryParamMap.add("SHT_CD", Strings.EMPTY);
 
 		KisDividendWrapper result = performGet(
-			oauthKisProperties.getDividendURI(),
+			oauthKisProperties.getDividendUrl(),
 			headerMap,
 			queryParamMap,
 			KisDividendWrapper.class,

--- a/src/main/java/codesquad/fineants/domain/kis/properties/OauthKisProperties.java
+++ b/src/main/java/codesquad/fineants/domain/kis/properties/OauthKisProperties.java
@@ -11,19 +11,19 @@ public class OauthKisProperties {
 
 	private final String appkey;
 	private final String secretkey;
-	private final String tokenURI;
-	private final String currentPriceURI;
-	private final String lastDayClosingPriceURI;
-	private final String dividendURI;
+	private final String tokenUrl;
+	private final String currentPriceUrl;
+	private final String closingPriceUrl;
+	private final String dividendUrl;
 
 	@ConstructorBinding
-	public OauthKisProperties(String appkey, String secretkey, String tokenURI, String currentPriceURI,
-		String lastDayClosingPriceURI, String dividendURI) {
+	public OauthKisProperties(String appkey, String secretkey, String tokenUrl, String currentPriceUrl,
+		String closingPriceUrl, String dividendUrl) {
 		this.appkey = appkey;
 		this.secretkey = secretkey;
-		this.tokenURI = tokenURI;
-		this.currentPriceURI = currentPriceURI;
-		this.lastDayClosingPriceURI = lastDayClosingPriceURI;
-		this.dividendURI = dividendURI;
+		this.tokenUrl = tokenUrl;
+		this.currentPriceUrl = currentPriceUrl;
+		this.closingPriceUrl = closingPriceUrl;
+		this.dividendUrl = dividendUrl;
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/stock_target_price/domain/dto/response/TargetPriceNotifyMessageItem.java
+++ b/src/main/java/codesquad/fineants/domain/stock_target_price/domain/dto/response/TargetPriceNotifyMessageItem.java
@@ -1,8 +1,8 @@
 package codesquad.fineants.domain.stock_target_price.domain.dto.response;
 
 import codesquad.fineants.domain.common.money.Money;
-import codesquad.fineants.domain.notification.domain.entity.type.NotificationType;
 import codesquad.fineants.domain.notification.domain.dto.response.TargetPriceNotificationResponse;
+import codesquad.fineants.domain.notification.domain.entity.type.NotificationType;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -2,6 +2,7 @@ spring:
   datasource:
     hikari:
       leak-detection-threshold: 2000
+      connection-timeout: 30000
   jpa:
     database: mysql
     database-platform: org.hibernate.dialect.MySQL8Dialect

--- a/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
@@ -29,6 +29,7 @@ import codesquad.fineants.domain.common.money.Money;
 import codesquad.fineants.domain.fcm_token.domain.entity.FcmToken;
 import codesquad.fineants.domain.fcm_token.repository.FcmRepository;
 import codesquad.fineants.domain.fcm_token.service.FirebaseMessagingService;
+import codesquad.fineants.domain.kis.aop.AccessTokenAspect;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
 import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
 import codesquad.fineants.domain.kis.service.KisService;
@@ -110,6 +111,9 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 	@MockBean
 	private FirebaseMessagingService firebaseMessagingService;
+
+	@MockBean
+	private AccessTokenAspect accessTokenAspect;
 
 	@AfterEach
 	void tearDown() {
@@ -564,9 +568,9 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 			.hasSize(2);
 	}
 
-	@DisplayName("종목 지정가 도달 알림을 보내는데 실패하면 알림을 저장하지 않아야 한다")
+	@DisplayName("종목 지정가 도달 알림을 보내는데 실패해도 알림은 저장되어야 한다")
 	@Test
-	void notifyTargetPrice_whenFailSendingNotification_thenNotSaveNotification() {
+	void notifyTargetPrice_whenFailSendingNotification_thenSaveNotification() {
 		// given
 		Member member = memberRepository.save(createMember());
 		notificationPreferenceRepository.save(NotificationPreference.builder()
@@ -591,13 +595,12 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 			List.of(stock.getTickerSymbol()));
 
 		// then
-		NotificationType type = NotificationType.STOCK_TARGET_PRICE;
 		assertThat(response.getNotifications())
 			.asList()
-			.isEmpty();
+			.hasSize(1);
 		assertThat(notificationRepository.findAllByMemberId(member.getId()))
 			.asList()
-			.hasSize(0);
+			.hasSize(1);
 	}
 
 	@DisplayName("티커 심볼을 기준으로 종목 지정가 알림을 발송한다")

--- a/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
@@ -201,7 +201,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 		);
 	}
 
-	@DisplayName("토큰이 유효하지 않아서 목표 수익률 알림을 보낼수 없다")
+	@DisplayName("토큰이 유효하지 않아서 목표 수익률 알림을 보낼수 없지만, 알림은 저장된다")
 	@Test
 	void notifyTargetGainBy_whenInvalidFcmToken_thenDeleteFcmToken() {
 		// given
@@ -234,7 +234,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 		// then
 		assertAll(
-			() -> assertThat(response.getNotifications()).isEmpty(),
+			() -> assertThat(response.getNotifications()).hasSize(1),
 			() -> assertThat(fcmRepository.findById(fcmToken.getId())).isEmpty()
 		);
 	}
@@ -317,7 +317,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 		);
 	}
 
-	@DisplayName("토큰이 유효하지 않아서 최대 손실율 달성 알림을 보낼수 없다")
+	@DisplayName("토큰이 유효하지 않아서 최대 손실율 달성 알림을 보낼수 없지만, 알림은 저장된다")
 	@Test
 	void notifyMaxLoss_whenInvalidFcmToken_thenDeleteFcmToken() throws FirebaseMessagingException {
 		// given
@@ -350,7 +350,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 		// then
 		assertAll(
-			() -> assertThat(response.getNotifications()).isEmpty(),
+			() -> assertThat(response.getNotifications()).hasSize(1),
 			() -> assertThat(fcmRepository.findById(fcmToken.getId())).isEmpty()
 		);
 	}

--- a/src/test/java/codesquad/fineants/domain/portfolio_holding/service/PortfolioHoldingServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/portfolio_holding/service/PortfolioHoldingServiceTest.java
@@ -24,6 +24,7 @@ import codesquad.fineants.domain.common.money.Expression;
 import codesquad.fineants.domain.common.money.Money;
 import codesquad.fineants.domain.common.money.Percentage;
 import codesquad.fineants.domain.common.money.RateDivision;
+import codesquad.fineants.domain.kis.aop.AccessTokenAspect;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
 import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
@@ -91,6 +92,10 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 
 	@MockBean
 	private PortfolioHoldingEventPublisher publisher;
+
+	// CurrentPriceRepository AccessToken 모킹
+	@MockBean
+	private AccessTokenAspect accessTokenAspect;
 
 	@AfterEach
 	void tearDown() {


### PR DESCRIPTION
## 구현한 것

- 기존 알림을 발송한 다음에 성공한 알림들에 대해서만 알림 저장하는 방식에서, 알림을 저장한 다음에 알림을 발송하는 방식으로 변경하였습니다.
- 알림 발송을 실패하여도 알림 저장은 별개로 저장됩니다.