### PR TITLE
[fix] oauth 계정의 프로필 변경 유지 문제 해결

### DIFF
--- a/src/main/java/codesquad/fineants/global/security/oauth/dto/OAuthAttribute.java
+++ b/src/main/java/codesquad/fineants/global/security/oauth/dto/OAuthAttribute.java
@@ -73,8 +73,15 @@ public class OAuthAttribute {
 
 	public Optional<Member> getMemberFrom(MemberRepository repository) {
 		return repository.findMemberByEmailAndProvider(email, provider)
-			.map(entity -> entity.updateProfileUrl(profileUrl))
+			.map(this::updateProfileUrlIfAbsent)
 			.stream().findAny();
+	}
+
+	private Member updateProfileUrlIfAbsent(Member entity) {
+		if (entity.getProfileUrl() != null) {
+			return entity;
+		}
+		return entity.updateProfileUrl(profileUrl);
 	}
 
 	public Member toEntity(NicknameGenerator generator) {

--- a/src/main/java/codesquad/fineants/global/security/oauth/service/AbstractUserService.java
+++ b/src/main/java/codesquad/fineants/global/security/oauth/service/AbstractUserService.java
@@ -27,7 +27,7 @@ public abstract class AbstractUserService {
 	private final NicknameGenerator nicknameGenerator;
 	private final RoleRepository roleRepository;
 
-	OAuthAttribute getUserInfo(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
+	public OAuthAttribute getUserInfo(OAuth2UserRequest userRequest, OAuth2User oAuth2User) {
 		String provider = userRequest.getClientRegistration().getRegistrationId();
 		String nameAttributeKey = userRequest.getClientRegistration()
 			.getProviderDetails()
@@ -38,7 +38,7 @@ public abstract class AbstractUserService {
 		return OAuthAttribute.of(provider, oAuth2User.getAttributes(), nameAttributeKey);
 	}
 
-	Member saveOrUpdate(OAuthAttribute attributes) {
+	public Member saveOrUpdate(OAuthAttribute attributes) {
 		Member member = attributes.getMemberFrom(memberRepository)
 			.orElseGet(() -> attributes.toEntity(nicknameGenerator));
 		Set<String> roleNames = member.getRoles().stream()

--- a/src/test/java/codesquad/fineants/AbstractContainerBaseTest.java
+++ b/src/test/java/codesquad/fineants/AbstractContainerBaseTest.java
@@ -143,6 +143,24 @@ public class AbstractContainerBaseTest {
 		return member;
 	}
 
+	protected Member createOauthMember(String nickname, String email, String provider, String profileUrl) {
+		Role userRole = roleRepository.findRoleByRoleName("ROLE_USER")
+			.orElseThrow(() -> new FineAntsException(RoleErrorCode.NOT_EXIST_ROLE));
+		// 회원 생성
+		Member member = Member.oauthMember(
+			email,
+			nickname,
+			provider,
+			profileUrl
+		);
+		// 역할 설정
+		member.addMemberRole(MemberRole.create(member, userRole));
+
+		// 계정 알림 설정
+		member.setNotificationPreference(NotificationPreference.allActive(member));
+		return member;
+	}
+
 	protected NotificationPreference createNotificationPreference(boolean browserNotify, boolean targetGainNotify,
 		boolean maxLossNotify, boolean targetPriceNotify, Member member) {
 		return NotificationPreference.create(

--- a/src/test/java/codesquad/fineants/domain/member/controller/AuthenticationIntegrationTest.java
+++ b/src/test/java/codesquad/fineants/domain/member/controller/AuthenticationIntegrationTest.java
@@ -87,7 +87,7 @@ public class AuthenticationIntegrationTest extends AbstractContainerBaseTest {
 			.assertThat()
 			.body("data", Matchers.nullValue());
 	}
-
+	
 	@DisplayName("사용자는 이메일 또는 비밀번호를 틀려서 로그인 할 수 없다")
 	@Test
 	void login_whenInvalidUsernameAndPassword_then401() {

--- a/src/test/java/codesquad/fineants/global/security/oauth/service/AbstractUserServiceTest.java
+++ b/src/test/java/codesquad/fineants/global/security/oauth/service/AbstractUserServiceTest.java
@@ -1,0 +1,54 @@
+package codesquad.fineants.global.security.oauth.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.transaction.annotation.Transactional;
+
+import codesquad.fineants.AbstractContainerBaseTest;
+import codesquad.fineants.domain.member.domain.entity.Member;
+import codesquad.fineants.domain.member.repository.MemberRepository;
+import codesquad.fineants.domain.member.repository.RoleRepository;
+import codesquad.fineants.domain.member.service.NicknameGenerator;
+import codesquad.fineants.domain.notificationpreference.repository.NotificationPreferenceRepository;
+import codesquad.fineants.global.security.oauth.dto.OAuthAttribute;
+
+class AbstractUserServiceTest extends AbstractContainerBaseTest {
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private NotificationPreferenceRepository notificationPreferenceRepository;
+
+	@Autowired
+	private NicknameGenerator nicknameGenerator;
+
+	@Autowired
+	private RoleRepository roleRepository;
+
+	@Transactional
+	@DisplayName("OAuth google 계정이 다른 프로필로 변경한 상태에서 회원 정보 저장시 프로필 사진을 유지한다")
+	@Test
+	void saveOrUpdate_givenOtherProfileUrl_whenSaveOrUpdate_thenMaintainProfileUrl() {
+		// given
+		memberRepository.save(createOauthMember("fineants1234", "fineants1234@gmail.com", "google", "profileUrl1"));
+		AbstractUserService userService = new CustomOidcUserService(memberRepository, notificationPreferenceRepository,
+			nicknameGenerator, roleRepository);
+		Map<String, Object> attributes = new HashMap<>();
+		attributes.put("email", "fineants1234@gmail.com");
+		attributes.put("profile", "profileUrl0");
+		attributes.put("sub", "123445");
+		OAuthAttribute googleOAuth = OAuthAttribute.of("google", attributes, "sub");
+		// when
+		Member member = userService.saveOrUpdate(googleOAuth);
+		// then
+		assertThat(member.getProfileUrl()).isEqualTo("profileUrl1");
+	}
+
+}


### PR DESCRIPTION
## 구현한 것

- oauth 계정이 로그인후 프로필을 변경했음에도 다시 소셜 로그인 시도시 프로필 url이 덮어씌우는 문제를 해결하였습니다.
