### PR TITLE
[fix] 액세스 토큰 재발급 문제 해결 

### DIFF
--- a/src/main/java/codesquad/fineants/domain/dividend/service/StockDividendService.java
+++ b/src/main/java/codesquad/fineants/domain/dividend/service/StockDividendService.java
@@ -64,7 +64,7 @@ public class StockDividendService {
 		// 0. 올해 말까지의 배당 일정을 조회
 		LocalDate now = localDateTimeService.getLocalDateWithNow();
 		LocalDate to = now.with(TemporalAdjusters.lastDayOfYear());
-		List<KisDividend> kisDividends = kisService.fetchDividendAll(now, to);
+		List<KisDividend> kisDividends = kisService.fetchDividendsBetween(now, to);
 
 		// 1. 새로운 배당 일정 탐색
 		Map<String, Stock> stockMap = getStockMapBy(kisDividends);

--- a/src/main/java/codesquad/fineants/domain/holding/event/listener/PortfolioHoldingEventListener.java
+++ b/src/main/java/codesquad/fineants/domain/holding/event/listener/PortfolioHoldingEventListener.java
@@ -24,6 +24,6 @@ public class PortfolioHoldingEventListener {
 		log.info("포트폴리오 종목 추가로 인한 종목 현재가 및 종가 갱신 수행");
 		String tickerSymbol = event.getTickerSymbol();
 		kisService.refreshStockCurrentPrice(List.of(tickerSymbol));
-		kisService.refreshLastDayClosingPrice(List.of(tickerSymbol));
+		kisService.refreshClosingPrice(List.of(tickerSymbol));
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/kis/aop/AccessTokenAspect.java
+++ b/src/main/java/codesquad/fineants/domain/kis/aop/AccessTokenAspect.java
@@ -12,11 +12,15 @@ import codesquad.fineants.domain.kis.client.KisAccessToken;
 import codesquad.fineants.domain.kis.client.KisClient;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.kis.service.KisAccessTokenRedisService;
+import codesquad.fineants.global.common.delay.DelayManager;
 import codesquad.fineants.global.common.time.LocalDateTimeService;
 import codesquad.fineants.global.errors.errorcode.KisErrorCode;
 import codesquad.fineants.global.errors.exception.FineAntsException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import reactor.core.Exceptions;
+import reactor.core.publisher.Mono;
+import reactor.util.retry.Retry;
 
 @Aspect
 @Component
@@ -28,6 +32,7 @@ public class AccessTokenAspect {
 	private final KisClient client;
 	private final KisAccessTokenRedisService redisService;
 	private final LocalDateTimeService localDateTimeService;
+	private final DelayManager delayManager;
 
 	@Before(value = "@annotation(CheckedKisAccessToken) && args(..)")
 	public void checkAccessTokenExpiration() {
@@ -36,7 +41,10 @@ public class AccessTokenAspect {
 		if (manager.isTokenExpiringSoon(now)) {
 			client.fetchAccessToken()
 				.doOnSuccess(kisAccessToken -> log.debug("success the kis access token issue : {}", kisAccessToken))
-				.blockOptional(Duration.ofMinutes(10))
+				.retryWhen(Retry.fixedDelay(5, delayManager.fixedAccessTokenDelay()))
+				.onErrorResume(Exceptions::isRetryExhausted, throwable -> Mono.empty())
+				.onErrorResume(throwable -> Mono.empty())
+				.blockOptional(delayManager.timeout())
 				.ifPresent(newKisAccessToken -> {
 					redisService.setAccessTokenMap(newKisAccessToken, now);
 					manager.refreshAccessToken(newKisAccessToken);
@@ -62,6 +70,9 @@ public class AccessTokenAspect {
 
 	private Optional<KisAccessToken> handleNewAccessToken() {
 		Optional<KisAccessToken> result = client.fetchAccessToken()
+			.doOnSuccess(kisAccessToken -> log.debug("success the kis access token issue : {}", kisAccessToken))
+			.retryWhen(Retry.fixedDelay(5, delayManager.fixedAccessTokenDelay()))
+			.onErrorResume(throwable -> Mono.empty())
 			.blockOptional(Duration.ofMinutes(10));
 		log.info("new access Token Issue : {}", result);
 		return result;

--- a/src/main/java/codesquad/fineants/domain/kis/aop/AccessTokenAspect.java
+++ b/src/main/java/codesquad/fineants/domain/kis/aop/AccessTokenAspect.java
@@ -35,6 +35,7 @@ public class AccessTokenAspect {
 		// 액세스 토큰이 만료 1시간 이전이라면 토큰을 재발급한다
 		if (manager.isTokenExpiringSoon(now)) {
 			client.fetchAccessToken()
+				.doOnSuccess(kisAccessToken -> log.debug("success the kis access token issue : {}", kisAccessToken))
 				.blockOptional(Duration.ofMinutes(10))
 				.ifPresent(newKisAccessToken -> {
 					redisService.setAccessTokenMap(newKisAccessToken, now);

--- a/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
@@ -168,7 +168,7 @@ public class KisClient {
 		);
 	}
 
-	public Mono<List<KisDividend>> fetchDividendAll(LocalDate from, LocalDate to) {
+	public Mono<List<KisDividend>> fetchDividendsBetween(LocalDate from, LocalDate to) {
 		MultiValueMap<String, String> header = KisHeaderBuilder.builder()
 			.add(CONTENT_TYPE, APPLICATION_JSON_UTF8)
 			.add(AUTHORIZATION, manager.createAuthorization())

--- a/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
@@ -17,7 +17,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import codesquad.fineants.domain.kis.aop.CheckedKisAccessToken;
 import codesquad.fineants.domain.kis.domain.dto.response.KisClosingPrice;
 import codesquad.fineants.domain.kis.domain.dto.response.KisDividend;
 import codesquad.fineants.domain.kis.domain.dto.response.KisDividendWrapper;
@@ -97,7 +96,6 @@ public class KisClient {
 	}
 
 	// 직전 거래일의 종가 조회
-	@CheckedKisAccessToken
 	public Mono<KisClosingPrice> fetchClosingPrice(String tickerSymbol) {
 		MultiValueMap<String, String> header = KisHeaderBuilder.builder()
 			.add(AUTHORIZATION, manager.createAuthorization())
@@ -134,7 +132,6 @@ public class KisClient {
 	 * @param tickerSymbol 종목의 단축코드
 	 * @return 종목의 배당 일정 정보
 	 */
-	@CheckedKisAccessToken
 	public Mono<KisDividendWrapper> fetchDividendThisYear(String tickerSymbol) {
 		LocalDate today = LocalDate.now();
 		// 해당 년도 첫일
@@ -171,7 +168,6 @@ public class KisClient {
 		).retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofSeconds(5)));
 	}
 
-	@CheckedKisAccessToken
 	public Mono<List<KisDividend>> fetchDividendAll(LocalDate from, LocalDate to) {
 		MultiValueMap<String, String> header = KisHeaderBuilder.builder()
 			.add(CONTENT_TYPE, APPLICATION_JSON_UTF8)
@@ -198,7 +194,6 @@ public class KisClient {
 		).map(KisDividendWrapper::getKisDividends);
 	}
 
-	@CheckedKisAccessToken
 	public Mono<KisIpoResponse> fetchIpo(LocalDate from, LocalDate to) {
 		MultiValueMap<String, String> header = KisHeaderBuilder.builder()
 			.add(CONTENT_TYPE, APPLICATION_JSON_UTF8)
@@ -228,7 +223,6 @@ public class KisClient {
 		return localDate.format(DateTimeFormatter.BASIC_ISO_DATE);
 	}
 
-	@CheckedKisAccessToken
 	public Mono<KisSearchStockInfo> fetchSearchStockInfo(String tickerSymbol) {
 		MultiValueMap<String, String> header = KisHeaderBuilder.builder()
 			.add(CONTENT_TYPE, APPLICATION_JSON_UTF8)

--- a/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
@@ -70,7 +70,6 @@ public class KisClient {
 			.retrieve()
 			.onStatus(HttpStatusCode::isError, this::handleError)
 			.bodyToMono(KisAccessToken.class)
-			.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofMinutes(1)))
 			.log();
 	}
 

--- a/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
@@ -37,6 +37,7 @@ import codesquad.fineants.domain.kis.properties.kiscodevalue.imple.GB1;
 import codesquad.fineants.domain.kis.properties.kiscodevalue.imple.PrdtTypeCd;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.global.errors.exception.KisException;
+import codesquad.fineants.global.util.ObjectMapperUtil;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
@@ -267,6 +268,9 @@ public class KisClient {
 	private Mono<? extends Throwable> handleError(ClientResponse clientResponse) {
 		return clientResponse.bodyToMono(String.class)
 			.doOnNext(log::error)
-			.flatMap(body -> Mono.error(() -> new KisException(body)));
+			.flatMap(body -> {
+				KisException exception = ObjectMapperUtil.deserialize(body, KisException.class);
+				return Mono.error(() -> exception);
+			});
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
+++ b/src/main/java/codesquad/fineants/domain/kis/client/KisClient.java
@@ -165,7 +165,7 @@ public class KisClient {
 			header,
 			queryParam,
 			KisDividendWrapper.class
-		).retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofSeconds(5)));
+		);
 	}
 
 	public Mono<List<KisDividend>> fetchDividendAll(LocalDate from, LocalDate to) {

--- a/src/main/java/codesquad/fineants/domain/kis/controller/KisRestController.java
+++ b/src/main/java/codesquad/fineants/domain/kis/controller/KisRestController.java
@@ -1,7 +1,5 @@
 package codesquad.fineants.domain.kis.controller;
 
-import java.time.Duration;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -25,7 +23,6 @@ import codesquad.fineants.global.api.ApiResponse;
 import codesquad.fineants.global.success.KisSuccessCode;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Mono;
-import reactor.util.retry.Retry;
 
 @RestController
 @RequestMapping("/api/kis")
@@ -92,10 +89,7 @@ public class KisRestController {
 	@GetMapping("/dividend/{tickerSymbol}")
 	@Secured(value = {"ROLE_MANAGER", "ROLE_ADMIN"})
 	public ApiResponse<List<KisDividend>> fetchDividend(@PathVariable String tickerSymbol) {
-		return ApiResponse.success(KisSuccessCode.OK_FETCH_DIVIDEND, service.fetchDividend(tickerSymbol)
-			.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofSeconds(5)))
-			.blockOptional(Duration.ofMinutes(1))
-			.orElseGet(Collections::emptyList));
+		return ApiResponse.success(KisSuccessCode.OK_FETCH_DIVIDEND, service.fetchDividend(tickerSymbol));
 	}
 
 	@DeleteMapping("/access-token")

--- a/src/main/java/codesquad/fineants/domain/kis/controller/KisRestController.java
+++ b/src/main/java/codesquad/fineants/domain/kis/controller/KisRestController.java
@@ -66,7 +66,7 @@ public class KisRestController {
 	@PostMapping("/closing-price/all/refresh")
 	@Secured(value = {"ROLE_MANAGER", "ROLE_ADMIN"})
 	public ApiResponse<List<KisClosingPrice>> refreshAllLastDayClosingPrice() {
-		List<KisClosingPrice> responses = service.refreshAllLastDayClosingPrice();
+		List<KisClosingPrice> responses = service.refreshAllClosingPrice();
 		return ApiResponse.success(KisSuccessCode.OK_REFRESH_LAST_DAY_CLOSING_PRICE, responses);
 	}
 
@@ -76,7 +76,7 @@ public class KisRestController {
 	public ApiResponse<List<KisClosingPrice>> refreshLastDayClosingPrice(
 		@RequestBody StockPriceRefreshRequest request
 	) {
-		List<KisClosingPrice> responses = service.refreshLastDayClosingPrice(request.getTickerSymbols());
+		List<KisClosingPrice> responses = service.refreshClosingPrice(request.getTickerSymbols());
 		return ApiResponse.success(KisSuccessCode.OK_REFRESH_LAST_DAY_CLOSING_PRICE, responses);
 	}
 

--- a/src/main/java/codesquad/fineants/domain/kis/controller/KisRestController.java
+++ b/src/main/java/codesquad/fineants/domain/kis/controller/KisRestController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.springframework.security.access.annotation.Secured;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import codesquad.fineants.domain.kis.client.KisAccessToken;
 import codesquad.fineants.domain.kis.client.KisCurrentPrice;
 import codesquad.fineants.domain.kis.domain.dto.request.StockPriceRefreshRequest;
 import codesquad.fineants.domain.kis.domain.dto.response.KisClosingPrice;
@@ -94,5 +96,10 @@ public class KisRestController {
 			.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofSeconds(5)))
 			.blockOptional(Duration.ofMinutes(1))
 			.orElseGet(Collections::emptyList));
+	}
+
+	@DeleteMapping("/access-token")
+	public ApiResponse<KisAccessToken> deleteAccessToken() {
+		return ApiResponse.ok("액세스 토큰을 삭제하였습니다.", service.deleteAccessToken());
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/kis/domain/dto/response/KisErrorResponse.java
+++ b/src/main/java/codesquad/fineants/domain/kis/domain/dto/response/KisErrorResponse.java
@@ -1,0 +1,23 @@
+package codesquad.fineants.domain.kis.domain.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import codesquad.fineants.global.errors.exception.KisException;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+public class KisErrorResponse {
+	@JsonProperty("rt_cd")
+	private String returnCode;
+	@JsonProperty("msg_cd")
+	private String messageCode;
+	@JsonProperty("msg1")
+	private String message;
+
+	public KisException toException() {
+		return new KisException(returnCode, messageCode, message);
+	}
+}

--- a/src/main/java/codesquad/fineants/domain/kis/domain/dto/response/KisErrorResponse.java
+++ b/src/main/java/codesquad/fineants/domain/kis/domain/dto/response/KisErrorResponse.java
@@ -2,6 +2,7 @@ package codesquad.fineants.domain.kis.domain.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import codesquad.fineants.global.errors.exception.kis.CredentialsTypeKisException;
 import codesquad.fineants.global.errors.exception.kis.ExpiredAccessTokenKisException;
 import codesquad.fineants.global.errors.exception.kis.KisException;
 import codesquad.fineants.global.errors.exception.kis.RequestLimitExceededKisException;
@@ -25,6 +26,7 @@ public class KisErrorResponse {
 			case "EGW00201" -> new RequestLimitExceededKisException(returnCode, messageCode, message);
 			case "EGW00133" -> new TokenIssuanceRetryLaterKisException(returnCode, messageCode, message);
 			case "EGW00123" -> new ExpiredAccessTokenKisException(returnCode, messageCode, message);
+			case "EGW00205" -> new CredentialsTypeKisException(returnCode, messageCode, message);
 			default -> new KisException(returnCode, messageCode, message);
 		};
 	}

--- a/src/main/java/codesquad/fineants/domain/kis/domain/dto/response/KisErrorResponse.java
+++ b/src/main/java/codesquad/fineants/domain/kis/domain/dto/response/KisErrorResponse.java
@@ -2,7 +2,10 @@ package codesquad.fineants.domain.kis.domain.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import codesquad.fineants.global.errors.exception.KisException;
+import codesquad.fineants.global.errors.exception.kis.ExpiredAccessTokenKisException;
+import codesquad.fineants.global.errors.exception.kis.KisException;
+import codesquad.fineants.global.errors.exception.kis.RequestLimitExceededKisException;
+import codesquad.fineants.global.errors.exception.kis.TokenIssuanceRetryLaterKisException;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -18,6 +21,11 @@ public class KisErrorResponse {
 	private String message;
 
 	public KisException toException() {
-		return new KisException(returnCode, messageCode, message);
+		return switch (messageCode) {
+			case "EGW00201" -> new RequestLimitExceededKisException(returnCode, messageCode, message);
+			case "EGW00133" -> new TokenIssuanceRetryLaterKisException(returnCode, messageCode, message);
+			case "EGW00123" -> new ExpiredAccessTokenKisException(returnCode, messageCode, message);
+			default -> new KisException(returnCode, messageCode, message);
+		};
 	}
 }

--- a/src/main/java/codesquad/fineants/domain/kis/repository/KisAccessTokenRepository.java
+++ b/src/main/java/codesquad/fineants/domain/kis/repository/KisAccessTokenRepository.java
@@ -32,6 +32,9 @@ public class KisAccessTokenRepository {
 	}
 
 	public String createAuthorization() {
+		if (accessToken == null) {
+			return null;
+		}
 		return accessToken.createAuthorization();
 	}
 

--- a/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
@@ -177,9 +177,9 @@ public class KisService {
 
 	@CheckedKisAccessToken
 	public List<KisDividend> fetchDividendsBetween(LocalDate from, LocalDate to) {
-		return kisClient.fetchDividendAll(from, to)
-			.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofSeconds(5)))
-			.blockOptional(TIMEOUT)
+		return kisClient.fetchDividendsBetween(from, to)
+			.retryWhen(Retry.fixedDelay(5, delayManager.fixedDelay()))
+			.blockOptional(delayManager.timeout())
 			.orElseGet(Collections::emptyList).stream()
 			.sorted()
 			.toList();

--- a/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
@@ -125,6 +125,7 @@ public class KisService {
 		return future;
 	}
 
+	@CheckedKisAccessToken
 	public Mono<KisCurrentPrice> fetchCurrentPrice(String tickerSymbol) {
 		return Mono.defer(() -> kisClient.fetchCurrentPrice(tickerSymbol));
 	}
@@ -141,13 +142,14 @@ public class KisService {
 	}
 
 	// 종목 종가 모두 갱신
-
+	@CheckedKisAccessToken
 	public List<KisClosingPrice> refreshAllLastDayClosingPrice() {
 		List<String> tickerSymbols = portFolioHoldingRepository.findAllTickerSymbol();
 		return refreshLastDayClosingPrice(tickerSymbols);
 	}
 
 	// 종목 종가 일부 갱신
+	@CheckedKisAccessToken
 	public List<KisClosingPrice> refreshLastDayClosingPrice(List<String> tickerSymbols) {
 		List<KisClosingPrice> lastDayClosingPrices = readLastDayClosingPriceResponses(tickerSymbols);
 		lastDayClosingPrices.forEach(closingPriceRepository::addPrice);
@@ -187,6 +189,7 @@ public class KisService {
 		return future;
 	}
 
+	@CheckedKisAccessToken
 	public Mono<KisClosingPrice> fetchClosingPrice(String tickerSymbol) {
 		return kisClient.fetchClosingPrice(tickerSymbol);
 	}
@@ -198,6 +201,7 @@ public class KisService {
 	 * @return 종목의 배당 일정 정보
 	 */
 
+	@CheckedKisAccessToken
 	public Mono<List<KisDividend>> fetchDividend(String tickerSymbol) {
 		return kisClient.fetchDividendThisYear(tickerSymbol)
 			.map(KisDividendWrapper::getKisDividends)
@@ -205,6 +209,7 @@ public class KisService {
 			.onErrorResume(e -> Mono.empty());
 	}
 
+	@CheckedKisAccessToken
 	public List<KisDividend> fetchDividendAll(LocalDate from, LocalDate to) {
 		return kisClient.fetchDividendAll(from, to)
 			.retryWhen(Retry.fixedDelay(Long.MAX_VALUE, Duration.ofSeconds(5)))
@@ -220,6 +225,7 @@ public class KisService {
 	 * @param tickerSymbol 종목 티커 심볼
 	 * @return 종목 정보
 	 */
+	@CheckedKisAccessToken
 	public Mono<KisSearchStockInfo> fetchSearchStockInfo(String tickerSymbol) {
 		return kisClient.fetchSearchStockInfo(tickerSymbol)
 			.doOnSuccess(response -> log.debug("fetchSearchStockInfo ticker is {}", response.getTickerSymbol()))
@@ -233,6 +239,7 @@ public class KisService {
 	 *
 	 * @return 종목 정보 리스트
 	 */
+	@CheckedKisAccessToken
 	public Set<StockDataResponse.StockIntegrationInfo> fetchStockInfoInRangedIpo() {
 		LocalDate today = LocalDate.now();
 		LocalDate yesterday = today.minusDays(1);

--- a/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
@@ -39,9 +39,9 @@ import codesquad.fineants.domain.stock_target_price.domain.entity.StockTargetPri
 import codesquad.fineants.domain.stock_target_price.event.publisher.StockTargetPricePublisher;
 import codesquad.fineants.domain.stock_target_price.repository.StockTargetPriceRepository;
 import codesquad.fineants.global.common.delay.DelayManager;
-import codesquad.fineants.global.errors.exception.ExpiredKisAccessTokenException;
-import codesquad.fineants.global.errors.exception.KisException;
-import codesquad.fineants.global.errors.exception.RequestLimitExceededException;
+import codesquad.fineants.global.errors.exception.kis.ExpiredAccessTokenKisException;
+import codesquad.fineants.global.errors.exception.kis.KisException;
+import codesquad.fineants.global.errors.exception.kis.RequestLimitExceededKisException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
@@ -93,14 +93,14 @@ public class KisService {
 				.doOnSuccess(kisCurrentPrice -> log.debug("reload stock current price {}", kisCurrentPrice))
 				.onErrorResume(throwable -> {
 					log.error(throwable.getMessage());
-					if (throwable instanceof ExpiredKisAccessTokenException) {
+					if (throwable instanceof ExpiredAccessTokenKisException) {
 						return Mono.empty();
 					} else {
 						return Mono.error(throwable);
 					}
 				})
 				.retryWhen(Retry.fixedDelay(3, delayManager.fixedDelay())
-					.filter(RequestLimitExceededException.class::isInstance))
+					.filter(RequestLimitExceededKisException.class::isInstance))
 				.blockOptional(delayManager.timeout())
 				.orElse(null);
 			if (price != null) {

--- a/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
+++ b/src/main/java/codesquad/fineants/domain/kis/service/KisService.java
@@ -55,7 +55,6 @@ public class KisService {
 	private static final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
 	public static final Duration DELAY = Duration.ofMillis(50L);
 	public static final Duration TIMEOUT = Duration.ofMinutes(10L);
-
 	private final KisClient kisClient;
 	private final PortfolioHoldingRepository portFolioHoldingRepository;
 	private final CurrentPriceRedisRepository currentPriceRedisRepository;
@@ -93,13 +92,12 @@ public class KisService {
 				.onErrorResume(ExpiredAccessTokenKisException.class::isInstance, throwable -> Mono.empty())
 				.retryWhen(Retry.fixedDelay(5, delayManager.fixedDelay())
 					.filter(RequestLimitExceededKisException.class::isInstance))
-				.onErrorResume(Exceptions::isRetryExhausted, throwable -> Mono.empty())
-				.onErrorResume(Mono::error))
+				.onErrorResume(Exceptions::isRetryExhausted, throwable -> Mono.empty()))
 			.collectList()
 			.blockOptional(delayManager.timeout())
 			.orElseGet(Collections::emptyList);
 		currentPriceRedisRepository.savePrice(toArray(prices));
-		log.info("The current stock price has renewed {} out of {}", prices.size(), tickerSymbols.size());
+		log.info("The stock's current price has renewed {} out of {}", prices.size(), tickerSymbols.size());
 		return prices;
 	}
 

--- a/src/main/java/codesquad/fineants/domain/watchlist/event/listener/WatchStockEventListener.java
+++ b/src/main/java/codesquad/fineants/domain/watchlist/event/listener/WatchStockEventListener.java
@@ -24,6 +24,6 @@ public class WatchStockEventListener {
 		log.info("포트폴리오 종목 추가로 인한 종목 현재가 및 종가 갱신 수행");
 		String tickerSymbol = event.getTickerSymbol();
 		kisService.refreshStockCurrentPrice(List.of(tickerSymbol));
-		kisService.refreshLastDayClosingPrice(List.of(tickerSymbol));
+		kisService.refreshClosingPrice(List.of(tickerSymbol));
 	}
 }

--- a/src/main/java/codesquad/fineants/global/common/delay/DelayManager.java
+++ b/src/main/java/codesquad/fineants/global/common/delay/DelayManager.java
@@ -7,6 +7,7 @@ public interface DelayManager {
 	Duration DEFAULT_DELAY = Duration.ofMillis(50);
 	Duration TIMEOUT = Duration.ofMinutes(10);
 	Duration FIXED_DELAY = Duration.ofSeconds(5);
+	Duration FIXED_ACCESS_TOKEN_DELAY = Duration.ofMinutes(1);
 
 	default Duration delay() {
 		return DEFAULT_DELAY;
@@ -18,5 +19,9 @@ public interface DelayManager {
 
 	default Duration fixedDelay() {
 		return FIXED_DELAY;
+	}
+
+	default Duration fixedAccessTokenDelay() {
+		return FIXED_ACCESS_TOKEN_DELAY;
 	}
 }

--- a/src/main/java/codesquad/fineants/global/errors/exception/ExpiredKisAccessTokenException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/ExpiredKisAccessTokenException.java
@@ -1,0 +1,8 @@
+package codesquad.fineants.global.errors.exception;
+
+public class ExpiredKisAccessTokenException extends KisException {
+
+	public ExpiredKisAccessTokenException(String returnCode, String messageCode, String message) {
+		super(returnCode, messageCode, message);
+	}
+}

--- a/src/main/java/codesquad/fineants/global/errors/exception/ExpiredKisAccessTokenException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/ExpiredKisAccessTokenException.java
@@ -1,8 +1,0 @@
-package codesquad.fineants.global.errors.exception;
-
-public class ExpiredKisAccessTokenException extends KisException {
-
-	public ExpiredKisAccessTokenException(String returnCode, String messageCode, String message) {
-		super(returnCode, messageCode, message);
-	}
-}

--- a/src/main/java/codesquad/fineants/global/errors/exception/KisException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/KisException.java
@@ -6,9 +6,14 @@ import lombok.ToString;
 @Getter
 @ToString
 public class KisException extends RuntimeException {
+	private final String returnCode;
+	private final String messageCode;
 	private final String message;
 
-	public KisException(String message) {
+	public KisException(String returnCode, String messageCode, String message) {
+		super(message);
+		this.returnCode = returnCode;
+		this.messageCode = messageCode;
 		this.message = message;
 	}
 }

--- a/src/main/java/codesquad/fineants/global/errors/exception/RequestLimitExceededException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/RequestLimitExceededException.java
@@ -1,7 +1,0 @@
-package codesquad.fineants.global.errors.exception;
-
-public class RequestLimitExceededException extends KisException {
-	public RequestLimitExceededException(String returnCode, String messageCode, String message) {
-		super(returnCode, messageCode, message);
-	}
-}

--- a/src/main/java/codesquad/fineants/global/errors/exception/RequestLimitExceededException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/RequestLimitExceededException.java
@@ -1,0 +1,7 @@
+package codesquad.fineants.global.errors.exception;
+
+public class RequestLimitExceededException extends KisException {
+	public RequestLimitExceededException(String returnCode, String messageCode, String message) {
+		super(returnCode, messageCode, message);
+	}
+}

--- a/src/main/java/codesquad/fineants/global/errors/exception/kis/CredentialsTypeKisException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/kis/CredentialsTypeKisException.java
@@ -1,0 +1,8 @@
+package codesquad.fineants.global.errors.exception.kis;
+
+public class CredentialsTypeKisException extends KisException {
+
+	public CredentialsTypeKisException(String returnCode, String messageCode, String message) {
+		super(returnCode, messageCode, message);
+	}
+}

--- a/src/main/java/codesquad/fineants/global/errors/exception/kis/ExpiredAccessTokenKisException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/kis/ExpiredAccessTokenKisException.java
@@ -1,0 +1,8 @@
+package codesquad.fineants.global.errors.exception.kis;
+
+public class ExpiredAccessTokenKisException extends KisException {
+
+	public ExpiredAccessTokenKisException(String returnCode, String messageCode, String message) {
+		super(returnCode, messageCode, message);
+	}
+}

--- a/src/main/java/codesquad/fineants/global/errors/exception/kis/KisException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/kis/KisException.java
@@ -16,4 +16,16 @@ public class KisException extends RuntimeException {
 		this.messageCode = messageCode;
 		this.message = message;
 	}
+
+	public static KisException expiredAccessToken() {
+		return new ExpiredAccessTokenKisException("1", "EGW00123", "기간이 만료된 token 입니다.");
+	}
+
+	public static KisException requestLimitExceeded() {
+		return new RequestLimitExceededKisException("1", "EGW00201", "초당 거래건수를 초과하였습니다.");
+	}
+
+	public static KisException tokenIssuanceRetryLater() {
+		return new TokenIssuanceRetryLaterKisException("1", "EGW00133", "접근토큰 발급 잠시 후 다시 시도하세요(1분당 1회)");
+	}
 }

--- a/src/main/java/codesquad/fineants/global/errors/exception/kis/KisException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/kis/KisException.java
@@ -1,4 +1,4 @@
-package codesquad.fineants.global.errors.exception;
+package codesquad.fineants.global.errors.exception.kis;
 
 import lombok.Getter;
 import lombok.ToString;

--- a/src/main/java/codesquad/fineants/global/errors/exception/kis/RequestLimitExceededKisException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/kis/RequestLimitExceededKisException.java
@@ -1,0 +1,7 @@
+package codesquad.fineants.global.errors.exception.kis;
+
+public class RequestLimitExceededKisException extends KisException {
+	public RequestLimitExceededKisException(String returnCode, String messageCode, String message) {
+		super(returnCode, messageCode, message);
+	}
+}

--- a/src/main/java/codesquad/fineants/global/errors/exception/kis/TokenIssuanceRetryLaterKisException.java
+++ b/src/main/java/codesquad/fineants/global/errors/exception/kis/TokenIssuanceRetryLaterKisException.java
@@ -1,0 +1,7 @@
+package codesquad.fineants.global.errors.exception.kis;
+
+public class TokenIssuanceRetryLaterKisException extends KisException {
+	public TokenIssuanceRetryLaterKisException(String returnCode, String messageCode, String message) {
+		super(returnCode, messageCode, message);
+	}
+}

--- a/src/test/java/codesquad/fineants/AbstractContainerBaseTest.java
+++ b/src/test/java/codesquad/fineants/AbstractContainerBaseTest.java
@@ -49,6 +49,7 @@ import codesquad.fineants.global.errors.exception.FineAntsException;
 import codesquad.fineants.global.security.factory.TokenFactory;
 import codesquad.fineants.global.security.oauth.dto.MemberAuthentication;
 import codesquad.fineants.global.security.oauth.dto.Token;
+import codesquad.fineants.support.RedisRepository;
 import jakarta.servlet.http.Cookie;
 import lombok.extern.slf4j.Slf4j;
 
@@ -86,6 +87,12 @@ public abstract class AbstractContainerBaseTest {
 	@Autowired
 	private DatabaseCleaner databaseCleaner;
 
+	@Autowired
+	private KisAccessTokenRepository kisAccessTokenRepository;
+
+	@Autowired
+	private RedisRepository redisRepository;
+
 	@DynamicPropertySource
 	public static void overrideProps(DynamicPropertyRegistry registry) {
 		// redis property config
@@ -99,9 +106,6 @@ public abstract class AbstractContainerBaseTest {
 		registry.add("spring.datasource.password", () -> "password1234!");
 	}
 
-	@Autowired
-	private KisAccessTokenRepository kisAccessTokenRepository;
-
 	@BeforeEach
 	public void abstractSetup() {
 		createRoleIfNotFound("ROLE_ADMIN", "관리자");
@@ -113,6 +117,7 @@ public abstract class AbstractContainerBaseTest {
 	@AfterEach
 	public void cleanDatabase() {
 		databaseCleaner.clear();
+		redisRepository.clearAll();
 	}
 
 	public KisAccessToken createKisAccessToken() {

--- a/src/test/java/codesquad/fineants/docs/kis/KisRestControllerDocsTest.java
+++ b/src/test/java/codesquad/fineants/docs/kis/KisRestControllerDocsTest.java
@@ -183,7 +183,7 @@ public class KisRestControllerDocsTest extends RestDocsSupport {
 	@Test
 	void refreshAllLastDayClosingPrice() throws Exception {
 		// given
-		given(service.refreshAllLastDayClosingPrice())
+		given(service.refreshAllClosingPrice())
 			.willReturn(List.of(
 				KisClosingPrice.create("005930", 60000L)
 			));
@@ -227,7 +227,7 @@ public class KisRestControllerDocsTest extends RestDocsSupport {
 		// given
 		List<String> tickerSymbols = List.of("005930");
 
-		given(service.refreshLastDayClosingPrice(tickerSymbols))
+		given(service.refreshClosingPrice(tickerSymbols))
 			.willReturn(List.of(
 				KisClosingPrice.create("005930", 60000L)
 			));

--- a/src/test/java/codesquad/fineants/domain/dividend/service/StockDividendServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/dividend/service/StockDividendServiceTest.java
@@ -94,7 +94,7 @@ class StockDividendServiceTest extends AbstractContainerBaseTest {
 		int kakaoDividend = 61;
 
 		kisAccessTokenRepository.refreshAccessToken(createKisAccessToken());
-		given(kisService.fetchDividendAll(
+		given(kisService.fetchDividendsBetween(
 			ArgumentMatchers.any(LocalDate.class),
 			ArgumentMatchers.any(LocalDate.class)
 		)).willReturn(List.of(

--- a/src/test/java/codesquad/fineants/domain/kis/aop/AccessTokenAspectTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/aop/AccessTokenAspectTest.java
@@ -6,30 +6,43 @@ import java.time.Duration;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import codesquad.fineants.AbstractContainerBaseTest;
 import codesquad.fineants.domain.kis.client.KisClient;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.kis.service.KisAccessTokenRedisService;
-import codesquad.fineants.global.common.time.LocalDateTimeService;
+import codesquad.fineants.global.common.delay.DelayManager;
 import codesquad.fineants.global.errors.exception.kis.KisException;
-import codesquad.fineants.global.errors.exception.kis.TokenIssuanceRetryLaterKisException;
 import reactor.core.publisher.Mono;
 
 class AccessTokenAspectTest extends AbstractContainerBaseTest {
 
-	@MockBean
-	private KisClient client;
+	@Autowired
+	private AccessTokenAspect accessTokenAspect;
 
 	@Autowired
 	private KisAccessTokenRedisService kisAccessTokenRedisService;
 
 	@Autowired
-	private LocalDateTimeService localDateTimeService;
+	private KisAccessTokenRepository kisAccessTokenRepository;
+
+	@SpyBean
+	private DelayManager delayManager;
+
+	@MockBean
+	private KisClient client;
+
+	@BeforeEach
+	void clean() {
+		kisAccessTokenRepository.refreshAccessToken(null);
+		kisAccessTokenRedisService.deleteAccessTokenMap();
+	}
 
 	@AfterEach
 	void tearDown() {
@@ -40,36 +53,25 @@ class AccessTokenAspectTest extends AbstractContainerBaseTest {
 	@Test
 	void checkAccessTokenExpiration() {
 		// given
-		AccessTokenAspect accessTokenAspect = new AccessTokenAspect(new KisAccessTokenRepository(null), client,
-			kisAccessTokenRedisService, localDateTimeService);
-		kisAccessTokenRedisService.deleteAccessTokenMap();
-
 		given(client.fetchAccessToken())
-			.willReturn(
-				Mono.just(createKisAccessToken())
-					.delayElement(Duration.ofMillis(500L))
-			);
+			.willReturn(Mono.just(createKisAccessToken()));
 		// when
 		accessTokenAspect.checkAccessTokenExpiration();
 		// then
-		Assertions.assertThat(kisAccessTokenRedisService.getAccessTokenMap().isPresent()).isTrue();
+		Assertions.assertThat(kisAccessTokenRedisService.getAccessTokenMap()).isPresent();
 	}
 
-	@DisplayName("액세스 토큰 발급이 실패하고 예외가 발생한다")
+	@DisplayName("액세스 토큰 발급이 실패하면 empty Mono를 반환한다")
 	@Test
-	void checkAccessTokenExpiration_whenAccessTokenExpiredAndFailFetchAccessToken_thenThrowException() {
+	void checkAccessTokenExpiration_whenAccessTokenExpiredAndFailFetchAccessToken_thenReturnEmptyMono() {
 		// given
-		AccessTokenAspect accessTokenAspect = new AccessTokenAspect(new KisAccessTokenRepository(null), client,
-			kisAccessTokenRedisService, localDateTimeService);
-		kisAccessTokenRedisService.deleteAccessTokenMap();
-
 		given(client.fetchAccessToken())
 			.willReturn(Mono.error(KisException.tokenIssuanceRetryLater()));
+		given(delayManager.fixedAccessTokenDelay()).willReturn(Duration.ZERO);
 		// when
-		Throwable throwable = Assertions.catchThrowable(accessTokenAspect::checkAccessTokenExpiration);
+		accessTokenAspect.checkAccessTokenExpiration();
 		// then
-		Assertions.assertThat(throwable)
-			.isInstanceOf(TokenIssuanceRetryLaterKisException.class)
-			.hasMessage("접근토큰 발급 잠시 후 다시 시도하세요(1분당 1회)");
+		Assertions.assertThat(kisAccessTokenRepository.createAuthorization()).isNull();
+		Assertions.assertThat(kisAccessTokenRedisService.getAccessTokenMap()).isEmpty();
 	}
 }

--- a/src/test/java/codesquad/fineants/domain/kis/aop/AccessTokenAspectTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/aop/AccessTokenAspectTest.java
@@ -16,7 +16,8 @@ import codesquad.fineants.domain.kis.client.KisClient;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.kis.service.KisAccessTokenRedisService;
 import codesquad.fineants.global.common.time.LocalDateTimeService;
-import codesquad.fineants.global.errors.exception.kis.ExpiredAccessTokenKisException;
+import codesquad.fineants.global.errors.exception.kis.KisException;
+import codesquad.fineants.global.errors.exception.kis.TokenIssuanceRetryLaterKisException;
 import reactor.core.publisher.Mono;
 
 class AccessTokenAspectTest extends AbstractContainerBaseTest {
@@ -63,12 +64,12 @@ class AccessTokenAspectTest extends AbstractContainerBaseTest {
 		kisAccessTokenRedisService.deleteAccessTokenMap();
 
 		given(client.fetchAccessToken())
-			.willReturn(Mono.error(new ExpiredAccessTokenKisException("1", "EGW00201", "초당 거래건수를 초과하였습니다.")));
+			.willReturn(Mono.error(KisException.tokenIssuanceRetryLater()));
 		// when
 		Throwable throwable = Assertions.catchThrowable(accessTokenAspect::checkAccessTokenExpiration);
 		// then
 		Assertions.assertThat(throwable)
-			.isInstanceOf(ExpiredAccessTokenKisException.class)
-			.hasMessage("초당 거래건수를 초과하였습니다.");
+			.isInstanceOf(TokenIssuanceRetryLaterKisException.class)
+			.hasMessage("접근토큰 발급 잠시 후 다시 시도하세요(1분당 1회)");
 	}
 }

--- a/src/test/java/codesquad/fineants/domain/kis/aop/AccessTokenAspectTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/aop/AccessTokenAspectTest.java
@@ -16,7 +16,7 @@ import codesquad.fineants.domain.kis.client.KisClient;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.kis.service.KisAccessTokenRedisService;
 import codesquad.fineants.global.common.time.LocalDateTimeService;
-import codesquad.fineants.global.errors.exception.ExpiredKisAccessTokenException;
+import codesquad.fineants.global.errors.exception.kis.ExpiredAccessTokenKisException;
 import reactor.core.publisher.Mono;
 
 class AccessTokenAspectTest extends AbstractContainerBaseTest {
@@ -63,12 +63,12 @@ class AccessTokenAspectTest extends AbstractContainerBaseTest {
 		kisAccessTokenRedisService.deleteAccessTokenMap();
 
 		given(client.fetchAccessToken())
-			.willReturn(Mono.error(new ExpiredKisAccessTokenException("1", "EGW00201", "초당 거래건수를 초과하였습니다.")));
+			.willReturn(Mono.error(new ExpiredAccessTokenKisException("1", "EGW00201", "초당 거래건수를 초과하였습니다.")));
 		// when
 		Throwable throwable = Assertions.catchThrowable(accessTokenAspect::checkAccessTokenExpiration);
 		// then
 		Assertions.assertThat(throwable)
-			.isInstanceOf(ExpiredKisAccessTokenException.class)
+			.isInstanceOf(ExpiredAccessTokenKisException.class)
 			.hasMessage("초당 거래건수를 초과하였습니다.");
 	}
 }

--- a/src/test/java/codesquad/fineants/domain/kis/aop/AccessTokenAspectTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/aop/AccessTokenAspectTest.java
@@ -16,7 +16,7 @@ import codesquad.fineants.domain.kis.client.KisClient;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.kis.service.KisAccessTokenRedisService;
 import codesquad.fineants.global.common.time.LocalDateTimeService;
-import codesquad.fineants.global.errors.exception.KisException;
+import codesquad.fineants.global.errors.exception.ExpiredKisAccessTokenException;
 import reactor.core.publisher.Mono;
 
 class AccessTokenAspectTest extends AbstractContainerBaseTest {
@@ -63,12 +63,12 @@ class AccessTokenAspectTest extends AbstractContainerBaseTest {
 		kisAccessTokenRedisService.deleteAccessTokenMap();
 
 		given(client.fetchAccessToken())
-			.willReturn(Mono.error(new KisException("요청 건수 초과")));
+			.willReturn(Mono.error(new ExpiredKisAccessTokenException("1", "EGW00201", "초당 거래건수를 초과하였습니다.")));
 		// when
 		Throwable throwable = Assertions.catchThrowable(accessTokenAspect::checkAccessTokenExpiration);
 		// then
 		Assertions.assertThat(throwable)
-			.isInstanceOf(KisException.class)
-			.hasMessage("요청 건수 초과");
+			.isInstanceOf(ExpiredKisAccessTokenException.class)
+			.hasMessage("초당 거래건수를 초과하였습니다.");
 	}
 }

--- a/src/test/java/codesquad/fineants/domain/kis/client/KisClientTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/client/KisClientTest.java
@@ -364,7 +364,7 @@ class KisClientTest extends AbstractContainerBaseTest {
 		);
 		mockWebServer.enqueue(createResponse(200, ObjectMapperUtil.serialize(output)));
 		// when
-		List<KisDividend> dividends = kisClient.fetchDividendAll(from, to)
+		List<KisDividend> dividends = kisClient.fetchDividendsBetween(from, to)
 			.blockOptional()
 			.orElseGet(Collections::emptyList);
 		// then

--- a/src/test/java/codesquad/fineants/domain/kis/client/KisClientTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/client/KisClientTest.java
@@ -39,6 +39,7 @@ import codesquad.fineants.domain.kis.properties.KisProperties;
 import codesquad.fineants.domain.kis.properties.KisTrIdProperties;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.kis.service.KisAccessTokenRedisService;
+import codesquad.fineants.global.errors.exception.KisException;
 import codesquad.fineants.global.util.ObjectMapperUtil;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -299,6 +300,23 @@ class KisClientTest extends AbstractContainerBaseTest {
 		assertThat(currentPrice)
 			.extracting(KisCurrentPrice::getTickerSymbol, KisCurrentPrice::getPrice)
 			.containsExactly("005930", 80000L);
+	}
+
+	@DisplayName("종목의 현재가 조회시 초당 거래 건수 초과하여 에러 응답한다")
+	@Test
+	void fetchCurrentPrice_whenExceedRequestLimit_thenMonoError() {
+		// given
+		Map<String, String> output = Map.of(
+			"rt_cd", "1",
+			"msg_cd", "EGW00201",
+			"msg1", "초당 거래건수를 초과하였습니다."
+		);
+		mockWebServer.enqueue(createResponse(500, ObjectMapperUtil.serialize(output)));
+		String ticker = "005930";
+		// when & then
+		StepVerifier.create(kisClient.fetchCurrentPrice(ticker))
+			.expectError(KisException.class)
+			.verify();
 	}
 
 	@DisplayName("사용자는 종목의 종가를 조회한다")

--- a/src/test/java/codesquad/fineants/domain/kis/client/KisClientTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/client/KisClientTest.java
@@ -39,7 +39,7 @@ import codesquad.fineants.domain.kis.properties.KisProperties;
 import codesquad.fineants.domain.kis.properties.KisTrIdProperties;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.kis.service.KisAccessTokenRedisService;
-import codesquad.fineants.global.errors.exception.kis.KisException;
+import codesquad.fineants.global.errors.exception.kis.RequestLimitExceededKisException;
 import codesquad.fineants.global.util.ObjectMapperUtil;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
@@ -315,7 +315,7 @@ class KisClientTest extends AbstractContainerBaseTest {
 		String ticker = "005930";
 		// when & then
 		StepVerifier.create(kisClient.fetchCurrentPrice(ticker))
-			.expectError(KisException.class)
+			.expectError(RequestLimitExceededKisException.class)
 			.verify();
 	}
 

--- a/src/test/java/codesquad/fineants/domain/kis/client/KisClientTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/client/KisClientTest.java
@@ -39,7 +39,7 @@ import codesquad.fineants.domain.kis.properties.KisProperties;
 import codesquad.fineants.domain.kis.properties.KisTrIdProperties;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.kis.service.KisAccessTokenRedisService;
-import codesquad.fineants.global.errors.exception.KisException;
+import codesquad.fineants.global.errors.exception.kis.KisException;
 import codesquad.fineants.global.util.ObjectMapperUtil;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -14,6 +14,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -181,7 +182,12 @@ class KisServiceTest extends AbstractContainerBaseTest {
 	@Test
 	void refreshStockCurrentPrice_whenAccessTokenExpired_thenCancelStockCurrentPriceRequest() {
 		// given
-		List<String> tickers = List.of("005930");
+		String ticker = "005930";
+		List<String> tickers = List.of(ticker);
+		BDDMockito.given(client.fetchCurrentPrice(ticker))
+			.willReturn(Mono.error(new KisException("액세스 토큰 만료")));
+		given(delayManager.timeout())
+			.willReturn(Duration.ofMillis(100));
 		// when
 		List<KisCurrentPrice> prices = kisService.refreshStockCurrentPrice(tickers);
 		// then

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -33,7 +33,6 @@ import codesquad.fineants.domain.kis.domain.dto.response.KisIpo;
 import codesquad.fineants.domain.kis.domain.dto.response.KisIpoResponse;
 import codesquad.fineants.domain.kis.domain.dto.response.KisSearchStockInfo;
 import codesquad.fineants.domain.kis.repository.CurrentPriceRedisRepository;
-import codesquad.fineants.domain.kis.repository.HolidayRepository;
 import codesquad.fineants.domain.kis.repository.KisAccessTokenRepository;
 import codesquad.fineants.domain.member.domain.entity.Member;
 import codesquad.fineants.domain.member.repository.MemberRepository;
@@ -82,9 +81,6 @@ class KisServiceTest extends AbstractContainerBaseTest {
 
 	@MockBean
 	private KisClient client;
-
-	@MockBean
-	private HolidayRepository holidayRepository;
 
 	@SpyBean
 	private DelayManager delayManager;

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -178,6 +178,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 		assertThat(currentPriceRedisRepository.fetchPriceBy("005930").orElseThrow()).isEqualTo(Money.won(10000));
 	}
 
+	// TODO: KisException 개선
 	@DisplayName("한국투자증권에 종목 현재가 요청중에 액세스 토큰이 만료되어 실패하게 되면, 해당 요청을 취소한다")
 	@Test
 	void refreshStockCurrentPrice_whenAccessTokenExpired_thenCancelStockCurrentPriceRequest() {
@@ -185,9 +186,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 		String ticker = "005930";
 		List<String> tickers = List.of(ticker);
 		BDDMockito.given(client.fetchCurrentPrice(ticker))
-			.willReturn(Mono.error(new KisException("액세스 토큰 만료")));
-		given(delayManager.timeout())
-			.willReturn(Duration.ofMillis(100));
+			.willReturn(Mono.error(new KisException("기간이 만료된 token입니다")));
 		// when
 		List<KisCurrentPrice> prices = kisService.refreshStockCurrentPrice(tickers);
 		// then

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -308,6 +308,8 @@ class KisServiceTest extends AbstractContainerBaseTest {
 		);
 		given(client.fetchSearchStockInfo(anyString()))
 			.willReturn(Mono.just(kisSearchStockInfo));
+		given(delayManager.timeout())
+			.willReturn(Duration.ofMinutes(10));
 		// when
 		Set<StockDataResponse.StockIntegrationInfo> stocks = kisService.fetchStockInfoInRangedIpo();
 		// then
@@ -353,6 +355,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 		// when & then
 		tickerSymbols.stream()
 			.map(kisService::fetchSearchStockInfo)
+			.map(Mono::just)
 			.forEach(mono ->
 				StepVerifier.create(mono)
 					.expectNextMatches(stockInfo -> {

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -45,9 +45,7 @@ import codesquad.fineants.domain.stock.domain.entity.Stock;
 import codesquad.fineants.domain.stock.repository.StockRepository;
 import codesquad.fineants.domain.stock.service.StockCsvReader;
 import codesquad.fineants.global.common.delay.DelayManager;
-import codesquad.fineants.global.errors.exception.kis.ExpiredAccessTokenKisException;
 import codesquad.fineants.global.errors.exception.kis.KisException;
-import codesquad.fineants.global.errors.exception.kis.RequestLimitExceededKisException;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -187,7 +185,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 		String ticker = "005930";
 		List<String> tickers = List.of(ticker);
 		BDDMockito.given(client.fetchCurrentPrice(ticker))
-			.willReturn(Mono.error(new ExpiredAccessTokenKisException("1", "EGW00123", "기간이 만료된 token 입니다.")));
+			.willReturn(Mono.error(KisException.expiredAccessToken()));
 		// when
 		List<KisCurrentPrice> prices = kisService.refreshStockCurrentPrice(tickers);
 		// then
@@ -207,7 +205,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 
 		kisAccessTokenRepository.refreshAccessToken(createKisAccessToken());
 		given(client.fetchCurrentPrice("005930"))
-			.willReturn(Mono.error(new RequestLimitExceededKisException("1", "EGW00201", "초당 거래건수를 초과하였습니다.")))
+			.willReturn(Mono.error(KisException.requestLimitExceeded()))
 			.willReturn(Mono.just(KisCurrentPrice.create("005930", 50000L)));
 		given(delayManager.timeout()).willReturn(Duration.ofSeconds(1));
 		given(delayManager.delay()).willReturn(Duration.ZERO);

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -203,7 +203,6 @@ class KisServiceTest extends AbstractContainerBaseTest {
 		));
 		stocks.forEach(stock -> portfolioHoldingRepository.save(createPortfolioHolding(portfolio, stock)));
 
-		kisAccessTokenRepository.refreshAccessToken(createKisAccessToken());
 		given(client.fetchCurrentPrice("005930"))
 			.willReturn(Mono.error(KisException.requestLimitExceeded()))
 			.willReturn(Mono.just(KisCurrentPrice.create("005930", 50000L)));

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -45,9 +45,9 @@ import codesquad.fineants.domain.stock.domain.entity.Stock;
 import codesquad.fineants.domain.stock.repository.StockRepository;
 import codesquad.fineants.domain.stock.service.StockCsvReader;
 import codesquad.fineants.global.common.delay.DelayManager;
-import codesquad.fineants.global.errors.exception.ExpiredKisAccessTokenException;
-import codesquad.fineants.global.errors.exception.KisException;
-import codesquad.fineants.global.errors.exception.RequestLimitExceededException;
+import codesquad.fineants.global.errors.exception.kis.ExpiredAccessTokenKisException;
+import codesquad.fineants.global.errors.exception.kis.KisException;
+import codesquad.fineants.global.errors.exception.kis.RequestLimitExceededKisException;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -187,7 +187,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 		String ticker = "005930";
 		List<String> tickers = List.of(ticker);
 		BDDMockito.given(client.fetchCurrentPrice(ticker))
-			.willReturn(Mono.error(new ExpiredKisAccessTokenException("1", "EGW00123", "기간이 만료된 token 입니다.")));
+			.willReturn(Mono.error(new ExpiredAccessTokenKisException("1", "EGW00123", "기간이 만료된 token 입니다.")));
 		// when
 		List<KisCurrentPrice> prices = kisService.refreshStockCurrentPrice(tickers);
 		// then
@@ -207,7 +207,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 
 		kisAccessTokenRepository.refreshAccessToken(createKisAccessToken());
 		given(client.fetchCurrentPrice("005930"))
-			.willReturn(Mono.error(new RequestLimitExceededException("1", "EGW00201", "초당 거래건수를 초과하였습니다.")))
+			.willReturn(Mono.error(new RequestLimitExceededKisException("1", "EGW00201", "초당 거래건수를 초과하였습니다.")))
 			.willReturn(Mono.just(KisCurrentPrice.create("005930", 50000L)));
 		given(delayManager.timeout()).willReturn(Duration.ofSeconds(1));
 		given(delayManager.delay()).willReturn(Duration.ZERO);

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -375,8 +375,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 				KisDividend.create(tickerSymbol, Money.won(300), LocalDate.of(2024, 3, 1),
 					LocalDate.of(2024, 5, 1))))));
 		// when
-		List<KisDividend> dividends = kisService.fetchDividend(tickerSymbol)
-			.block();
+		List<KisDividend> dividends = kisService.fetchDividend(tickerSymbol);
 		// then
 		Assertions.assertThat(dividends)
 			.hasSize(1)
@@ -401,8 +400,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 				KisDividend.create(tickerSymbol, Money.won(300), LocalDate.of(2024, 3, 1),
 					LocalDate.of(2024, 5, 1))))));
 		// when
-		List<KisDividend> dividends = kisService.fetchDividend(tickerSymbol)
-			.block();
+		List<KisDividend> dividends = kisService.fetchDividend(tickerSymbol);
 		// then
 		Assertions.assertThat(dividends)
 			.hasSize(1)

--- a/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/kis/service/KisServiceTest.java
@@ -177,6 +177,17 @@ class KisServiceTest extends AbstractContainerBaseTest {
 		assertThat(currentPriceRedisRepository.fetchPriceBy("005930").orElseThrow()).isEqualTo(Money.won(10000));
 	}
 
+	@DisplayName("한국투자증권에 종목 현재가 요청중에 액세스 토큰이 만료되어 실패하게 되면, 해당 요청을 취소한다")
+	@Test
+	void refreshStockCurrentPrice_whenAccessTokenExpired_thenCancelStockCurrentPriceRequest() {
+		// given
+		List<String> tickers = List.of("005930");
+		// when
+		List<KisCurrentPrice> prices = kisService.refreshStockCurrentPrice(tickers);
+		// then
+		Assertions.assertThat(prices).isEmpty();
+	}
+
 	@DisplayName("종목 현재가 갱신시 예외가 발생하면 다시 시도하여 가격을 조회한다")
 	@Test
 	void refreshStockCurrentPrice_whenFailFetch_thenRetryFetch() {
@@ -235,7 +246,7 @@ class KisServiceTest extends AbstractContainerBaseTest {
 		// then
 		verify(client, times(1)).fetchClosingPrice(anyString());
 	}
-	
+
 	@DisplayName("한국투자증권에 상장된 종목 정보를 조회한다")
 	@Test
 	void fetchStockInfoInRangedIpo() {

--- a/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
@@ -206,20 +206,18 @@ class StockServiceTest extends AbstractContainerBaseTest {
 		given(kisService.fetchStockInfoInRangedIpo())
 			.willReturn(Set.of(hynix));
 		given(kisService.fetchSearchStockInfo(hynix.getTickerSymbol()))
-			.willReturn(Mono.just(KisSearchStockInfo.listedStock(
-					"KR7000660001",
-					"000660",
-					"에스케이하이닉스보통주",
-					"SK hynix",
-					"STK",
-					"전기,전자")
-				)
+			.willReturn(KisSearchStockInfo.listedStock(
+				"KR7000660001",
+				"000660",
+				"에스케이하이닉스보통주",
+				"SK hynix",
+				"STK",
+				"전기,전자")
 			);
 		given(kisService.fetchSearchStockInfo(nokwon.getTickerSymbol()))
-			.willReturn(Mono.just(
-				KisSearchStockInfo.delistedStock("KR7065560005", "065560", "녹원씨엔아이",
-					"Nokwon Commercials & Industries, Inc.",
-					"KSQ", "소프트웨어", LocalDate.of(2024, 7, 29))));
+			.willReturn(KisSearchStockInfo.delistedStock("KR7065560005", "065560", "녹원씨엔아이",
+				"Nokwon Commercials & Industries, Inc.",
+				"KSQ", "소프트웨어", LocalDate.of(2024, 7, 29)));
 		DateTimeFormatter dtf = DateTimeFormatter.BASIC_ISO_DATE;
 		given(kisService.fetchDividend(hynix.getTickerSymbol()))
 			.willReturn(List.of(
@@ -233,6 +231,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 					LocalDate.parse("20240814", dtf))
 			));
 		given(delayManager.delay()).willReturn(Duration.ZERO);
+		given(delayManager.timeout()).willReturn(Duration.ofMinutes(10));
 		// when
 		StockReloadResponse response = stockService.reloadStocks();
 		// then
@@ -281,19 +280,17 @@ class StockServiceTest extends AbstractContainerBaseTest {
 		given(kisService.fetchStockInfoInRangedIpo())
 			.willReturn(Set.of(stock));
 		given(kisService.fetchSearchStockInfo(stock.getTickerSymbol()))
-			.willReturn(Mono.just(
+			.willReturn(
 				KisSearchStockInfo.listedStock(stock.getStockCode(), stock.getTickerSymbol(), stock.getCompanyName(),
-					stock.getCompanyNameEng(), "STK", "전기,전자")));
+					stock.getCompanyNameEng(), "STK", "전기,전자"));
 		stocks.forEach(s -> given(kisService.fetchSearchStockInfo(s.getTickerSymbol()))
-			.willReturn(Mono.just(
-					KisSearchStockInfo.listedStock(
-						s.getStockCode(),
-						s.getTickerSymbol(),
-						s.getCompanyName(),
-						s.getCompanyNameEng(),
-						"STK",
-						s.getSector()
-					)
+			.willReturn(KisSearchStockInfo.listedStock(
+				s.getStockCode(),
+				s.getTickerSymbol(),
+				s.getCompanyName(),
+				s.getCompanyNameEng(),
+				"STK",
+				s.getSector()
 				)
 			));
 		stocks.forEach(s -> given(kisService.fetchDividend(anyString()))
@@ -305,6 +302,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 				KisDividend.create(s.getTickerSymbol(), Money.won(300), LocalDate.of(2024, 5, 1),
 					LocalDate.of(2024, 7, 1)))));
 		given(delayManager.delay()).willReturn(Duration.ZERO);
+		given(delayManager.timeout()).willReturn(Duration.ofMinutes(10));
 		// when
 		stockService.scheduledReloadStocks();
 		// then

--- a/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 
 import codesquad.fineants.AbstractContainerBaseTest;
 import codesquad.fineants.domain.common.money.Money;
@@ -80,7 +81,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 	@MockBean
 	private KisService kisService;
 
-	@MockBean
+	@SpyBean
 	private DelayManager delayManager;
 
 	@AfterEach
@@ -231,7 +232,6 @@ class StockServiceTest extends AbstractContainerBaseTest {
 					LocalDate.parse("20240814", dtf))
 			));
 		given(delayManager.delay()).willReturn(Duration.ZERO);
-		given(delayManager.timeout()).willReturn(Duration.ofMinutes(10));
 		// when
 		StockReloadResponse response = stockService.reloadStocks();
 		// then
@@ -285,12 +285,12 @@ class StockServiceTest extends AbstractContainerBaseTest {
 					stock.getCompanyNameEng(), "STK", "전기,전자"));
 		stocks.forEach(s -> given(kisService.fetchSearchStockInfo(s.getTickerSymbol()))
 			.willReturn(KisSearchStockInfo.listedStock(
-				s.getStockCode(),
-				s.getTickerSymbol(),
-				s.getCompanyName(),
-				s.getCompanyNameEng(),
-				"STK",
-				s.getSector()
+					s.getStockCode(),
+					s.getTickerSymbol(),
+					s.getCompanyName(),
+					s.getCompanyNameEng(),
+					"STK",
+					s.getSector()
 				)
 			));
 		stocks.forEach(s -> given(kisService.fetchDividend(anyString()))
@@ -302,7 +302,6 @@ class StockServiceTest extends AbstractContainerBaseTest {
 				KisDividend.create(s.getTickerSymbol(), Money.won(300), LocalDate.of(2024, 5, 1),
 					LocalDate.of(2024, 7, 1)))));
 		given(delayManager.delay()).willReturn(Duration.ZERO);
-		given(delayManager.timeout()).willReturn(Duration.ofMinutes(10));
 		// when
 		stockService.scheduledReloadStocks();
 		// then

--- a/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
+++ b/src/test/java/codesquad/fineants/domain/stock/service/StockServiceTest.java
@@ -222,7 +222,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 					"KSQ", "소프트웨어", LocalDate.of(2024, 7, 29))));
 		DateTimeFormatter dtf = DateTimeFormatter.BASIC_ISO_DATE;
 		given(kisService.fetchDividend(hynix.getTickerSymbol()))
-			.willReturn(Mono.just(List.of(
+			.willReturn(List.of(
 				KisDividend.create(hynix.getTickerSymbol(),
 					Money.won(300),
 					LocalDate.parse("20240331", dtf),
@@ -231,7 +231,7 @@ class StockServiceTest extends AbstractContainerBaseTest {
 					Money.won(300),
 					LocalDate.parse("20240630", dtf),
 					LocalDate.parse("20240814", dtf))
-			)));
+			));
 		given(delayManager.delay()).willReturn(Duration.ZERO);
 		// when
 		StockReloadResponse response = stockService.reloadStocks();
@@ -297,24 +297,25 @@ class StockServiceTest extends AbstractContainerBaseTest {
 				)
 			));
 		stocks.forEach(s -> given(kisService.fetchDividend(anyString()))
-			.willReturn(Mono.just(Collections.emptyList())));
+			.willReturn(Collections.emptyList()));
 		stocks.forEach(s -> given(kisService.fetchDividend(s.getTickerSymbol()))
-			.willReturn(Mono.just(List.of(
+			.willReturn(List.of(
 				KisDividend.create(s.getTickerSymbol(), Money.won(300), LocalDate.of(2024, 3, 1),
 					LocalDate.of(2024, 5, 1)),
 				KisDividend.create(s.getTickerSymbol(), Money.won(300), LocalDate.of(2024, 5, 1),
-					LocalDate.of(2024, 7, 1)))))
-		);
+					LocalDate.of(2024, 7, 1)))));
 		given(delayManager.delay()).willReturn(Duration.ZERO);
 		// when
 		stockService.scheduledReloadStocks();
 		// then
 		assertThat(stockRepository.findByTickerSymbol("000660")).isPresent();
 		assertThat(amazonS3StockService.fetchStocks())
-			.as("Verify that the stock information in the stocks.csv file stored in s3 matches the items in the database")
+			.as("Verify that the stock information in the stocks.csv file stored "
+				+ "in s3 matches the items in the database")
 			.containsExactlyInAnyOrderElementsOf(stockRepository.findAll());
 		assertThat(amazonS3DividendService.fetchDividends())
-			.as("Verify that the dividend information in the dividends.csv file stored in s3 matches the items in the database")
+			.as("Verify that the dividend information in the dividends.csv file stored "
+				+ "in s3 matches the items in the database")
 			.containsExactlyInAnyOrderElementsOf(stockDividendRepository.findAllStockDividends());
 	}
 

--- a/src/test/java/codesquad/fineants/global/init/SetupDataLoaderTest.java
+++ b/src/test/java/codesquad/fineants/global/init/SetupDataLoaderTest.java
@@ -91,7 +91,7 @@ class SetupDataLoaderTest extends AbstractContainerBaseTest {
 		List<StockDividend> stockDividends = writeStockDividends(stocks, limit);
 
 		doNothing().when(exchangeRateService).updateExchangeRates();
-		doNothing().when(kisService).refreshClosingPrice();
+		doNothing().when(kisService).scheduledRefreshAllClosingPrice();
 		// when
 		setupDataLoader.setupResources();
 		// then

--- a/src/test/java/codesquad/fineants/support/RedisRepository.java
+++ b/src/test/java/codesquad/fineants/support/RedisRepository.java
@@ -1,0 +1,24 @@
+package codesquad.fineants.support;
+
+import java.util.Set;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@Repository
+@RequiredArgsConstructor
+public class RedisRepository {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void clearAll() {
+		// Fetch all keys from Redis
+		Set<String> keys = redisTemplate.keys("*");
+
+		if (keys != null && !keys.isEmpty()) {
+			// Delete all keys
+			redisTemplate.delete(keys);
+		}
+	}
+}


### PR DESCRIPTION
## 구현한 것

- 종목 현재가와 같은 액세스 토큰이 필요한 요청시 액세스 토큰이 없거나 만료되는 경우에 대비하여 에러 폴백 처리를 추가
- delayManager를 SpyBean으로 변경하여 불필요한 모킹 해결
- 테스트 코드 실패 해결
