### PR TITLE
[fix] 매입 이력 알람 리스너 문제 해결

### DIFF
--- a/src/main/java/codesquad/fineants/domain/dividend/domain/reader/HolidayFileReader.java
+++ b/src/main/java/codesquad/fineants/domain/dividend/domain/reader/HolidayFileReader.java
@@ -8,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -34,7 +33,7 @@ public class HolidayFileReader {
 				.map(parts -> new HolidayDto(
 					LocalDate.parse(parts[0], formatter),
 					parts[1]))
-				.collect(Collectors.toList());
+				.toList();
 		}
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/codesquad/fineants/domain/holding/domain/entity/PortfolioHolding.java
@@ -238,4 +238,9 @@ public class PortfolioHolding extends BaseEntity {
 	public boolean hasAuthorization(Long memberId) {
 		return portfolio.hasAuthorization(memberId);
 	}
+
+	// TODO: 불변 컬렉션으로 변경
+	public List<PurchaseHistory> getPurchaseHistory() {
+		return purchaseHistory;
+	}
 }

--- a/src/main/java/codesquad/fineants/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/codesquad/fineants/domain/holding/domain/entity/PortfolioHolding.java
@@ -3,6 +3,7 @@ package codesquad.fineants.domain.holding.domain.entity;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -239,8 +240,7 @@ public class PortfolioHolding extends BaseEntity {
 		return portfolio.hasAuthorization(memberId);
 	}
 
