### PR TITLE
[refactor] currentPriceRepository 개선

### DIFF
--- a/src/main/java/codesquad/fineants/domain/gainhistory/service/PortfolioGainHistoryService.java
+++ b/src/main/java/codesquad/fineants/domain/gainhistory/service/PortfolioGainHistoryService.java
@@ -11,7 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 import codesquad.fineants.domain.gainhistory.domain.dto.response.PortfolioGainHistoryCreateResponse;
 import codesquad.fineants.domain.gainhistory.domain.entity.PortfolioGainHistory;
 import codesquad.fineants.domain.gainhistory.repository.PortfolioGainHistoryRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import codesquad.fineants.domain.portfolio.repository.PortfolioRepository;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +24,7 @@ import lombok.extern.slf4j.Slf4j;
 public class PortfolioGainHistoryService {
 	private final PortfolioGainHistoryRepository repository;
 	private final PortfolioRepository portfolioRepository;
-	private final CurrentPriceRepository currentPriceRepository;
+	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@Transactional
 	@Scheduled(cron = "0 0 16 * * ?") // 매일 16시에 실행
@@ -39,7 +39,7 @@ public class PortfolioGainHistoryService {
 		List<PortfolioGainHistory> portfolioGainHistories = new ArrayList<>();
 
 		for (Portfolio portfolio : portfolios) {
-			portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRepository);
+			portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRedisRepository);
 			PortfolioGainHistory latestHistory =
 				repository.findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
 						portfolio.getId(), LocalDateTime.now())

--- a/src/main/java/codesquad/fineants/domain/holding/domain/chart/DividendChart.java
+++ b/src/main/java/codesquad/fineants/domain/holding/domain/chart/DividendChart.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioDividendChartItem;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import lombok.RequiredArgsConstructor;
 
