### PR TITLE
[hotfix] 종목 및 배당일정 최신화 기능 버그

### DIFF
--- a/.github/workflows/ci.cd.release.yml
+++ b/.github/workflows/ci.cd.release.yml
@@ -34,7 +34,7 @@ jobs:
           distribution: 'temurin'
       # gradle caching - 빌드 시간 향상
       - name: Gradle Caching
-        uses: actions/cache@v3
+        uses: actions/cache@v4.0.2
         with:
           # 캐시할 디렉토리 경로를 지정합니다.
           path: |

--- a/src/main/java/codesquad/fineants/global/init/SetupDataLoader.java
+++ b/src/main/java/codesquad/fineants/global/init/SetupDataLoader.java
@@ -65,8 +65,6 @@ public class SetupDataLoader implements ApplicationListener<ContextRefreshedEven
 		kisService.refreshCurrentPrice();
 		kisService.refreshClosingPrice();
 		log.info("애플리케이션 시작시 종목 현재가 및 종가 초기화 종료");
-		stockDividendService.initializeStockDividend();
-
 		alreadySetup = true;
 	}
 


### PR DESCRIPTION
## 구현한 것

- 서버 실행시 배당금 초기화 호출 제거
- 시크릿 정보에서 s3 프로파일별 경로 오타 수정
