### PR TITLE
[feat] LineChart API 개선

### DIFF
--- a/src/main/java/co/fineants/api/domain/gainhistory/domain/entity/PortfolioGainHistory.java
+++ b/src/main/java/co/fineants/api/domain/gainhistory/domain/entity/PortfolioGainHistory.java
@@ -1,6 +1,9 @@
 package co.fineants.api.domain.gainhistory.domain.entity;
 
+import java.time.format.DateTimeFormatter;
+
 import co.fineants.api.domain.BaseEntity;
+import co.fineants.api.domain.common.money.Expression;
 import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.common.money.MoneyConverter;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
@@ -42,6 +45,8 @@ public class PortfolioGainHistory extends BaseEntity {
 	@JoinColumn(name = "portfolio_id")
 	private Portfolio portfolio;
 
+	private static final DateTimeFormatter LINE_CHART_KEY_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
 	private PortfolioGainHistory(Money totalGain, Money dailyGain, Money cash, Money currentValuation,
 		Portfolio portfolio) {
 		this(null, totalGain, dailyGain, cash, currentValuation, portfolio);
@@ -64,5 +69,18 @@ public class PortfolioGainHistory extends BaseEntity {
 	public static PortfolioGainHistory create(Money totalGain, Money dailyGain, Money cash, Money currentValuation,
 		Portfolio portfolio) {
 		return new PortfolioGainHistory(totalGain, dailyGain, cash, currentValuation, portfolio);
+	}
+
+	public String getLineChartKey() {
+		return LINE_CHART_KEY_FORMATTER.format(super.getCreateAt());
+	}
+
+	/**
+	 * Return cash + currentValuation
+	 *
+	 * @return cash + currentValuation
+	 */
+	public Expression calculateTotalPortfolioValue() {
+		return cash.plus(currentValuation);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/gainhistory/service/PortfolioGainHistoryService.java
+++ b/src/main/java/co/fineants/api/domain/gainhistory/service/PortfolioGainHistoryService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,6 +27,7 @@ public class PortfolioGainHistoryService {
 	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 
 	@Transactional
+	@CacheEvict(value = "lineChartCache", allEntries = true)
 	public PortfolioGainHistoryCreateResponse addPortfolioGainHistory() {
 		List<Portfolio> portfolios = portfolioRepository.findAll();
 		List<PortfolioGainHistory> portfolioGainHistories = new ArrayList<>();

--- a/src/main/java/co/fineants/api/domain/portfolio/controller/DashboardRestController.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/controller/DashboardRestController.java
@@ -41,6 +41,8 @@ public class DashboardRestController {
 	@GetMapping("/lineChart")
 	public ApiResponse<List<DashboardLineChartResponse>> readLineChart(
 		@MemberAuthenticationPrincipal MemberAuthentication authentication) {
+		List<DashboardLineChartResponse> response = dashboardService.getLineChart(authentication.getId());
+		log.debug("response = {}", response);
 		return ApiResponse.success(DashboardSuccessCode.OK_LINE_CHART,
 			dashboardService.getLineChart(authentication.getId()));
 	}

--- a/src/main/java/co/fineants/api/domain/portfolio/service/DashboardService.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/service/DashboardService.java
@@ -1,13 +1,13 @@
 package co.fineants.api.domain.portfolio.service;
 
-import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -115,24 +115,24 @@ public class DashboardService {
 
 	@Transactional(readOnly = true)
 	@Secured("ROLE_USER")
+	@Cacheable(value = "lineChartCache", key = "#memberId")
 	public List<DashboardLineChartResponse> getLineChart(Long memberId) {
 		List<PortfolioGainHistory> histories = portfolioRepository.findAllByMemberId(memberId).stream()
 			.map(Portfolio::getId)
 			.map(portfolioGainHistoryRepository::findAllByPortfolioId)
 			.flatMap(Collection::stream)
 			.toList();
-		
-		Map<String, Expression> timeValueMap = new HashMap<>();
-		for (PortfolioGainHistory history : histories) {
-			String time = history.getCreateAt().format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
-			timeValueMap.put(time, timeValueMap.getOrDefault(time, Money.zero())
-				.plus(history.getCash())
-				.plus(history.getCurrentValuation()));
-		}
-		return timeValueMap.keySet()
+
+		Map<String, Expression> result = histories.stream()
+			.collect(Collectors.toMap(
+				PortfolioGainHistory::getLineChartKey,
+				PortfolioGainHistory::calculateTotalPortfolioValue,
+				Expression::plus
+			));
+		return result.keySet()
 			.stream()
 			.sorted()
-			.map(key -> DashboardLineChartResponse.of(key, timeValueMap.get(key)))
+			.map(key -> DashboardLineChartResponse.of(key, result.get(key)))
 			.toList();
 	}
 }

--- a/src/main/java/co/fineants/api/global/config/CacheConfig.java
+++ b/src/main/java/co/fineants/api/global/config/CacheConfig.java
@@ -27,7 +27,9 @@ public class CacheConfig {
 		// 캐시별 만료 시간 설정
 		Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
 		cacheConfigurations.put("tickerSymbols",
-			RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(5))); // 5분 TTL
+			RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(5))); // 5 minute TTL
+		cacheConfigurations.put("lineChartCache",
+			RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofHours(24))); // 24 hourTTL
 
 		return RedisCacheManager.builder(redisConnectionFactory)
 			.cacheDefaults(defaultCacheConfig)

--- a/src/main/java/co/fineants/api/global/config/CacheConfig.java
+++ b/src/main/java/co/fineants/api/global/config/CacheConfig.java
@@ -11,12 +11,21 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import lombok.RequiredArgsConstructor;
+
 @EnableCaching
 @Configuration
+@RequiredArgsConstructor
 public class CacheConfig {
+
+	private final ObjectMapper objectMapper;
+
 	@Bean
 	public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
 		// 기본 캐시 설정 (10분 TTL)
@@ -28,8 +37,13 @@ public class CacheConfig {
 		Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
 		cacheConfigurations.put("tickerSymbols",
 			RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofMinutes(5))); // 5 minute TTL
+
+		RedisSerializationContext.SerializationPair<Object> serializer = RedisSerializationContext.SerializationPair.fromSerializer(
+			new Jackson2JsonRedisSerializer<>(objectMapper, Object.class));
 		cacheConfigurations.put("lineChartCache",
-			RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofHours(24))); // 24 hourTTL
+			RedisCacheConfiguration.defaultCacheConfig().entryTtl(Duration.ofHours(24))
+				.serializeValuesWith(serializer)
+		); // 24 hourTTL
 
 		return RedisCacheManager.builder(redisConnectionFactory)
 			.cacheDefaults(defaultCacheConfig)


### PR DESCRIPTION
## 구현한 것

- LineChart API에 캐시 추가
  - TTL : 24 hour
 
## 성능 테스트 결과
5000건의 포트폴리오를 계산하는 라인 차트를 조회하는 작업에 캐시 적용전/후의 성능 테스트 결과

평균 TPS : { 0.8 } → { 624.6 }
  - 약 780.75배 개선

Peek TPS : { 5.0 } → { 780.5 }
  - 약 156.1배 개선

Mean Test Time : { 18,157.13ms } → { 14.53ms }
  - 약 1249.63배 단축

Executed Tests : { 30 } → { 35,039 }
  - 약 1167.96배 개선