@@ -14,7 +14,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class DividendChart {
 
-	private final CurrentPriceRepository manager;
+	private final CurrentPriceRedisRepository manager;
 
 	public List<PortfolioDividendChartItem> createBy(Portfolio portfolio, LocalDate currentLocalDate) {
 		portfolio.applyCurrentPriceAllHoldingsBy(manager);

--- a/src/main/java/codesquad/fineants/domain/holding/domain/chart/PieChart.java
+++ b/src/main/java/codesquad/fineants/domain/holding/domain/chart/PieChart.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioPieChartItem;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import lombok.RequiredArgsConstructor;
 
@@ -13,7 +13,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PieChart {
 
-	private final CurrentPriceRepository manager;
+	private final CurrentPriceRedisRepository manager;
 
 	public List<PortfolioPieChartItem> createBy(Portfolio portfolio) {
 		portfolio.applyCurrentPriceAllHoldingsBy(manager);

--- a/src/main/java/codesquad/fineants/domain/holding/domain/chart/SectorChart.java
+++ b/src/main/java/codesquad/fineants/domain/holding/domain/chart/SectorChart.java
@@ -5,14 +5,14 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioSectorChartItem;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
 public class SectorChart {
-	private final CurrentPriceRepository manager;
+	private final CurrentPriceRedisRepository manager;
 
 	public List<PortfolioSectorChartItem> createBy(Portfolio portfolio) {
 		portfolio.applyCurrentPriceAllHoldingsBy(manager);

--- a/src/main/java/codesquad/fineants/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/codesquad/fineants/domain/holding/domain/entity/PortfolioHolding.java
@@ -20,7 +20,7 @@ import codesquad.fineants.domain.common.money.RateDivision;
 import codesquad.fineants.domain.dividend.domain.entity.StockDividend;
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioPieChartItem;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import codesquad.fineants.domain.purchasehistory.domain.entity.PurchaseHistory;
 import codesquad.fineants.domain.stock.domain.entity.Stock;
@@ -208,7 +208,7 @@ public class PortfolioHolding extends BaseEntity {
 		return monthlyDividends;
 	}
 
-	public void applyCurrentPrice(CurrentPriceRepository manager) {
+	public void applyCurrentPrice(CurrentPriceRedisRepository manager) {
 		Bank bank = Bank.getInstance();
 		Currency to = Currency.KRW;
 		this.currentPrice = stock.getCurrentPrice(manager).reduce(bank, to);

--- a/src/main/java/codesquad/fineants/domain/holding/domain/factory/PortfolioDetailFactory.java
+++ b/src/main/java/codesquad/fineants/domain/holding/domain/factory/PortfolioDetailFactory.java
@@ -8,7 +8,7 @@ import codesquad.fineants.domain.gainhistory.domain.entity.PortfolioGainHistory;
 import codesquad.fineants.domain.gainhistory.repository.PortfolioGainHistoryRepository;
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioDetailRealTimeItem;
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioDetailResponse;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import lombok.RequiredArgsConstructor;
 
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PortfolioDetailFactory {
 
-	private final CurrentPriceRepository manager;
+	private final CurrentPriceRedisRepository manager;
 	private final PortfolioGainHistoryRepository portfolioGainHistoryRepository;
 
 	public PortfolioDetailResponse createPortfolioDetailItem(Portfolio portfolio) {

--- a/src/main/java/codesquad/fineants/domain/holding/domain/factory/PortfolioHoldingDetailFactory.java
+++ b/src/main/java/codesquad/fineants/domain/holding/domain/factory/PortfolioHoldingDetailFactory.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component;
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioHoldingItem;
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioHoldingRealTimeItem;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import lombok.RequiredArgsConstructor;
 
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PortfolioHoldingDetailFactory {
 
-	private final CurrentPriceRepository manager;
+	private final CurrentPriceRedisRepository manager;
 	private final ClosingPriceRepository closingPriceRepository;
 
 	public List<PortfolioHoldingItem> createPortfolioHoldingItems(Portfolio portfolio) {

--- a/src/main/java/codesquad/fineants/domain/kis/client/KisCurrentPrice.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisCurrentPrice.java
@@ -34,6 +34,14 @@ public class KisCurrentPrice {
 		return new KisCurrentPrice(tickerSymbol, price);
 	}
 
+	public String toRedisKey(String format) {
+		return String.format(format, tickerSymbol);
+	}
+
+	public String toRedisValue() {
+		return String.valueOf(price);
+	}
+
 	static class KisCurrentPriceDeserializer extends JsonDeserializer<KisCurrentPrice> {
 		@Override
 		public KisCurrentPrice deserialize(JsonParser parser, DeserializationContext context) throws

--- a/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRedisRepository.java
+++ b/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRedisRepository.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Repository
-public class CurrentPriceRepository {
+public class CurrentPriceRedisRepository implements PriceRepository {
 	private static final String CURRENT_PRICE_FORMAT = "cp:%s";
 	private final RedisTemplate<String, String> redisTemplate;
 	private final KisClient kisClient;
@@ -25,11 +25,10 @@ public class CurrentPriceRepository {
 	}
 
 	private KisCurrentPrice save(KisCurrentPrice currentPrice) {
-		redisTemplate.opsForValue()
-			.set(currentPrice.toRedisKey(CURRENT_PRICE_FORMAT), currentPrice.toRedisValue());
+		redisTemplate.opsForValue().set(currentPrice.toRedisKey(CURRENT_PRICE_FORMAT), currentPrice.toRedisValue());
 		return currentPrice;
 	}
-	
+
 	public Optional<Money> fetchCurrentPrice(String tickerSymbol) {
 		Optional<String> currentPrice = getCachedPrice(tickerSymbol);
 		if (currentPrice.isEmpty()) {

--- a/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRedisRepository.java
+++ b/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRedisRepository.java
@@ -20,16 +20,18 @@ public class CurrentPriceRedisRepository implements PriceRepository {
 	private final RedisTemplate<String, String> redisTemplate;
 	private final KisClient kisClient;
 
-	public void addCurrentPrice(KisCurrentPrice... currentPrices) {
-		Arrays.stream(currentPrices).forEach(this::save);
+	@Override
+	public void savePrice(KisCurrentPrice... currentPrices) {
+		Arrays.stream(currentPrices).forEach(this::savePrice);
 	}
 
-	private KisCurrentPrice save(KisCurrentPrice currentPrice) {
+	private KisCurrentPrice savePrice(KisCurrentPrice currentPrice) {
 		redisTemplate.opsForValue().set(currentPrice.toRedisKey(CURRENT_PRICE_FORMAT), currentPrice.toRedisValue());
 		return currentPrice;
 	}
 
-	public Optional<Money> fetchCurrentPrice(String tickerSymbol) {
+	@Override
+	public Optional<Money> fetchPriceBy(String tickerSymbol) {
 		Optional<String> currentPrice = getCachedPrice(tickerSymbol);
 		if (currentPrice.isEmpty()) {
 			Optional<KisCurrentPrice> kisCurrentPrice = fetchAndCachePriceFromKis(tickerSymbol);
@@ -47,6 +49,6 @@ public class CurrentPriceRedisRepository implements PriceRepository {
 	private Optional<KisCurrentPrice> fetchAndCachePriceFromKis(String tickerSymbol) {
 		return kisClient.fetchCurrentPrice(tickerSymbol)
 			.blockOptional(TIMEOUT)
-			.map(this::save);
+			.map(this::savePrice);
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRepository.java
+++ b/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRepository.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
 
 import codesquad.fineants.domain.common.money.Money;
 import codesquad.fineants.domain.kis.client.KisClient;
@@ -14,7 +14,7 @@ import codesquad.fineants.domain.kis.client.KisCurrentPrice;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Component
+@Repository
 public class CurrentPriceRepository {
 	private static final String CURRENT_PRICE_FORMAT = "cp:%s";
 	private final RedisTemplate<String, String> redisTemplate;
@@ -26,14 +26,10 @@ public class CurrentPriceRepository {
 
 	private KisCurrentPrice save(KisCurrentPrice currentPrice) {
 		redisTemplate.opsForValue()
-			.set(getRedisKey(currentPrice.getTickerSymbol()), String.valueOf(currentPrice.getPrice()));
+			.set(currentPrice.toRedisKey(CURRENT_PRICE_FORMAT), currentPrice.toRedisValue());
 		return currentPrice;
 	}
-
-	private String getRedisKey(String tickerSymbol) {
-		return String.format(CURRENT_PRICE_FORMAT, tickerSymbol);
-	}
-
+	
 	public Optional<Money> fetchCurrentPrice(String tickerSymbol) {
 		Optional<String> currentPrice = getCachedPrice(tickerSymbol);
 		if (currentPrice.isEmpty()) {

--- a/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRepository.java
+++ b/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRepository.java
@@ -2,14 +2,13 @@ package codesquad.fineants.domain.kis.repository;
 
 import static codesquad.fineants.domain.kis.service.KisService.*;
 
-import java.util.List;
+import java.util.Arrays;
 import java.util.Optional;
 
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import codesquad.fineants.domain.common.money.Money;
-import codesquad.fineants.domain.kis.aop.AccessTokenAspect;
 import codesquad.fineants.domain.kis.client.KisClient;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
 import lombok.RequiredArgsConstructor;
@@ -20,24 +19,19 @@ public class CurrentPriceRepository {
 	private static final String CURRENT_PRICE_FORMAT = "cp:%s";
 	private final RedisTemplate<String, String> redisTemplate;
 	private final KisClient kisClient;
-	private final AccessTokenAspect accessTokenAspect;
 
-	public void addCurrentPrice(KisCurrentPrice currentPrice) {
-		addCurrentPrice(List.of(currentPrice));
-	}
-
-	public void addCurrentPrice(List<KisCurrentPrice> currentPrices) {
-		currentPrices.forEach(currentPrice ->
+	public void addCurrentPrice(KisCurrentPrice... currentPrices) {
+		Arrays.stream(currentPrices).forEach(currentPrice ->
 			redisTemplate.opsForValue()
 				.set(String.format(CURRENT_PRICE_FORMAT, currentPrice.getTickerSymbol()),
 					String.valueOf(currentPrice.getPrice())));
 	}
 
-	public Optional<Money> getCurrentPrice(String tickerSymbol) {
+	public Optional<Money> fetchCurrentPrice(String tickerSymbol) {
 		String currentPrice = redisTemplate.opsForValue().get(String.format(CURRENT_PRICE_FORMAT, tickerSymbol));
 		if (currentPrice == null) {
 			handleCurrentPrice(tickerSymbol);
-			return getCurrentPrice(tickerSymbol);
+			return fetchCurrentPrice(tickerSymbol);
 		}
 		return Optional.of(Money.won(currentPrice));
 	}

--- a/src/main/java/codesquad/fineants/domain/kis/repository/PriceRepository.java
+++ b/src/main/java/codesquad/fineants/domain/kis/repository/PriceRepository.java
@@ -1,5 +1,12 @@
 package codesquad.fineants.domain.kis.repository;
 
-public interface PriceRepository {
+import java.util.Optional;
 
+import codesquad.fineants.domain.common.money.Money;
+import codesquad.fineants.domain.kis.client.KisCurrentPrice;
+
+public interface PriceRepository {
+	void savePrice(KisCurrentPrice... currentPrices);
+
+	Optional<Money> fetchPriceBy(String tickerSymbol);
 }

--- a/src/main/java/codesquad/fineants/domain/kis/repository/PriceRepository.java
+++ b/src/main/java/codesquad/fineants/domain/kis/repository/PriceRepository.java
@@ -1,0 +1,5 @@
+package codesquad.fineants.domain.kis.repository;
+
+public interface PriceRepository {
+
+}

--- a/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
@@ -111,7 +111,7 @@ public class KisService {
 			.filter(Objects::nonNull)
 			.toList();
 
-		prices.forEach(currentPriceRedisRepository::addCurrentPrice);
+		prices.forEach(currentPriceRedisRepository::savePrice);
 
 		log.info("종목 현재가 {}개중 {}개 갱신", tickerSymbols.size(), prices.size());
 		return prices;

--- a/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
@@ -29,7 +29,7 @@ import codesquad.fineants.domain.kis.domain.dto.response.KisDividendWrapper;
 import codesquad.fineants.domain.kis.domain.dto.response.KisIpo;
 import codesquad.fineants.domain.kis.domain.dto.response.KisSearchStockInfo;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.kis.repository.HolidayRepository;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.notification.event.publisher.PortfolioPublisher;
@@ -56,7 +56,7 @@ public class KisService {
 	private final KisClient kisClient;
 	private final PortfolioHoldingRepository portFolioHoldingRepository;
 	private final KisAccessTokenRepository manager;
-	private final CurrentPriceRepository currentPriceRepository;
+	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 	private final ClosingPriceRepository closingPriceRepository;
 	private final HolidayRepository holidayRepository;
 	private final StockTargetPricePublisher stockTargetPricePublisher;
@@ -111,7 +111,7 @@ public class KisService {
 			.filter(Objects::nonNull)
 			.toList();
 
-		prices.forEach(currentPriceRepository::addCurrentPrice);
+		prices.forEach(currentPriceRedisRepository::addCurrentPrice);
 
 		log.info("종목 현재가 {}개중 {}개 갱신", tickerSymbols.size(), prices.size());
 		return prices;

--- a/src/main/java/codesquad/fineants/domain/notification/config/NotificationConfig.java
+++ b/src/main/java/codesquad/fineants/domain/notification/config/NotificationConfig.java
@@ -6,7 +6,7 @@ import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.notification.domain.entity.policy.ConditionEvaluator;
 import codesquad.fineants.domain.notification.domain.entity.policy.TargetGainNotificationEvaluator;
 import codesquad.fineants.domain.notification.domain.entity.policy.maxloss.MaxLossAccountPreferenceCondition;
@@ -36,7 +36,7 @@ import lombok.RequiredArgsConstructor;
 public class NotificationConfig {
 
 	private final NotificationSentRepository sentManager;
-	private final CurrentPriceRepository currentPriceRepository;
+	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 	private final FirebaseNotificationProvider firebaseNotificationProvider;
 
 	@Bean
@@ -82,7 +82,7 @@ public class NotificationConfig {
 	public TargetPriceNotificationPolicy targetPriceNotificationPolicy() {
 		return new TargetPriceNotificationPolicy(
 			List.of(
-				new TargetPriceCondition(currentPriceRepository),
+				new TargetPriceCondition(currentPriceRedisRepository),
 				new TargetPriceActiveCondition(),
 				new TargetPriceSentHistoryCondition(sentManager)
 			),

--- a/src/main/java/codesquad/fineants/domain/notification/domain/entity/policy/target_price/TargetPriceCondition.java
+++ b/src/main/java/codesquad/fineants/domain/notification/domain/entity/policy/target_price/TargetPriceCondition.java
@@ -2,13 +2,13 @@ package codesquad.fineants.domain.notification.domain.entity.policy.target_price
 
 import codesquad.fineants.domain.notification.domain.entity.policy.NotificationCondition;
 import codesquad.fineants.domain.stock_target_price.domain.entity.TargetPriceNotification;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 public class TargetPriceCondition implements NotificationCondition<TargetPriceNotification> {
 
-	private final CurrentPriceRepository manager;
+	private final CurrentPriceRedisRepository manager;
 
 	@Override
 	public boolean isSatisfiedBy(TargetPriceNotification targetPriceNotification) {

--- a/src/main/java/codesquad/fineants/domain/notification/service/NotificationService.java
+++ b/src/main/java/codesquad/fineants/domain/notification/service/NotificationService.java
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.fineants.domain.common.notification.Notifiable;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.notification.domain.dto.request.NotificationSaveRequest;
@@ -50,7 +50,7 @@ public class NotificationService {
 	private final PortfolioRepository portfolioRepository;
 	private final NotificationRepository notificationRepository;
 	private final MemberRepository memberRepository;
-	private final CurrentPriceRepository currentPriceRepository;
+	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 	private final NotificationSentRepository sentManager;
 	private final StockTargetPriceRepository stockTargetPriceRepository;
 	private final TargetGainNotificationPolicy targetGainNotificationPolicy;
@@ -95,7 +95,7 @@ public class NotificationService {
 	public NotifyMessageResponse notifyTargetGainAll() {
 		// 모든 회원의 포트폴리오 중에서 입력으로 받은 종목들을 가진 포트폴리오들을 조회
 		List<Notifiable> portfolios = portfolioRepository.findAllWithAll().stream()
-			.peek(portfolio -> portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRepository))
+			.peek(portfolio -> portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRedisRepository))
 			.collect(Collectors.toList());
 		Consumer<Long> sentFunction = sentManager::addTargetGainSendHistory;
 		return PortfolioNotifyMessagesResponse.create(
@@ -111,7 +111,7 @@ public class NotificationService {
 	@Transactional
 	public NotifyMessageResponse notifyTargetGain(Long portfolioId) {
 		Portfolio portfolio = portfolioRepository.findByPortfolioIdWithAll(portfolioId).stream()
-			.peek(p -> p.applyCurrentPriceAllHoldingsBy(currentPriceRepository))
+			.peek(p -> p.applyCurrentPriceAllHoldingsBy(currentPriceRedisRepository))
 			.findFirst()
 			.orElseThrow(() -> new FineAntsException(PortfolioErrorCode.NOT_FOUND_PORTFOLIO));
 		Consumer<Long> sentFunction = sentManager::addTargetGainSendHistory;
@@ -171,7 +171,7 @@ public class NotificationService {
 	@Transactional
 	public NotifyMessageResponse notifyMaxLossAll() {
 		List<Notifiable> portfolios = portfolioRepository.findAllWithAll().stream()
-			.peek(portfolio -> portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRepository))
+			.peek(portfolio -> portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRedisRepository))
 			.collect(Collectors.toList());
 		Consumer<Long> sentFunction = sentManager::addMaxLossSendHistory;
 		return PortfolioNotifyMessagesResponse.create(
@@ -187,7 +187,7 @@ public class NotificationService {
 	@Transactional
 	public NotifyMessageResponse notifyMaxLoss(Long portfolioId) {
 		Portfolio portfolio = portfolioRepository.findByPortfolioIdWithAll(portfolioId)
-			.stream().peek(p -> p.applyCurrentPriceAllHoldingsBy(currentPriceRepository))
+			.stream().peek(p -> p.applyCurrentPriceAllHoldingsBy(currentPriceRedisRepository))
 			.findAny()
 			.orElseThrow(() -> new FineAntsException(PortfolioErrorCode.NOT_FOUND_PORTFOLIO));
 		Consumer<Long> sentFunction = sentManager::addMaxLossSendHistory;

--- a/src/main/java/codesquad/fineants/domain/portfolio/domain/dto/response/PortfoliosResponse.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/domain/dto/response/PortfoliosResponse.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import codesquad.fineants.domain.gainhistory.domain.entity.PortfolioGainHistory;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -24,12 +24,12 @@ public class PortfoliosResponse {
 
 	public static PortfoliosResponse of(List<Portfolio> portfolios,
 		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap,
-		CurrentPriceRepository manager) {
+		CurrentPriceRedisRepository manager) {
 		return new PortfoliosResponse(getContents(portfolios, portfolioGainHistoryMap, manager));
 	}
 
 	private static List<PortFolioItem> getContents(List<Portfolio> portfolios,
-		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap, CurrentPriceRepository manager) {
+		Map<Portfolio, PortfolioGainHistory> portfolioGainHistoryMap, CurrentPriceRedisRepository manager) {
 		return portfolios.stream()
 			.map(portfolio -> {
 				portfolio.applyCurrentPriceAllHoldingsBy(manager);

--- a/src/main/java/codesquad/fineants/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/domain/entity/Portfolio.java
@@ -25,7 +25,7 @@ import codesquad.fineants.domain.holding.domain.dto.response.PortfolioDividendCh
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioPieChartItem;
 import codesquad.fineants.domain.holding.domain.dto.response.PortfolioSectorChartItem;
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.notification.domain.dto.response.NotifyMessage;
 import codesquad.fineants.domain.notification.domain.entity.type.NotificationType;
@@ -287,7 +287,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	}
 
 	// 포트폴리오 모든 종목들에 주식 현재가 적용
-	public void applyCurrentPriceAllHoldingsBy(CurrentPriceRepository manager) {
+	public void applyCurrentPriceAllHoldingsBy(CurrentPriceRedisRepository manager) {
 		for (PortfolioHolding portfolioHolding : portfolioHoldings) {
 			portfolioHolding.applyCurrentPrice(manager);
 			log.debug("portfolioHolding : {}, purchaseHistory : {}", portfolioHolding,

--- a/src/main/java/codesquad/fineants/domain/portfolio/service/DashboardService.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/service/DashboardService.java
@@ -19,7 +19,7 @@ import codesquad.fineants.domain.common.money.Money;
 import codesquad.fineants.domain.common.money.RateDivision;
 import codesquad.fineants.domain.gainhistory.domain.entity.PortfolioGainHistory;
 import codesquad.fineants.domain.gainhistory.repository.PortfolioGainHistoryRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.portfolio.domain.dto.response.DashboardLineChartResponse;
@@ -38,7 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 public class DashboardService {
 	private final PortfolioRepository portfolioRepository;
 	private final MemberRepository memberRepository;
-	private final CurrentPriceRepository currentPriceRepository;
+	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 	private final PortfolioGainHistoryRepository portfolioGainHistoryRepository;
 
 	@Transactional(readOnly = true)
@@ -56,7 +56,7 @@ public class DashboardService {
 			return OverviewResponse.empty(member.getNickname());
 		}
 		for (Portfolio portfolio : portfolios) {
-			portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRepository);
+			portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRedisRepository);
 			totalValuation = totalValuation.plus(portfolio.calculateTotalAsset());
 			totalCurrentValuation = totalCurrentValuation.plus(portfolio.calculateTotalCurrentValuation());
 			totalInvestment = totalInvestment.plus(portfolio.calculateTotalInvestmentAmount());
@@ -86,7 +86,7 @@ public class DashboardService {
 		}
 		Expression totalValuation = Money.wonZero(); // 평가 금액 + 현금
 		for (Portfolio portfolio : portfolios) {
-			portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRepository);
+			portfolio.applyCurrentPriceAllHoldingsBy(currentPriceRedisRepository);
 			totalValuation = totalValuation.plus(portfolio.calculateTotalAsset());
 		}
 		List<DashboardPieChartResponse> pieChartResponses = new ArrayList<>();

--- a/src/main/java/codesquad/fineants/domain/portfolio/service/PortFolioService.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/service/PortFolioService.java
@@ -13,7 +13,7 @@ import codesquad.fineants.domain.gainhistory.domain.entity.PortfolioGainHistory;
 import codesquad.fineants.domain.gainhistory.repository.PortfolioGainHistoryRepository;
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.portfolio.domain.dto.request.PortfolioCreateRequest;
@@ -48,7 +48,7 @@ public class PortFolioService {
 	private final PortfolioHoldingRepository portfolioHoldingRepository;
 	private final PurchaseHistoryRepository purchaseHistoryRepository;
 	private final PortfolioGainHistoryRepository portfolioGainHistoryRepository;
-	private final CurrentPriceRepository currentPriceRepository;
+	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 	private final PortfolioPropertiesRepository portfolioPropertiesRepository;
 
 	@Transactional
@@ -160,6 +160,6 @@ public class PortFolioService {
 						.orElseGet(() -> PortfolioGainHistory.empty(portfolio))
 			));
 
-		return PortfoliosResponse.of(portfolios, portfolioGainHistoryMap, currentPriceRepository);
+		return PortfoliosResponse.of(portfolios, portfolioGainHistoryMap, currentPriceRedisRepository);
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/stock/domain/dto/response/StockResponse.java
+++ b/src/main/java/codesquad/fineants/domain/stock/domain/dto/response/StockResponse.java
@@ -9,7 +9,7 @@ import codesquad.fineants.domain.common.money.Money;
 import codesquad.fineants.domain.common.money.Percentage;
 import codesquad.fineants.domain.stock.domain.entity.Market;
 import codesquad.fineants.domain.stock.domain.entity.Stock;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -59,7 +59,7 @@ public class StockResponse {
 			.build();
 	}
 
-	public static StockResponse of(Stock stock, CurrentPriceRepository currentPriceRepository,
+	public static StockResponse of(Stock stock, CurrentPriceRedisRepository currentPriceRedisRepository,
 		ClosingPriceRepository closingPriceRepository) {
 		Bank bank = Bank.getInstance();
 		Currency to = Currency.KRW;
@@ -69,14 +69,14 @@ public class StockResponse {
 			.companyName(stock.getCompanyName())
 			.companyNameEng(stock.getCompanyNameEng())
 			.market(stock.getMarket())
-			.currentPrice(stock.getCurrentPrice(currentPriceRepository).reduce(bank, to))
-			.dailyChange(stock.getDailyChange(currentPriceRepository, closingPriceRepository).reduce(bank, to))
-			.dailyChangeRate(stock.getDailyChangeRate(currentPriceRepository, closingPriceRepository).toPercentage(
+			.currentPrice(stock.getCurrentPrice(currentPriceRedisRepository).reduce(bank, to))
+			.dailyChange(stock.getDailyChange(currentPriceRedisRepository, closingPriceRepository).reduce(bank, to))
+			.dailyChangeRate(stock.getDailyChangeRate(currentPriceRedisRepository, closingPriceRepository).toPercentage(
 				bank, to))
 			.sector(stock.getSector())
 			.annualDividend(stock.getAnnualDividend().reduce(bank, to))
 			.annualDividendYield(
-				stock.getAnnualDividendYield(currentPriceRepository).toPercentage(bank, to))
+				stock.getAnnualDividendYield(currentPriceRedisRepository).toPercentage(bank, to))
 			.dividendMonths(stock.getDividendMonths())
 			.build();
 	}

--- a/src/main/java/codesquad/fineants/domain/stock/domain/entity/Stock.java
+++ b/src/main/java/codesquad/fineants/domain/stock/domain/entity/Stock.java
@@ -181,7 +181,7 @@ public class Stock extends BaseEntity {
 
 	public RateDivision getDailyChangeRate(CurrentPriceRedisRepository currentPriceRedisRepository,
 		ClosingPriceRepository closingPriceRepository) {
-		Money currentPrice = currentPriceRedisRepository.fetchCurrentPrice(tickerSymbol).orElse(null);
+		Money currentPrice = currentPriceRedisRepository.fetchPriceBy(tickerSymbol).orElse(null);
 		Money lastDayClosingPrice = closingPriceRepository.getClosingPrice(tickerSymbol).orElse(null);
 		if (currentPrice == null || lastDayClosingPrice == null) {
 			return null;
@@ -190,7 +190,7 @@ public class Stock extends BaseEntity {
 	}
 
 	public Expression getCurrentPrice(CurrentPriceRedisRepository manager) {
-		return manager.fetchCurrentPrice(tickerSymbol).orElseGet(Money::zero);
+		return manager.fetchPriceBy(tickerSymbol).orElseGet(Money::zero);
 	}
 
 	public Expression getClosingPrice(ClosingPriceRepository manager) {

--- a/src/main/java/codesquad/fineants/domain/stock/domain/entity/Stock.java
+++ b/src/main/java/codesquad/fineants/domain/stock/domain/entity/Stock.java
@@ -181,7 +181,7 @@ public class Stock extends BaseEntity {
 
 	public RateDivision getDailyChangeRate(CurrentPriceRepository currentPriceRepository,
 		ClosingPriceRepository closingPriceRepository) {
-		Money currentPrice = currentPriceRepository.getCurrentPrice(tickerSymbol).orElse(null);
+		Money currentPrice = currentPriceRepository.fetchCurrentPrice(tickerSymbol).orElse(null);
 		Money lastDayClosingPrice = closingPriceRepository.getClosingPrice(tickerSymbol).orElse(null);
 		if (currentPrice == null || lastDayClosingPrice == null) {
 			return null;
@@ -190,7 +190,7 @@ public class Stock extends BaseEntity {
 	}
 
 	public Expression getCurrentPrice(CurrentPriceRepository manager) {
-		return manager.getCurrentPrice(tickerSymbol).orElseGet(Money::zero);
+		return manager.fetchCurrentPrice(tickerSymbol).orElseGet(Money::zero);
 	}
 
 	public Expression getClosingPrice(ClosingPriceRepository manager) {

--- a/src/main/java/codesquad/fineants/domain/stock/service/StockService.java
+++ b/src/main/java/codesquad/fineants/domain/stock/service/StockService.java
@@ -8,7 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.fineants.domain.dividend.repository.StockDividendRepository;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.stock.domain.dto.request.StockSearchRequest;
 import codesquad.fineants.domain.stock.domain.dto.response.StockReloadResponse;
 import codesquad.fineants.domain.stock.domain.dto.response.StockResponse;
@@ -28,7 +28,7 @@ import lombok.extern.slf4j.Slf4j;
 @Service
 public class StockService {
 	private final StockRepository stockRepository;
-	private final CurrentPriceRepository currentPriceRepository;
+	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 	private final ClosingPriceRepository closingPriceRepository;
 	private final AmazonS3StockService amazonS3StockService;
 	private final AmazonS3DividendService amazonS3DividendService;
@@ -55,7 +55,7 @@ public class StockService {
 	public StockResponse getDetailedStock(String tickerSymbol) {
 		Stock stock = stockRepository.findByTickerSymbol(tickerSymbol)
 			.orElseThrow(() -> new NotFoundResourceException(StockErrorCode.NOT_FOUND_STOCK));
-		return StockResponse.of(stock, currentPriceRepository, closingPriceRepository);
+		return StockResponse.of(stock, currentPriceRedisRepository, closingPriceRepository);
 	}
 
 	@Scheduled(cron = "${cron.expression.reload-stocks:0 0 8 * * ?}") // 매일 오전 8시 (초, 분, 시간)

--- a/src/main/java/codesquad/fineants/domain/stock_target_price/domain/entity/StockTargetPrice.java
+++ b/src/main/java/codesquad/fineants/domain/stock_target_price/domain/entity/StockTargetPrice.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import codesquad.fineants.domain.BaseEntity;
 import codesquad.fineants.domain.common.money.Expression;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.stock.domain.entity.Stock;
 import jakarta.persistence.Entity;
@@ -77,7 +77,7 @@ public class StockTargetPrice extends BaseEntity {
 		this.isActive = isActive;
 	}
 
-	public Expression getCurrentPrice(CurrentPriceRepository manager) {
+	public Expression getCurrentPrice(CurrentPriceRedisRepository manager) {
 		return stock.getCurrentPrice(manager);
 	}
 

--- a/src/main/java/codesquad/fineants/domain/stock_target_price/domain/entity/TargetPriceNotification.java
+++ b/src/main/java/codesquad/fineants/domain/stock_target_price/domain/entity/TargetPriceNotification.java
@@ -7,7 +7,7 @@ import codesquad.fineants.domain.common.money.Expression;
 import codesquad.fineants.domain.common.money.Money;
 import codesquad.fineants.domain.common.money.MoneyConverter;
 import codesquad.fineants.domain.common.notification.Notifiable;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.notification.domain.dto.response.NotifyMessage;
 import codesquad.fineants.domain.notification.domain.entity.type.NotificationType;
 import codesquad.fineants.domain.notificationpreference.domain.entity.NotificationPreference;
@@ -65,7 +65,7 @@ public class TargetPriceNotification extends BaseEntity implements Notifiable {
 		StockTargetPrice stockTargetPrice) {
 		return new TargetPriceNotification(LocalDateTime.now(), null, id, targetPrice, stockTargetPrice);
 	}
-	
+
 	public String getReferenceId() {
 		return stockTargetPrice.getStock().getTickerSymbol();
 	}
@@ -74,7 +74,7 @@ public class TargetPriceNotification extends BaseEntity implements Notifiable {
 		return stockTargetPrice.getIsActive();
 	}
 
-	public boolean isSameTargetPrice(CurrentPriceRepository manager) {
+	public boolean isSameTargetPrice(CurrentPriceRedisRepository manager) {
 		Expression currentPrice = stockTargetPrice.getCurrentPrice(manager);
 		return targetPrice.compareTo(currentPrice) == 0;
 	}

--- a/src/main/java/codesquad/fineants/domain/watchlist/domain/dto/response/ReadWatchListResponse.java
+++ b/src/main/java/codesquad/fineants/domain/watchlist/domain/dto/response/ReadWatchListResponse.java
@@ -10,7 +10,7 @@ import codesquad.fineants.domain.common.money.Currency;
 import codesquad.fineants.domain.common.money.Money;
 import codesquad.fineants.domain.common.money.Percentage;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.stock.domain.entity.Stock;
 import codesquad.fineants.domain.watchlist.domain.entity.WatchStock;
 import lombok.AllArgsConstructor;
@@ -40,7 +40,7 @@ public class ReadWatchListResponse {
 	}
 
 	public static ReadWatchListResponse.WatchStockResponse from(WatchStock watchStock,
-		CurrentPriceRepository currentPriceRepository, ClosingPriceRepository closingPriceRepository) {
+		CurrentPriceRedisRepository currentPriceRedisRepository, ClosingPriceRepository closingPriceRepository) {
 		Bank bank = Bank.getInstance();
 		Currency to = Currency.KRW;
 		Stock stock = watchStock.getStock();
@@ -48,15 +48,15 @@ public class ReadWatchListResponse {
 			.id(watchStock.getId())
 			.companyName(stock.getCompanyName())
 			.tickerSymbol(stock.getTickerSymbol())
-			.currentPrice(stock.getCurrentPrice(currentPriceRepository).reduce(bank, to))
+			.currentPrice(stock.getCurrentPrice(currentPriceRedisRepository).reduce(bank, to))
 			.dailyChange(stock
-				.getDailyChange(currentPriceRepository, closingPriceRepository)
+				.getDailyChange(currentPriceRedisRepository, closingPriceRepository)
 				.reduce(bank, to))
 			.dailyChangeRate(stock
-				.getDailyChangeRate(currentPriceRepository, closingPriceRepository)
+				.getDailyChangeRate(currentPriceRedisRepository, closingPriceRepository)
 				.toPercentage(bank, to))
 			.annualDividendYield(stock
-				.getAnnualDividendYield(currentPriceRepository)
+				.getAnnualDividendYield(currentPriceRedisRepository)
 				.toPercentage(bank, to))
 			.sector(stock.getSector())
 			.dateAdded(watchStock.getCreateAt())

--- a/src/main/java/codesquad/fineants/domain/watchlist/service/WatchListService.java
+++ b/src/main/java/codesquad/fineants/domain/watchlist/service/WatchListService.java
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.stock.repository.StockRepository;
@@ -45,10 +45,10 @@ public class WatchListService {
 	private final MemberRepository memberRepository;
 	private final StockRepository stockRepository;
 	private final WatchStockRepository watchStockRepository;
-	private final CurrentPriceRepository currentPriceRepository;
+	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 	private final ClosingPriceRepository closingPriceRepository;
 	private final WatchStockEventPublisher watchStockEventPublisher;
-	
+
 	@Transactional
 	@Secured("ROLE_USER")
 	public CreateWatchListResponse createWatchList(Long memberId, CreateWatchListRequest request) {
@@ -79,7 +79,8 @@ public class WatchListService {
 		List<WatchStock> watchStocks = watchStockRepository.findWithStockAndDividendsByWatchList(watchList);
 
 		List<ReadWatchListResponse.WatchStockResponse> watchStockResponses = watchStocks.stream()
-			.map(watchStock -> ReadWatchListResponse.from(watchStock, currentPriceRepository, closingPriceRepository))
+			.map(watchStock -> ReadWatchListResponse.from(watchStock, currentPriceRedisRepository,
+				closingPriceRepository))
 			.toList();
 		return new ReadWatchListResponse(watchList.getName(), watchStockResponses);
 	}

--- a/src/test/java/codesquad/fineants/docs/stock/StockRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/docs/stock/StockRestControllerDocsTest.java
@@ -288,7 +288,7 @@ public class StockRestControllerDocsTest extends RestDocsSupport {
 
 		Money currentPrice = Money.won(68000L);
 		Money closingPrice = Money.won(80000L);
-		given(currentPriceRepository.getCurrentPrice(stock.getTickerSymbol()))
+		given(currentPriceRepository.fetchCurrentPrice(stock.getTickerSymbol()))
 			.willReturn(Optional.of(currentPrice));
 		given(closingPriceRepository.getClosingPrice(stock.getTickerSymbol()))
 			.willReturn(Optional.of(closingPrice));

--- a/src/test/java/codesquad/fineants/docs/stock/StockRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/docs/stock/StockRestControllerDocsTest.java
@@ -288,7 +288,7 @@ public class StockRestControllerDocsTest extends RestDocsSupport {
 
 		Money currentPrice = Money.won(68000L);
 		Money closingPrice = Money.won(80000L);
-		given(currentPriceRedisRepository.fetchCurrentPrice(stock.getTickerSymbol()))
+		given(currentPriceRedisRepository.fetchPriceBy(stock.getTickerSymbol()))
 			.willReturn(Optional.of(currentPrice));
 		given(closingPriceRepository.getClosingPrice(stock.getTickerSymbol()))
 			.willReturn(Optional.of(closingPrice));

--- a/src/test/java/codesquad/fineants/docs/stock/StockRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/docs/stock/StockRestControllerDocsTest.java
@@ -30,7 +30,7 @@ import codesquad.fineants.domain.common.money.Percentage;
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.kis.domain.dto.response.DividendItem;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import codesquad.fineants.domain.stock.controller.StockRestController;
 import codesquad.fineants.domain.stock.domain.dto.request.StockSearchRequest;
@@ -283,12 +283,12 @@ public class StockRestControllerDocsTest extends RestDocsSupport {
 		holding.addPurchaseHistory(createPurchaseHistory(holding, LocalDateTime.now()));
 		portfolio.addHolding(holding);
 
-		CurrentPriceRepository currentPriceRepository = Mockito.mock(CurrentPriceRepository.class);
+		CurrentPriceRedisRepository currentPriceRedisRepository = Mockito.mock(CurrentPriceRedisRepository.class);
 		ClosingPriceRepository closingPriceRepository = Mockito.mock(ClosingPriceRepository.class);
 
 		Money currentPrice = Money.won(68000L);
 		Money closingPrice = Money.won(80000L);
-		given(currentPriceRepository.fetchCurrentPrice(stock.getTickerSymbol()))
+		given(currentPriceRedisRepository.fetchCurrentPrice(stock.getTickerSymbol()))
 			.willReturn(Optional.of(currentPrice));
 		given(closingPriceRepository.getClosingPrice(stock.getTickerSymbol()))
 			.willReturn(Optional.of(closingPrice));

--- a/src/test/java/codesquad/fineants/domain/gainhistory/service/PortfolioGainHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/gainhistory/service/PortfolioGainHistoryServiceTest.java
@@ -72,7 +72,7 @@ class PortfolioGainHistoryServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePricePerShare, memo, portfolioHolding));
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
 
 		// when
 		PortfolioGainHistoryCreateResponse response = service.addPortfolioGainHistory();

--- a/src/test/java/codesquad/fineants/domain/gainhistory/service/PortfolioGainHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/gainhistory/service/PortfolioGainHistoryServiceTest.java
@@ -19,7 +19,7 @@ import codesquad.fineants.domain.gainhistory.repository.PortfolioGainHistoryRepo
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
@@ -52,7 +52,7 @@ class PortfolioGainHistoryServiceTest extends AbstractContainerBaseTest {
 	private PurchaseHistoryRepository purchaseHistoryRepository;
 
 	@Autowired
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	// TODO: Kis 접근 토큰 모킹 처리
 	@DisplayName("모든 포트폴리오의 손익 내역을 추가한다")
@@ -72,7 +72,7 @@ class PortfolioGainHistoryServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePricePerShare, memo, portfolioHolding));
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
 
 		// when
 		PortfolioGainHistoryCreateResponse response = service.addPortfolioGainHistory();

--- a/src/test/java/codesquad/fineants/domain/holding/controller/PortfolioHoldingRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/domain/holding/controller/PortfolioHoldingRestControllerTest.java
@@ -343,7 +343,7 @@ class PortfolioHoldingRestControllerTest extends ControllerTestSupport {
 		portfolioHolding.addPurchaseHistory(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, portfolioHolding));
 
-		given(currentPriceRepository.getCurrentPrice(stock.getTickerSymbol()))
+		given(currentPriceRepository.fetchCurrentPrice(stock.getTickerSymbol()))
 			.willReturn(Optional.of(portfolioHolding.getCurrentPrice()));
 
 		PieChart pieChart = new PieChart(currentPriceRepository);

--- a/src/test/java/codesquad/fineants/domain/holding/controller/PortfolioHoldingRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/domain/holding/controller/PortfolioHoldingRestControllerTest.java
@@ -46,7 +46,7 @@ import codesquad.fineants.domain.holding.domain.dto.response.PortfolioStockDelet
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.service.PortfolioHoldingService;
 import codesquad.fineants.domain.holding.service.PortfolioObservableService;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import codesquad.fineants.domain.portfolio.service.PortFolioService;
@@ -68,7 +68,7 @@ class PortfolioHoldingRestControllerTest extends ControllerTestSupport {
 	private PortFolioService portFolioService;
 
 	@MockBean
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@Override
 	protected Object initController() {
@@ -343,12 +343,12 @@ class PortfolioHoldingRestControllerTest extends ControllerTestSupport {
 		portfolioHolding.addPurchaseHistory(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, portfolioHolding));
 
-		given(currentPriceRepository.fetchCurrentPrice(stock.getTickerSymbol()))
+		given(currentPriceRedisRepository.fetchCurrentPrice(stock.getTickerSymbol()))
 			.willReturn(Optional.of(portfolioHolding.getCurrentPrice()));
 
-		PieChart pieChart = new PieChart(currentPriceRepository);
-		DividendChart dividendChart = new DividendChart(currentPriceRepository);
-		SectorChart sectorChart = new SectorChart(currentPriceRepository);
+		PieChart pieChart = new PieChart(currentPriceRedisRepository);
+		DividendChart dividendChart = new DividendChart(currentPriceRedisRepository);
+		SectorChart sectorChart = new SectorChart(currentPriceRedisRepository);
 
 		PortfolioDetails portfolioDetails = PortfolioDetails.from(portfolio);
 		List<PortfolioPieChartItem> pieChartItems = pieChart.createBy(portfolio);

--- a/src/test/java/codesquad/fineants/domain/holding/controller/PortfolioHoldingRestControllerTest.java
+++ b/src/test/java/codesquad/fineants/domain/holding/controller/PortfolioHoldingRestControllerTest.java
@@ -343,7 +343,7 @@ class PortfolioHoldingRestControllerTest extends ControllerTestSupport {
 		portfolioHolding.addPurchaseHistory(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, portfolioHolding));
 
-		given(currentPriceRedisRepository.fetchCurrentPrice(stock.getTickerSymbol()))
+		given(currentPriceRedisRepository.fetchPriceBy(stock.getTickerSymbol()))
 			.willReturn(Optional.of(portfolioHolding.getCurrentPrice()));
 
 		PieChart pieChart = new PieChart(currentPriceRedisRepository);

--- a/src/test/java/codesquad/fineants/domain/holding/service/PortfolioHoldingServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/holding/service/PortfolioHoldingServiceTest.java
@@ -41,7 +41,7 @@ import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
 import codesquad.fineants.domain.kis.aop.AccessTokenAspect;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
@@ -82,7 +82,7 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 	private StockRepository stockRepository;
 
 	@Autowired
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@Autowired
 	private ClosingPriceRepository closingPriceRepository;
@@ -111,7 +111,7 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, portfolioHolding));
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create("005930", 60000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 60000L));
 		closingPriceRepository.addPrice("005930", 50000);
 
 		setAuthentication(member);
@@ -244,7 +244,7 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, portfolioHolding));
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create("005930", 60000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 60000L));
 		closingPriceRepository.addPrice("005930", 50000);
 
 		setAuthentication(member);
@@ -392,8 +392,8 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, portfolioHolding2));
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create("005930", 60000L));
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create("035720", 60000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 60000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("035720", 60000L));
 		closingPriceRepository.addPrice("005930", 50000);
 		closingPriceRepository.addPrice("035720", 50000);
 

--- a/src/test/java/codesquad/fineants/domain/holding/service/PortfolioHoldingServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/holding/service/PortfolioHoldingServiceTest.java
@@ -111,7 +111,7 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, portfolioHolding));
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 60000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create("005930", 60000L));
 		closingPriceRepository.addPrice("005930", 50000);
 
 		setAuthentication(member);
@@ -244,7 +244,7 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, portfolioHolding));
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 60000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create("005930", 60000L));
 		closingPriceRepository.addPrice("005930", 50000);
 
 		setAuthentication(member);
@@ -392,8 +392,8 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, portfolioHolding2));
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 60000L));
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("035720", 60000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create("005930", 60000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create("035720", 60000L));
 		closingPriceRepository.addPrice("005930", 50000);
 		closingPriceRepository.addPrice("035720", 50000);
 

--- a/src/test/java/codesquad/fineants/domain/notification/event/listener/PurchaseHistoryEventListenerTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/event/listener/PurchaseHistoryEventListenerTest.java
@@ -81,7 +81,7 @@ class PurchaseHistoryEventListenerTest extends AbstractContainerBaseTest {
 			createPurchaseHistory(null, LocalDateTime.now(), Count.from(100), Money.won(10000), "memo",
 				portfolioHolding));
 		fcmRepository.save(createFcmToken("token", member));
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		PushNotificationEvent event = new PushNotificationEvent(
 			PurchaseHistoryEventSendableParameter.create(portfolio.getId(), member.getId()));

--- a/src/test/java/codesquad/fineants/domain/notification/event/listener/PurchaseHistoryEventListenerTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/event/listener/PurchaseHistoryEventListenerTest.java
@@ -21,7 +21,7 @@ import codesquad.fineants.domain.fcm.repository.FcmRepository;
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.notification.repository.NotificationRepository;
@@ -58,7 +58,7 @@ class PurchaseHistoryEventListenerTest extends AbstractContainerBaseTest {
 	private NotificationRepository notificationRepository;
 
 	@Autowired
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@Autowired
 	private FcmRepository fcmRepository;
@@ -81,7 +81,7 @@ class PurchaseHistoryEventListenerTest extends AbstractContainerBaseTest {
 			createPurchaseHistory(null, LocalDateTime.now(), Count.from(100), Money.won(10000), "memo",
 				portfolioHolding));
 		fcmRepository.save(createFcmToken("token", member));
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		PushNotificationEvent event = new PushNotificationEvent(
 			PurchaseHistoryEventSendableParameter.create(portfolio.getId(), member.getId()));

--- a/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
@@ -36,7 +36,7 @@ import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
 import codesquad.fineants.domain.kis.aop.AccessTokenAspect;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.kis.service.KisService;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
@@ -101,7 +101,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 	private FirebaseMessaging firebaseMessaging;
 
 	@Autowired
-	private CurrentPriceRepository manager;
+	private CurrentPriceRedisRepository manager;
 
 	@MockBean
 	private KisService kisService;

--- a/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
@@ -137,7 +137,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.of("projects/fineants-404407/messages/4754d355-5d5d-4f14-a642-75fecdb91fa5"));
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		// when
 		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)service.notifyTargetGain(
@@ -181,8 +181,8 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.of("projects/fineants-404407/messages/4754d355-5d5d-4f14-a642-75fecdb91fa5"));
-		manager.addCurrentPrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 83300L));
-		manager.addCurrentPrice(KisCurrentPrice.create(ccs.getTickerSymbol(), 3750L));
+		manager.savePrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 83300L));
+		manager.savePrice(KisCurrentPrice.create(ccs.getTickerSymbol(), 3750L));
 
 		// when
 		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)service.notifyTargetGain(
@@ -216,7 +216,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.empty());
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		// when
 		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)service.notifyTargetGain(
@@ -254,7 +254,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePricePerShare, memo, portfolioHolding));
 		fcmRepository.save(createFcmToken("token", member));
 
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		// when
 		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)service.notifyTargetGain(
@@ -285,7 +285,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.of("messageId"));
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 100L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 100L));
 
 		// when
 		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)service.notifyMaxLossAll();
@@ -317,7 +317,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.of("messageId"));
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 100L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 100L));
 
 		// when
 		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)service.notifyMaxLoss(
@@ -354,7 +354,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePricePerShare, memo, portfolioHolding));
 		fcmRepository.save(createFcmToken("token", member));
 
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		// when
 		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)service.notifyMaxLoss(
@@ -387,7 +387,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 		given(firebaseMessaging.send(any(Message.class)))
 			.willThrow(FirebaseMessagingException.class);
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		// when
 		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)service.notifyMaxLoss(
@@ -427,8 +427,8 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePricePerShare, memo, holding2));
 
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
-		manager.addCurrentPrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 60000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		manager.savePrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 60000L));
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.of("messageId"));
 
@@ -471,8 +471,8 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 		targetPriceNotificationRepository.saveAll(
 			createTargetPriceNotification(stockTargetPrice4, List.of(10000L, 20000L)));
 
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
-		manager.addCurrentPrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 10000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		manager.savePrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 10000L));
 		given(kisService.fetchCurrentPrice(stock2.getTickerSymbol()))
 			.willReturn(Mono.just(KisCurrentPrice.create(stock2.getTickerSymbol(), 10000L)));
 		given(firebaseMessagingService.send(any(Message.class)))
@@ -512,7 +512,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 				targetPriceNotificationRepository.saveAll(
 					createTargetPriceNotification(stockTargetPrice1, List.of(60000L, 70000L)));
 
-				manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+				manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
 				given(kisService.fetchCurrentPrice(stock.getTickerSymbol()))
 					.willReturn(Mono.just(KisCurrentPrice.create(stock.getTickerSymbol(), 10000L)));
 				given(firebaseMessagingService.send(any(Message.class)))
@@ -580,8 +580,8 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 		targetPriceNotificationRepository.saveAll(
 			createTargetPriceNotification(stockTargetPrice2, List.of(10000L, 20000L)));
 
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
-		manager.addCurrentPrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 10000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		manager.savePrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 10000L));
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.of("messageId"));
 		// when
@@ -662,8 +662,8 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 			member
 		));
 
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
-		manager.addCurrentPrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 10000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		manager.savePrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 10000L));
 		sentManager.addTargetPriceSendHistory(sendTargetPriceNotification.getId());
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.of("messageId"));
@@ -697,7 +697,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 			List.of(60000L, 70000L));
 		targetPriceNotificationRepository.saveAll(targetPriceNotifications);
 
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.empty());
 		// when
@@ -729,8 +729,8 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 		targetPriceNotificationRepository.saveAll(
 			createTargetPriceNotification(stockTargetPrice2, List.of(10000L, 20000L)));
 
-		manager.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
-		manager.addCurrentPrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 10000L));
+		manager.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		manager.savePrice(KisCurrentPrice.create(stock2.getTickerSymbol(), 10000L));
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.of("messageId"));
 		// when

--- a/src/test/java/codesquad/fineants/domain/notification/service/provider/FirebaseNotificationProviderTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/service/provider/FirebaseNotificationProviderTest.java
@@ -82,7 +82,7 @@ class FirebaseNotificationProviderTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Stock samsung = stockRepository.save(createSamsungStock());
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 50000L));
 		willDoNothing().given(accessTokenAspect).checkAccessTokenExpiration();
 		Portfolio portfolio = createPortfolioSample(member, samsung);
 
@@ -106,7 +106,7 @@ class FirebaseNotificationProviderTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Stock samsung = stockRepository.save(createSamsungStock());
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 50000L));
 		willDoNothing().given(accessTokenAspect).checkAccessTokenExpiration();
 		PurchaseHistory purchaseHistory = createPurchaseHistory(null, LocalDateTime.now(), Count.from(30),
 			Money.won(100000), "첫구매", null);

--- a/src/test/java/codesquad/fineants/domain/notification/service/provider/FirebaseNotificationProviderTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/service/provider/FirebaseNotificationProviderTest.java
@@ -24,7 +24,7 @@ import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
 import codesquad.fineants.domain.kis.aop.AccessTokenAspect;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.notification.domain.dto.response.SentNotifyMessage;
@@ -61,7 +61,7 @@ class FirebaseNotificationProviderTest extends AbstractContainerBaseTest {
 	private PurchaseHistoryRepository purchaseHistoryRepository;
 
 	@Autowired
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@Autowired
 	private TargetGainNotificationPolicy targetGainNotificationPolicy;
@@ -82,7 +82,7 @@ class FirebaseNotificationProviderTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Stock samsung = stockRepository.save(createSamsungStock());
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 50000L));
 		willDoNothing().given(accessTokenAspect).checkAccessTokenExpiration();
 		Portfolio portfolio = createPortfolioSample(member, samsung);
 
@@ -106,7 +106,7 @@ class FirebaseNotificationProviderTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Stock samsung = stockRepository.save(createSamsungStock());
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(samsung.getTickerSymbol(), 50000L));
 		willDoNothing().given(accessTokenAspect).checkAccessTokenExpiration();
 		PurchaseHistory purchaseHistory = createPurchaseHistory(null, LocalDateTime.now(), Count.from(30),
 			Money.won(100000), "첫구매", null);
@@ -136,7 +136,7 @@ class FirebaseNotificationProviderTest extends AbstractContainerBaseTest {
 		PortfolioHolding holding = holdingRepository.save(createPortfolioHolding(portfolio, stock));
 		PurchaseHistory history = purchaseHistoryRepository.save(purchaseHistory);
 		holding.addPurchaseHistory(history);
-		holding.applyCurrentPrice(currentPriceRepository);
+		holding.applyCurrentPrice(currentPriceRedisRepository);
 		portfolio.addHolding(holding);
 		fcmRepository.save(createFcmToken("token", member));
 		return portfolio;

--- a/src/test/java/codesquad/fineants/domain/portfolio/service/DashboardServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/portfolio/service/DashboardServiceTest.java
@@ -106,7 +106,7 @@ public class DashboardServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePricePerShare, memo, portfolioHolding));
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 72900L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 72900L));
 		// when
 		OverviewResponse response = dashboardService.getOverview(member.getId());
 
@@ -145,7 +145,7 @@ public class DashboardServiceTest extends AbstractContainerBaseTest {
 		Stock stock = stockRepository.save(createSamsungStock());
 		portfolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		// when
 		OverviewResponse response = dashboardService.getOverview(member.getId());
 
@@ -219,7 +219,7 @@ public class DashboardServiceTest extends AbstractContainerBaseTest {
 				"첫구매"
 			)
 		));
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
 		// when
 		List<DashboardPieChartResponse> responses = dashboardService.getPieChart(member.getId());
 

--- a/src/test/java/codesquad/fineants/domain/portfolio/service/DashboardServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/portfolio/service/DashboardServiceTest.java
@@ -21,7 +21,7 @@ import codesquad.fineants.domain.gainhistory.repository.PortfolioGainHistoryRepo
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.portfolio.domain.dto.response.DashboardLineChartResponse;
@@ -53,7 +53,7 @@ public class DashboardServiceTest extends AbstractContainerBaseTest {
 	@Autowired
 	private StockDividendRepository stockDividendRepository;
 	@Autowired
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@Test
 	void getOverviewWhenNoPortfolio() {
@@ -106,7 +106,7 @@ public class DashboardServiceTest extends AbstractContainerBaseTest {
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, purchaseDate, numShares, purchasePricePerShare, memo, portfolioHolding));
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 72900L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 72900L));
 		// when
 		OverviewResponse response = dashboardService.getOverview(member.getId());
 
@@ -145,7 +145,7 @@ public class DashboardServiceTest extends AbstractContainerBaseTest {
 		Stock stock = stockRepository.save(createSamsungStock());
 		portfolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		// when
 		OverviewResponse response = dashboardService.getOverview(member.getId());
 
@@ -219,7 +219,7 @@ public class DashboardServiceTest extends AbstractContainerBaseTest {
 				"첫구매"
 			)
 		));
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 60000L));
 		// when
 		List<DashboardPieChartResponse> responses = dashboardService.getPieChart(member.getId());
 

--- a/src/test/java/codesquad/fineants/domain/portfolio/service/PortFolioServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/portfolio/service/PortFolioServiceTest.java
@@ -31,7 +31,7 @@ import codesquad.fineants.domain.gainhistory.repository.PortfolioGainHistoryRepo
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.portfolio.domain.dto.request.PortfolioCreateRequest;
@@ -75,7 +75,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 	private StockRepository stockRepository;
 
 	@Autowired
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@DisplayName("회원이 포트폴리오를 추가한다")
 	@CsvSource(value = {
@@ -419,7 +419,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 				portfolio
 			)
 		);
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 40000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 40000L));
 		// when
 		PortfoliosResponse response = service.readMyAllPortfolio(member.getId());
 

--- a/src/test/java/codesquad/fineants/domain/portfolio/service/PortFolioServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/portfolio/service/PortFolioServiceTest.java
@@ -419,7 +419,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 				portfolio
 			)
 		);
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 40000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 40000L));
 		// when
 		PortfoliosResponse response = service.readMyAllPortfolio(member.getId());
 

--- a/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
@@ -27,7 +27,7 @@ import codesquad.fineants.domain.fcm.service.FirebaseMessagingService;
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.notification.repository.NotificationRepository;
@@ -75,7 +75,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 	private FcmRepository fcmRepository;
 
 	@Autowired
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@MockBean
 	private FirebaseMessagingService firebaseMessagingService;
@@ -105,7 +105,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.purchasePricePerShare(money)
 			.memo("첫구매")
 			.build();
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		setAuthentication(member);
 		// when
@@ -152,7 +152,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.memo("첫구매")
 			.build();
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		given(sentManager.hasTargetGainSendHistory(anyLong()))
 			.willReturn(false);
 		given(firebaseMessagingService.send(any(Message.class)))
@@ -191,7 +191,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.memo("첫구매")
 			.build();
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		given(sentManager.hasTargetGainSendHistory(anyLong()))
 			.willReturn(false);
 		given(firebaseMessagingService.send(any(Message.class)))
@@ -288,7 +288,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.memo("첫구매")
 			.build();
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		setAuthentication(member);
 		// when
@@ -329,7 +329,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.memo("첫구매")
 			.build();
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		given(sentManager.hasTargetGainSendHistory(anyLong()))
 			.willReturn(false);
 		given(firebaseMessagingService.send(any(Message.class)))
@@ -429,7 +429,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			createPurchaseHistory(null, LocalDateTime.now(), Count.from(100), Money.won(100), "첫구매", holding));
 		fcmRepository.save(createFcmToken("token", member));
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		given(sentManager.hasTargetGainSendHistory(anyLong()))
 			.willReturn(false);
 		given(firebaseMessagingService.send(any(Message.class)))

--- a/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
@@ -105,7 +105,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.purchasePricePerShare(money)
 			.memo("첫구매")
 			.build();
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		setAuthentication(member);
 		// when
@@ -152,7 +152,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.memo("첫구매")
 			.build();
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		given(sentManager.hasTargetGainSendHistory(anyLong()))
 			.willReturn(false);
 		given(firebaseMessagingService.send(any(Message.class)))
@@ -191,7 +191,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.memo("첫구매")
 			.build();
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		given(sentManager.hasTargetGainSendHistory(anyLong()))
 			.willReturn(false);
 		given(firebaseMessagingService.send(any(Message.class)))
@@ -288,7 +288,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.memo("첫구매")
 			.build();
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 
 		setAuthentication(member);
 		// when
@@ -329,7 +329,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.memo("첫구매")
 			.build();
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		given(sentManager.hasTargetGainSendHistory(anyLong()))
 			.willReturn(false);
 		given(firebaseMessagingService.send(any(Message.class)))
@@ -429,7 +429,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			createPurchaseHistory(null, LocalDateTime.now(), Count.from(100), Money.won(100), "첫구매", holding));
 		fcmRepository.save(createFcmToken("token", member));
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		given(sentManager.hasTargetGainSendHistory(anyLong()))
 			.willReturn(false);
 		given(firebaseMessagingService.send(any(Message.class)))