-	// TODO: 불변 컬렉션으로 변경
 	public List<PurchaseHistory> getPurchaseHistory() {
-		return purchaseHistory;
+		return Collections.unmodifiableList(purchaseHistory);
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/kis/client/KisCurrentPrice.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisCurrentPrice.java
@@ -2,6 +2,8 @@ package codesquad.fineants.domain.kis.client;
 
 import java.io.IOException;
 
+import org.apache.logging.log4j.util.Strings;
+
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -26,6 +28,10 @@ public class KisCurrentPrice {
 	private String tickerSymbol;
 	private Long price;
 
+	public static KisCurrentPrice empty() {
+		return empty(Strings.EMPTY);
+	}
+
 	public static KisCurrentPrice empty(String tickerSymbol) {
 		return new KisCurrentPrice(tickerSymbol, 0L);
 	}
@@ -40,6 +46,10 @@ public class KisCurrentPrice {
 
 	public String toRedisValue() {
 		return String.valueOf(price);
+	}
+
+	public boolean isEmpty() {
+		return tickerSymbol == null;
 	}
 
 	static class KisCurrentPriceDeserializer extends JsonDeserializer<KisCurrentPrice> {

--- a/src/main/java/codesquad/fineants/domain/kis/client/KisCurrentPrice.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisCurrentPrice.java
@@ -48,8 +48,8 @@ public class KisCurrentPrice {
 		return String.valueOf(price);
 	}
 
-	public boolean isEmpty() {
-		return tickerSymbol == null;
+	public boolean hasPrice() {
+		return tickerSymbol != null && price > 0;
 	}
 
 	static class KisCurrentPriceDeserializer extends JsonDeserializer<KisCurrentPrice> {

--- a/src/main/java/codesquad/fineants/domain/kis/client/KisCurrentPrice.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisCurrentPrice.java
@@ -2,8 +2,6 @@ package codesquad.fineants.domain.kis.client;
 
 import java.io.IOException;
 
-import org.apache.logging.log4j.util.Strings;
-
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -28,10 +26,6 @@ public class KisCurrentPrice {
 	private String tickerSymbol;
 	private Long price;
 
-	public static KisCurrentPrice empty() {
-		return empty(Strings.EMPTY);
-	}
-
 	public static KisCurrentPrice empty(String tickerSymbol) {
 		return new KisCurrentPrice(tickerSymbol, 0L);
 	}
@@ -46,10 +40,6 @@ public class KisCurrentPrice {
 
 	public String toRedisValue() {
 		return String.valueOf(price);
-	}
-
-	public boolean hasPrice() {
-		return tickerSymbol != null && price > 0;
 	}
 
 	static class KisCurrentPriceDeserializer extends JsonDeserializer<KisCurrentPrice> {

--- a/src/main/java/codesquad/fineants/domain/kis/domain/dto/response/KisDividendWrapper.java
+++ b/src/main/java/codesquad/fineants/domain/kis/domain/dto/response/KisDividendWrapper.java
@@ -22,7 +22,6 @@ import lombok.extern.slf4j.Slf4j;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonDeserialize(using = KisDividendWrapper.KissDividendWrapperDeserializer.class)
-// TODO: KisDividend 클래스의 역직렬화를 수정하여 래퍼 클래스가 없도록 수정
 public class KisDividendWrapper {
 	private List<KisDividend> kisDividends;
 

--- a/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRedisRepository.java
+++ b/src/main/java/codesquad/fineants/domain/kis/repository/CurrentPriceRedisRepository.java
@@ -19,7 +19,7 @@ public class CurrentPriceRedisRepository implements PriceRepository {
 	private static final String CURRENT_PRICE_FORMAT = "cp:%s";
 	private final RedisTemplate<String, String> redisTemplate;
 	private final KisClient kisClient;
-
+	
 	@Override
 	public void savePrice(KisCurrentPrice... currentPrices) {
 		Arrays.stream(currentPrices).forEach(this::savePrice);

--- a/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
@@ -97,9 +97,10 @@ public class KisService {
 	// 주식 현재가 갱신
 	@Transactional(readOnly = true)
 	public List<KisCurrentPrice> refreshStockCurrentPrice(List<String> tickerSymbols) {
+		int concurrency = 20;
 		List<KisCurrentPrice> prices = Flux.fromIterable(tickerSymbols)
 			.flatMap(ticker -> this.fetchCurrentPrice(ticker)
-				.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, delayManager.fixedDelay())), 20)
+				.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, delayManager.fixedDelay())), concurrency)
 			.delayElements(delayManager.delay())
 			.collectList()
 			.blockOptional(delayManager.timeout())

--- a/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
@@ -109,12 +109,6 @@ public class KisService {
 		return prices;
 	}
 
-	private CompletableFuture<KisCurrentPrice> submitCurrentPriceFuture(String tickerSymbol) {
-		CompletableFuture<KisCurrentPrice> future = createCompletableFuture();
-		executorService.schedule(createCurrentPriceRunnable(tickerSymbol, future), 1L, TimeUnit.SECONDS);
-		return future;
-	}
-
 	private <T> CompletableFuture<T> createCompletableFuture() {
 		CompletableFuture<T> future = new CompletableFuture<>();
 		future.orTimeout(TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
@@ -123,19 +117,6 @@ public class KisService {
 			return null;
 		});
 		return future;
-	}
-
-	private Runnable createCurrentPriceRunnable(String tickerSymbol, CompletableFuture<KisCurrentPrice> future) {
-		return () -> {
-			try {
-				future.complete(fetchCurrentPrice(tickerSymbol)
-					.blockOptional(Duration.ofMinutes(1L))
-					.orElseGet(() -> KisCurrentPrice.empty(tickerSymbol))
-				);
-			} catch (KisException e) {
-				future.completeExceptionally(e);
-			}
-		};
 	}
 
 	public Mono<KisCurrentPrice> fetchCurrentPrice(String tickerSymbol) {

--- a/src/main/java/codesquad/fineants/domain/member/domain/entity/Member.java
+++ b/src/main/java/codesquad/fineants/domain/member/domain/entity/Member.java
@@ -2,6 +2,7 @@ package codesquad.fineants.domain.member.domain.entity;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -139,5 +140,9 @@ public class Member extends BaseEntity {
 			.map(MemberRole::getRoleName)
 			.collect(Collectors.toSet()));
 		return result;
+	}
+
+	public Set<MemberRole> getRoles() {
+		return Collections.unmodifiableSet(roles);
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/notification/service/NotificationService.java
+++ b/src/main/java/codesquad/fineants/domain/notification/service/NotificationService.java
@@ -73,6 +73,7 @@ public class NotificationService {
 
 	/**
 	 * 포트폴리오 알림 저장
+	 *
 	 * @param request 알림 데이터
 	 * @return 알림 저장 결과
 	 */
@@ -89,6 +90,7 @@ public class NotificationService {
 
 	/**
 	 * 모든 회원을 대상으로 목표 수익률을 만족하는 포트폴리오에 대해서 목표 수익률 달성 알림 푸시
+	 *
 	 * @return 알림 전송 결과
 	 */
 	@Transactional
@@ -105,6 +107,7 @@ public class NotificationService {
 
 	/**
 	 * 특정 포트폴리오의 목표 수익률 달성 알림 푸시
+	 *
 	 * @param portfolioId 포트폴리오 등록번호
 	 * @return 알림 전송 결과
 	 */
@@ -166,6 +169,7 @@ public class NotificationService {
 
 	/**
 	 * 모든 포트폴리오를 대상으로 최대 손실율에 도달하는 모든 포트폴리오에 대해서 최대 손실율 도달 알림 푸시
+	 *
 	 * @return 알림 전송 결과
 	 */
 	@Transactional
@@ -181,6 +185,7 @@ public class NotificationService {
 
 	/**
 	 * 특정 포트폴리오의 최대 손실율 달성 알림 푸시
+	 *
 	 * @param portfolioId 포트폴리오 등록번호
 	 * @return 알림 전송 결과
 	 */
@@ -190,6 +195,7 @@ public class NotificationService {
 			.stream().peek(p -> p.applyCurrentPriceAllHoldingsBy(currentPriceRedisRepository))
 			.findAny()
 			.orElseThrow(() -> new FineAntsException(PortfolioErrorCode.NOT_FOUND_PORTFOLIO));
+		log.info("portfolio HashCode is {}", portfolio.hashCode());
 		Consumer<Long> sentFunction = sentManager::addMaxLossSendHistory;
 		return PortfolioNotifyMessagesResponse.create(
 			notifyMessage(List.of(portfolio), maximumLossNotificationPolicy, sentFunction)
@@ -198,6 +204,7 @@ public class NotificationService {
 
 	/**
 	 * 모든 회원을 대상으로 특정 종목들에 대한 종목 지정가 알림 발송
+	 *
 	 * @param tickerSymbols 종목의 티커 심볼 리스트
 	 * @return 알림 전송 결과
 	 */
@@ -220,6 +227,7 @@ public class NotificationService {
 
 	/**
 	 * 특정 회원을 대상으로 종목 지정가 알림 발송
+	 *
 	 * @param memberId 회원의 등록번호
 	 * @return 알림 전송 결과
 	 */

--- a/src/main/java/codesquad/fineants/domain/notification/service/NotificationService.java
+++ b/src/main/java/codesquad/fineants/domain/notification/service/NotificationService.java
@@ -195,7 +195,6 @@ public class NotificationService {
 			.stream().peek(p -> p.applyCurrentPriceAllHoldingsBy(currentPriceRedisRepository))
 			.findAny()
 			.orElseThrow(() -> new FineAntsException(PortfolioErrorCode.NOT_FOUND_PORTFOLIO));
-		log.info("portfolio HashCode is {}", portfolio.hashCode());
 		Consumer<Long> sentFunction = sentManager::addMaxLossSendHistory;
 		return PortfolioNotifyMessagesResponse.create(
 			notifyMessage(List.of(portfolio), maximumLossNotificationPolicy, sentFunction)

--- a/src/main/java/codesquad/fineants/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/codesquad/fineants/domain/portfolio/domain/entity/Portfolio.java
@@ -2,6 +2,7 @@ package codesquad.fineants.domain.portfolio.domain.entity;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -527,5 +528,9 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	@Override
 	public NotifyMessage getTargetPriceMessage(String token) {
 		throw new UnsupportedOperationException("This method is not supported for Portfolio");
+	}
+
+	public List<PortfolioHolding> getPortfolioHoldings() {
+		return Collections.unmodifiableList(portfolioHoldings);
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/purchasehistory/event/listener/PurchaseHistoryEventListener.java
+++ b/src/main/java/codesquad/fineants/domain/purchasehistory/event/listener/PurchaseHistoryEventListener.java
@@ -2,9 +2,9 @@ package codesquad.fineants.domain.purchasehistory.event.listener;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
 
 import codesquad.fineants.domain.notification.domain.dto.response.PortfolioNotifyMessagesResponse;
 import codesquad.fineants.domain.notification.service.NotificationService;
@@ -22,7 +22,7 @@ public class PurchaseHistoryEventListener {
 
 	// 매입 이력 이벤트가 발생하면 포트폴리오 목표수익률에 달성하면 푸시 알림
 	@Async
-	@EventListener
+	@TransactionalEventListener
 	public CompletableFuture<PortfolioNotifyMessagesResponse> notifyTargetGainBy(PushNotificationEvent event) {
 		PurchaseHistoryEventSendableParameter parameter = event.getValue();
 		return CompletableFuture.supplyAsync(() ->
@@ -31,7 +31,7 @@ public class PurchaseHistoryEventListener {
 
 	// 매입 이력 이벤트가 발생하면 포트폴리오 최대손실율에 도달하면 푸시 알림
 	@Async
-	@EventListener
+	@TransactionalEventListener
 	public CompletableFuture<PortfolioNotifyMessagesResponse> notifyMaxLoss(PushNotificationEvent event) {
 		PurchaseHistoryEventSendableParameter parameter = event.getValue();
 		return CompletableFuture.supplyAsync(() ->

--- a/src/main/java/codesquad/fineants/domain/purchasehistory/event/listener/PurchaseHistoryEventListener.java
+++ b/src/main/java/codesquad/fineants/domain/purchasehistory/event/listener/PurchaseHistoryEventListener.java
@@ -1,5 +1,7 @@
 package codesquad.fineants.domain.purchasehistory.event.listener;
 
+import java.util.concurrent.CompletableFuture;
+
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -21,20 +23,18 @@ public class PurchaseHistoryEventListener {
 	// 매입 이력 이벤트가 발생하면 포트폴리오 목표수익률에 달성하면 푸시 알림
 	@Async
 	@EventListener
-	public void notifyTargetGainBy(PushNotificationEvent event) {
+	public CompletableFuture<PortfolioNotifyMessagesResponse> notifyTargetGainBy(PushNotificationEvent event) {
 		PurchaseHistoryEventSendableParameter parameter = event.getValue();
-		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)notificationService.notifyTargetGain(
-			parameter.getPortfolioId());
-		log.info("매입 이력 이벤트로 인한 목표 수익률 달성 알림 결과 : {}", response);
+		return CompletableFuture.supplyAsync(() ->
+			(PortfolioNotifyMessagesResponse)notificationService.notifyTargetGain(parameter.getPortfolioId()));
 	}
 
 	// 매입 이력 이벤트가 발생하면 포트폴리오 최대손실율에 도달하면 푸시 알림
 	@Async
 	@EventListener
-	public void notifyMaxLoss(PushNotificationEvent event) {
+	public CompletableFuture<PortfolioNotifyMessagesResponse> notifyMaxLoss(PushNotificationEvent event) {
 		PurchaseHistoryEventSendableParameter parameter = event.getValue();
-		PortfolioNotifyMessagesResponse response = (PortfolioNotifyMessagesResponse)notificationService.notifyMaxLoss(
-			parameter.getPortfolioId());
-		log.info("매입 이력 이벤트로 인한 최대 손실율 달성 알림 결과 : response={}", response);
+		return CompletableFuture.supplyAsync(() ->
+			(PortfolioNotifyMessagesResponse)notificationService.notifyMaxLoss(parameter.getPortfolioId()));
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryService.java
+++ b/src/main/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryService.java
@@ -110,13 +110,6 @@ public class PurchaseHistoryService {
 		PurchaseHistory deletePurchaseHistory = findPurchaseHistory(purchaseHistoryId);
 		repository.deleteById(purchaseHistoryId);
 
-		// 매입 이력 알람 이벤트를 위한 매입 이력 데이터 삭제
-		findPortfolio(portfolioId).getPortfolioHoldings().stream()
-			.filter(holding -> holding.getId().equals(portfolioHoldingId))
-			.findAny()
-			.orElseThrow(() -> new FineAntsException(PortfolioHoldingErrorCode.NOT_FOUND_PORTFOLIO_HOLDING))
-			.getPurchaseHistory().remove(deletePurchaseHistory);
-
 		purchaseHistoryEventPublisher.publishPushNotificationEvent(portfolioId, memberId);
 		return PurchaseHistoryDeleteResponse.from(deletePurchaseHistory, portfolioId, memberId);
 	}

--- a/src/main/java/codesquad/fineants/domain/stock/domain/entity/Stock.java
+++ b/src/main/java/codesquad/fineants/domain/stock/domain/entity/Stock.java
@@ -3,6 +3,7 @@ package codesquad.fineants.domain.stock.domain.entity;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -236,5 +237,9 @@ public class Stock extends BaseEntity {
 			companyNameEng,
 			market.name(),
 			sector);
+	}
+
+	public List<StockDividend> getStockDividends() {
+		return Collections.unmodifiableList(stockDividends);
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/stock/service/StockAndDividendManager.java
+++ b/src/main/java/codesquad/fineants/domain/stock/service/StockAndDividendManager.java
@@ -152,7 +152,7 @@ public class StockAndDividendManager {
 		final int concurrency = 20;
 		return Flux.fromIterable(findAllTickerSymbols())
 			.flatMap(kisService::fetchSearchStockInfo, concurrency)
-			.delayElements(delayManager.getDelay())
+			.delayElements(delayManager.delay())
 			.collectList()
 			.blockOptional(TIMEOUT)
 			.orElseGet(Collections::emptyList).stream()
@@ -191,7 +191,7 @@ public class StockAndDividendManager {
 		final int concurrency = 20;
 		return Flux.fromIterable(tickerSymbols)
 			.flatMap(ticker -> kisService.fetchDividend(ticker).flatMapMany(Flux::fromIterable), concurrency)
-			.delayElements(delayManager.getDelay())
+			.delayElements(delayManager.delay())
 			.collectList()
 			.blockOptional(TIMEOUT)
 			.orElseGet(Collections::emptyList).stream()

--- a/src/main/java/codesquad/fineants/domain/stock_target_price/domain/entity/StockTargetPrice.java
+++ b/src/main/java/codesquad/fineants/domain/stock_target_price/domain/entity/StockTargetPrice.java
@@ -2,6 +2,7 @@ package codesquad.fineants.domain.stock_target_price.domain.entity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import codesquad.fineants.domain.BaseEntity;
@@ -50,11 +51,6 @@ public class StockTargetPrice extends BaseEntity {
 	@OneToMany(fetch = FetchType.LAZY, mappedBy = "stockTargetPrice")
 	private List<TargetPriceNotification> targetPriceNotifications;
 
-	private StockTargetPrice(Boolean isActive, Member member, Stock stock,
-		List<TargetPriceNotification> targetPriceNotifications) {
-		this(LocalDateTime.now(), null, null, isActive, member, stock, targetPriceNotifications);
-	}
-
 	private StockTargetPrice(LocalDateTime createAt, LocalDateTime modifiedAt, Long id, Boolean isActive, Member member,
 		Stock stock, List<TargetPriceNotification> targetPriceNotifications) {
 		super(createAt, modifiedAt);
@@ -83,5 +79,9 @@ public class StockTargetPrice extends BaseEntity {
 
 	public boolean hasAuthorization(Long memberId) {
 		return member.hasAuthorization(memberId);
+	}
+
+	public List<TargetPriceNotification> getTargetPriceNotifications() {
+		return Collections.unmodifiableList(targetPriceNotifications);
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/stock_target_price/domain/entity/TargetPriceNotification.java
+++ b/src/main/java/codesquad/fineants/domain/stock_target_price/domain/entity/TargetPriceNotification.java
@@ -44,10 +44,6 @@ public class TargetPriceNotification extends BaseEntity implements Notifiable {
 	@JoinColumn(name = "stock_target_price_id")
 	private StockTargetPrice stockTargetPrice;
 
-	private TargetPriceNotification(Money targetPrice, StockTargetPrice stockTargetPrice) {
-		this(LocalDateTime.now(), null, null, targetPrice, stockTargetPrice);
-	}
-
 	private TargetPriceNotification(LocalDateTime createAt, LocalDateTime modifiedAt, Long id,
 		Money targetPrice, StockTargetPrice stockTargetPrice) {
 		super(createAt, modifiedAt);

--- a/src/main/java/codesquad/fineants/domain/watchlist/domain/entity/WatchList.java
+++ b/src/main/java/codesquad/fineants/domain/watchlist/domain/entity/WatchList.java
@@ -2,6 +2,7 @@ package codesquad.fineants.domain.watchlist.domain.entity;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import codesquad.fineants.domain.BaseEntity;
@@ -61,5 +62,9 @@ public class WatchList extends BaseEntity {
 
 	public boolean hasAuthorization(Long memberId) {
 		return member.hasAuthorization(memberId);
+	}
+
+	public List<WatchStock> getWatchStocks() {
+		return Collections.unmodifiableList(watchStocks);
 	}
 }

--- a/src/main/java/codesquad/fineants/global/common/delay/DelayManager.java
+++ b/src/main/java/codesquad/fineants/global/common/delay/DelayManager.java
@@ -5,8 +5,18 @@ import java.time.Duration;
 public interface DelayManager {
 
 	Duration DEFAULT_DELAY = Duration.ofMillis(50);
+	Duration TIMEOUT = Duration.ofMinutes(10);
+	Duration FIXED_DELAY = Duration.ofSeconds(5);
 
-	default Duration getDelay() {
+	default Duration delay() {
 		return DEFAULT_DELAY;
+	}
+
+	default Duration timeout() {
+		return TIMEOUT;
+	}
+
+	default Duration fixedDelay() {
+		return FIXED_DELAY;
 	}
 }

--- a/src/main/java/codesquad/fineants/global/config/SpringConfig.java
+++ b/src/main/java/codesquad/fineants/global/config/SpringConfig.java
@@ -3,6 +3,7 @@ package codesquad.fineants.global.config;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 import codesquad.fineants.domain.kis.properties.KisProperties;
 import codesquad.fineants.domain.kis.properties.KisTrIdProperties;
@@ -13,6 +14,7 @@ import codesquad.fineants.global.init.properties.RoleProperties;
 import codesquad.fineants.global.init.properties.UserProperties;
 
 @EnableAspectJAutoProxy
+@EnableAsync
 @EnableConfigurationProperties(value = {PortfolioProperties.class, AdminProperties.class, ManagerProperties.class,
 	KisProperties.class, RoleProperties.class, UserProperties.class, KisTrIdProperties.class})
 @Configuration

--- a/src/main/java/codesquad/fineants/global/init/SetupDataLoader.java
+++ b/src/main/java/codesquad/fineants/global/init/SetupDataLoader.java
@@ -14,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import codesquad.fineants.domain.dividend.domain.entity.StockDividend;
 import codesquad.fineants.domain.dividend.repository.StockDividendRepository;
 import codesquad.fineants.domain.exchangerate.domain.entity.ExchangeRate;
 import codesquad.fineants.domain.exchangerate.repository.ExchangeRateRepository;
@@ -26,6 +27,7 @@ import codesquad.fineants.domain.member.repository.MemberRepository;
 import codesquad.fineants.domain.member.repository.RoleRepository;
 import codesquad.fineants.domain.notificationpreference.domain.entity.NotificationPreference;
 import codesquad.fineants.domain.notificationpreference.repository.NotificationPreferenceRepository;
+import codesquad.fineants.domain.stock.domain.entity.Stock;
 import codesquad.fineants.domain.stock.repository.StockRepository;
 import codesquad.fineants.global.errors.errorcode.MemberErrorCode;
 import codesquad.fineants.global.errors.errorcode.RoleErrorCode;
@@ -68,11 +70,6 @@ public class SetupDataLoader {
 		setupExchangeRateResources();
 		setupStockResources();
 		setupStockDividendResources();
-
-		log.info("애플리케이션 시작시 종목 현재가 및 종가 초기화 시작");
-		kisService.refreshCurrentPrice();
-		kisService.refreshClosingPrice();
-		log.info("애플리케이션 시작시 종목 현재가 및 종가 초기화 종료");
 	}
 
 	private void setupSecurityResources() {
@@ -175,10 +172,12 @@ public class SetupDataLoader {
 	}
 
 	private void setupStockResources() {
-		stockRepository.saveAll(amazonS3StockService.fetchStocks());
+		List<Stock> stocks = stockRepository.saveAll(amazonS3StockService.fetchStocks());
+		log.info("setupStock count is {}", stocks.size());
 	}
 
 	private void setupStockDividendResources() {
-		stockDividendRepository.saveAll(amazonS3DividendService.fetchDividends());
+		List<StockDividend> dividends = stockDividendRepository.saveAll(amazonS3DividendService.fetchDividends());
+		log.info("setupStockDividend count is {}", dividends.size());
 	}
 }

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -144,7 +144,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 
 		kisAccessTokenRepository.refreshAccessToken(createKisAccessToken());
 		given(client.fetchCurrentPrice(anyString()))
-			.willThrow(new KisException("요청건수가 초과되었습니다"));
+			.willReturn(Mono.error(new KisException("요청건수가 초과되었습니다")));
 
 		List<String> tickerSymbols = stocks.stream()
 			.map(Stock::getTickerSymbol)

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -124,6 +124,9 @@ class KisServiceTest extends AbstractContainerBaseTest {
 
 		given(client.fetchCurrentPrice("005930"))
 			.willReturn(Mono.just(KisCurrentPrice.create("005930", 10000L)));
+		given(delayManager.timeout()).willReturn(Duration.ofSeconds(1));
+		given(delayManager.delay()).willReturn(Duration.ZERO);
+		given(delayManager.fixedDelay()).willReturn(Duration.ZERO);
 
 		List<String> tickerSymbols = stocks.stream()
 			.map(Stock::getTickerSymbol)

--- a/src/test/java/codesquad/fineants/domain/notification/event/listener/PurchaseHistoryEventListenerTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/event/listener/PurchaseHistoryEventListenerTest.java
@@ -1,10 +1,11 @@
 package codesquad.fineants.domain.notification.event.listener;
 
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDateTime;
+import java.util.concurrent.CompletableFuture;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,6 +25,7 @@ import codesquad.fineants.domain.kis.client.KisCurrentPrice;
 import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
+import codesquad.fineants.domain.notification.domain.dto.response.PortfolioNotifyMessagesResponse;
 import codesquad.fineants.domain.notification.repository.NotificationRepository;
 import codesquad.fineants.domain.portfolio.domain.entity.Portfolio;
 import codesquad.fineants.domain.portfolio.repository.PortfolioRepository;
@@ -86,8 +88,38 @@ class PurchaseHistoryEventListenerTest extends AbstractContainerBaseTest {
 		PushNotificationEvent event = new PushNotificationEvent(
 			PurchaseHistoryEventSendableParameter.create(portfolio.getId(), member.getId()));
 		// when
-		purchaseHistoryEventListener.notifyTargetGainBy(event);
+		CompletableFuture<PortfolioNotifyMessagesResponse> future = purchaseHistoryEventListener.notifyTargetGainBy(
+			event);
 		// then
-		Assertions.assertThat(notificationRepository.findAllByMemberId(member.getId())).hasSize(1);
+		PortfolioNotifyMessagesResponse response = future.join();
+		assertThat(response.getNotifications()).hasSize(1);
+		assertThat(notificationRepository.findAllByMemberId(member.getId())).hasSize(1);
+	}
+
+	@DisplayName("사용자는 매입 이벤트 발생 시 최대 손실율에 달성하여 푸시 알림을 받는다")
+	@Test
+	void addPurchaseHistory_whenAchieveMaxLoss_thenSaveNotification() throws FirebaseMessagingException {
+		// given
+		given(firebaseMessaging.send(any(Message.class)))
+			.willReturn("projects/fineants-404407/messages/4754d355-5d5d-4f14-a642-75fecdb91fa5");
+
+		Member member = memberRepository.save(createMember());
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock stock = stockRepository.save(createSamsungStock());
+		PortfolioHolding portfolioHolding = portfolioHoldingRepository.save(createPortfolioHolding(portfolio, stock));
+		purchaseHistoryRepository.save(
+			createPurchaseHistory(null, LocalDateTime.now(), Count.from(1), Money.won(1000000), "memo",
+				portfolioHolding));
+		fcmRepository.save(createFcmToken("token", member));
+		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
+
+		PushNotificationEvent event = new PushNotificationEvent(
+			PurchaseHistoryEventSendableParameter.create(portfolio.getId(), member.getId()));
+		// when
+		CompletableFuture<PortfolioNotifyMessagesResponse> future = purchaseHistoryEventListener.notifyMaxLoss(event);
+		// then
+		PortfolioNotifyMessagesResponse response = future.join();
+		assertThat(response.getNotifications()).hasSize(1);
+		assertThat(notificationRepository.findAllByMemberId(member.getId())).hasSize(1);
 	}
 }

--- a/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/notification/service/NotificationServiceTest.java
@@ -520,7 +520,7 @@ class NotificationServiceTest extends AbstractContainerBaseTest {
 
 				List<String> tickerSymbols = Stream.of(stock)
 					.map(Stock::getTickerSymbol)
-					.collect(Collectors.toList());
+					.toList();
 
 				// when
 				NotifyMessageResponse response = service.notifyTargetPriceToAllMember(tickerSymbols);

--- a/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
@@ -26,6 +26,7 @@ import codesquad.fineants.domain.fcm.repository.FcmRepository;
 import codesquad.fineants.domain.fcm.service.FirebaseMessagingService;
 import codesquad.fineants.domain.holding.domain.entity.PortfolioHolding;
 import codesquad.fineants.domain.holding.repository.PortfolioHoldingRepository;
+import codesquad.fineants.domain.kis.client.KisClient;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
 import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
@@ -47,6 +48,7 @@ import codesquad.fineants.global.errors.errorcode.MemberErrorCode;
 import codesquad.fineants.global.errors.errorcode.PortfolioErrorCode;
 import codesquad.fineants.global.errors.errorcode.PurchaseHistoryErrorCode;
 import codesquad.fineants.global.errors.exception.FineAntsException;
+import reactor.core.publisher.Mono;
 
 class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 
@@ -82,6 +84,9 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 
 	@MockBean
 	private NotificationSentRepository sentManager;
+
+	@MockBean
+	private KisClient kisClient;
 
 	@WithMockUser
 	@DisplayName("사용자는 매입 이력을 추가한다")
@@ -157,6 +162,8 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 			.willReturn(false);
 		given(firebaseMessagingService.send(any(Message.class)))
 			.willReturn(Optional.of("messageId"));
+		given(kisClient.fetchCurrentPrice(anyString()))
+			.willReturn(Mono.just(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L)));
 
 		setAuthentication(member);
 		// when
@@ -397,6 +404,8 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		PurchaseHistory history = purchaseHistoryRepository.save(
 			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(50000), "첫구매",
 				holding));
+		given(kisClient.fetchCurrentPrice(anyString()))
+			.willReturn(Mono.just(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L)));
 
 		setAuthentication(member);
 		// when

--- a/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.BDDMockito.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,8 +15,6 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.test.context.support.WithMockUser;
-
-import com.google.firebase.messaging.Message;
 
 import codesquad.fineants.AbstractContainerBaseTest;
 import codesquad.fineants.domain.common.count.Count;
@@ -134,92 +131,6 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		);
 	}
 
-	@DisplayName("사용자는 매입 이력 추가시 목표 수익률을 달성하여 알림을 받는다")
-	@Test
-	void addPurchaseHistory_whenAchieveTargetGain_thenSaveNotification() {
-		// given
-		Member member = memberRepository.save(createMember());
-		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
-		Stock stock = stockRepository.save(createSamsungStock());
-		Stock stock2 = stockRepository.save(createDongwhaPharmStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
-		portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock2));
-		purchaseHistoryRepository.save(
-			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(50000), "첫구매",
-				holding));
-		fcmRepository.save(createFcmToken("token", member));
-		fcmRepository.save(createFcmToken("token2", member));
-
-		PurchaseHistoryCreateRequest request = PurchaseHistoryCreateRequest.builder()
-			.purchaseDate(LocalDateTime.now())
-			.numShares(Count.from(100L))
-			.purchasePricePerShare(Money.won(100.0))
-			.memo("첫구매")
-			.build();
-
-		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
-		given(sentManager.hasTargetGainSendHistory(anyLong()))
-			.willReturn(false);
-		given(firebaseMessagingService.send(any(Message.class)))
-			.willReturn(Optional.of("messageId"));
-		given(kisClient.fetchCurrentPrice(anyString()))
-			.willReturn(Mono.just(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L)));
-
-		setAuthentication(member);
-		// when
-		PurchaseHistoryCreateResponse response = service.createPurchaseHistory(
-			request,
-			portfolio.getId(),
-			holding.getId(),
-			member.getId()
-		);
-
-		// then
-		assertAll(
-			() -> assertThat(response.getId()).isNotNull(),
-			() -> assertThat(notificationRepository.findAllByMemberId(member.getId())).hasSize(1)
-		);
-	}
-
-	@DisplayName("사용자는 매입 이력 추가시 최대 손실율에 달성하여 알림을 받는다")
-	@Test
-	void addPurchaseHistory_whenAchieveMaxLoss_thenSaveNotification() {
-		// given
-		Member member = memberRepository.save(createMember());
-		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
-		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
-		fcmRepository.save(createFcmToken("token", member));
-
-		PurchaseHistoryCreateRequest request = PurchaseHistoryCreateRequest.builder()
-			.purchaseDate(LocalDateTime.now())
-			.numShares(Count.from(10L))
-			.purchasePricePerShare(Money.won(90000.0))
-			.memo("첫구매")
-			.build();
-
-		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
-		given(sentManager.hasTargetGainSendHistory(anyLong()))
-			.willReturn(false);
-		given(firebaseMessagingService.send(any(Message.class)))
-			.willReturn(Optional.of("messageId"));
-
-		setAuthentication(member);
-		// when
-		PurchaseHistoryCreateResponse response = service.createPurchaseHistory(
-			request,
-			portfolio.getId(),
-			holding.getId(),
-			member.getId()
-		);
-
-		// then
-		assertAll(
-			() -> assertThat(response.getId()).isNotNull(),
-			() -> assertThat(notificationRepository.findAllByMemberId(member.getId())).hasSize(1)
-		);
-	}
-
 	@DisplayName("사용자가 매입 이력을 추가할 때 예산이 부족해 실패한다.")
 	@Test
 	void addPurchaseHistoryFailsWhenTotalInvestmentExceedsBudget() {
@@ -316,52 +227,6 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		);
 	}
 
-	@DisplayName("사용자는 매입 이력을 수정시 목표 수익율을 달성하여 알림을 받는다")
-	@Test
-	void modifyPurchaseHistory_whenTargetGain_thenSaveNotification() {
-		// given
-		Member member = memberRepository.save(createMember());
-		fcmRepository.save(createFcmToken("token", member));
-		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
-		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
-		PurchaseHistory history = purchaseHistoryRepository.save(
-			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(50000), "첫구매",
-				holding));
-
-		PurchaseHistoryUpdateRequest request = PurchaseHistoryUpdateRequest.builder()
-			.purchaseDate(LocalDateTime.now())
-			.numShares(Count.from(100L))
-			.purchasePricePerShare(Money.won(100.0))
-			.memo("첫구매")
-			.build();
-
-		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
-		given(sentManager.hasTargetGainSendHistory(anyLong()))
-			.willReturn(false);
-		given(firebaseMessagingService.send(any(Message.class)))
-			.willReturn(Optional.of("messageId"));
-
-		setAuthentication(member);
-		// when
-		PurchaseHistoryUpdateResponse response = service.updatePurchaseHistory(
-			request,
-			holding.getId(),
-			history.getId(),
-			portfolio.getId(),
-			member.getId()
-		);
-
-		// then
-		PurchaseHistory changePurchaseHistory = purchaseHistoryRepository.findById(history.getId()).orElseThrow();
-		assertAll(
-			() -> assertThat(response).extracting("id").isNotNull(),
-			() -> assertThat(response.getNumShares()).isEqualByComparingTo(Count.from(100)),
-			() -> assertThat(changePurchaseHistory.getNumShares()).isEqualByComparingTo(Count.from(100L)),
-			() -> assertThat(notificationRepository.findAllByMemberId(member.getId())).hasSize(1)
-		);
-	}
-
 	@DisplayName("회원은 다른 회원의 매입 이력을 수정할 수 없다")
 	@Test
 	void modifyPurchaseHistory_whenOtherMemberModify_thenThrowException() {
@@ -420,45 +285,6 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		assertAll(
 			() -> assertThat(response).extracting("id").isNotNull(),
 			() -> assertThat(purchaseHistoryRepository.findById(history.getId())).isEmpty()
-		);
-	}
-
-	@DisplayName("사용자는 매입 이력 삭제시 목표 수익율을 달성하여 알림을 받는다")
-	@Test
-	void deletePurchaseHistory_whenTargetGain_thenSaveNotification() {
-		// given
-		Member member = memberRepository.save(createMember());
-		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
-		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
-		PurchaseHistory history = purchaseHistoryRepository.save(
-			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(10000000),
-				"첫구매",
-				holding));
-		purchaseHistoryRepository.save(
-			createPurchaseHistory(null, LocalDateTime.now(), Count.from(100), Money.won(100), "첫구매", holding));
-		fcmRepository.save(createFcmToken("token", member));
-
-		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
-		given(sentManager.hasTargetGainSendHistory(anyLong()))
-			.willReturn(false);
-		given(firebaseMessagingService.send(any(Message.class)))
-			.willReturn(Optional.of("messageId"));
-
-		setAuthentication(member);
-		// when
-		PurchaseHistoryDeleteResponse response = service.deletePurchaseHistory(
-			holding.getId(),
-			history.getId(),
-			portfolio.getId(),
-			member.getId()
-		);
-
-		// then
-		assertAll(
-			() -> assertThat(response).extracting("id").isNotNull(),
-			() -> assertThat(purchaseHistoryRepository.findById(history.getId())).isEmpty(),
-			() -> assertThat(notificationRepository.findAllByMemberId(member.getId())).hasSize(1)
 		);
 	}
 

--- a/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
@@ -432,7 +432,8 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		Stock stock = stockRepository.save(createSamsungStock());
 		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
 		PurchaseHistory history = purchaseHistoryRepository.save(
-			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(50000), "첫구매",
+			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(10000000),
+				"첫구매",
 				holding));
 		purchaseHistoryRepository.save(
 			createPurchaseHistory(null, LocalDateTime.now(), Count.from(100), Money.won(100), "첫구매", holding));

--- a/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
@@ -232,7 +232,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 					LocalDate.parse("20240630", dtf),
 					LocalDate.parse("20240814", dtf))
 			)));
-		given(delayManager.getDelay()).willReturn(Duration.ZERO);
+		given(delayManager.delay()).willReturn(Duration.ZERO);
 		// when
 		StockReloadResponse response = stockService.reloadStocks();
 		// then
@@ -305,7 +305,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 				KisDividend.create(s.getTickerSymbol(), Money.won(300), LocalDate.of(2024, 5, 1),
 					LocalDate.of(2024, 7, 1)))))
 		);
-		given(delayManager.getDelay()).willReturn(Duration.ZERO);
+		given(delayManager.delay()).willReturn(Duration.ZERO);
 		// when
 		stockService.scheduledReloadStocks();
 		// then


### PR DESCRIPTION
## 구현한 것

- 매입 이력 이벤트에 따른 알람 서비스에서 삭제된 매입 이력이 같이 조회되는 문제를 해결하였습니다.
- 주식 현재가 갱신시 Flux를 이용하도록 변경 (리팩토링 진행중)