--- a/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
@@ -96,7 +96,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 		Stock stock = stockRepository.save(createSamsungStock());
 		stockDividendRepository.saveAll(createStockDividendWith(stock));
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 50000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create("005930", 50000L));
 		closingPriceRepository.addPrice(KisClosingPrice.create("005930", 49000L));
 		given(kisClient.fetchAccessToken())
 			.willReturn(

--- a/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
@@ -31,7 +31,7 @@ import codesquad.fineants.domain.kis.domain.dto.response.KisClosingPrice;
 import codesquad.fineants.domain.kis.domain.dto.response.KisDividend;
 import codesquad.fineants.domain.kis.domain.dto.response.KisSearchStockInfo;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.kis.service.KisService;
 import codesquad.fineants.domain.stock.domain.dto.response.StockDataResponse;
@@ -63,7 +63,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 	private KisAccessTokenRepository kisAccessTokenRepository;
 
 	@Autowired
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@Autowired
 	private ClosingPriceRepository closingPriceRepository;
@@ -96,7 +96,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 		Stock stock = stockRepository.save(createSamsungStock());
 		stockDividendRepository.saveAll(createStockDividendWith(stock));
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create("005930", 50000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 50000L));
 		closingPriceRepository.addPrice(KisClosingPrice.create("005930", 49000L));
 		given(kisClient.fetchAccessToken())
 			.willReturn(

--- a/src/test/java/codesquad/fineants/domain/watchlist/service/WatchListServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/watchlist/service/WatchListServiceTest.java
@@ -111,7 +111,7 @@ class WatchListServiceTest extends AbstractContainerBaseTest {
 		WatchList watchList = watchListRepository.save(createWatchList("My WatchList 1", member));
 		watchStockRepository.save(createWatchStock(watchList, stock));
 
-		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 77000L));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create("005930", 77000L));
 		closingPriceRepository.addPrice(KisClosingPrice.create("005930", 77000L));
 
 		setAuthentication(member);

--- a/src/test/java/codesquad/fineants/domain/watchlist/service/WatchListServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/watchlist/service/WatchListServiceTest.java
@@ -21,7 +21,7 @@ import codesquad.fineants.domain.dividend.repository.StockDividendRepository;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
 import codesquad.fineants.domain.kis.domain.dto.response.KisClosingPrice;
 import codesquad.fineants.domain.kis.repository.ClosingPriceRepository;
-import codesquad.fineants.domain.kis.repository.CurrentPriceRepository;
+import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.kis.service.KisService;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
@@ -54,7 +54,7 @@ class WatchListServiceTest extends AbstractContainerBaseTest {
 	private WatchListRepository watchListRepository;
 
 	@Autowired
-	private CurrentPriceRepository currentPriceRepository;
+	private CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@Autowired
 	private ClosingPriceRepository closingPriceRepository;
@@ -111,7 +111,7 @@ class WatchListServiceTest extends AbstractContainerBaseTest {
 		WatchList watchList = watchListRepository.save(createWatchList("My WatchList 1", member));
 		watchStockRepository.save(createWatchStock(watchList, stock));
 
-		currentPriceRepository.addCurrentPrice(KisCurrentPrice.create("005930", 77000L));
+		currentPriceRedisRepository.addCurrentPrice(KisCurrentPrice.create("005930", 77000L));
 		closingPriceRepository.addPrice(KisClosingPrice.create("005930", 77000L));
 
 		setAuthentication(member);


### PR DESCRIPTION
## 구현한 것

- 무한 재귀 구조가 아닌 한국투자증권 서버로부터 현재가를 조회받으면 재귀적으로 바로 반환하도록 변경
- PriceRepository 인터페이스에 맞게 구현
