### PR TITLE
[refactor] 포트폴리오 엔티티 개선

### DIFF
--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -34,6 +34,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Transient;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +43,7 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 @ToString(exclude = {"stock", "portfolio", "purchaseHistory"})
 @Entity
+@EqualsAndHashCode(of = {"portfolio", "stock"}, callSuper = false)
 public class PortfolioHolding extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -102,7 +102,13 @@ public class PortfolioHolding extends BaseEntity {
 	}
 
 	public void setPortfolio(Portfolio portfolio) {
+		if (this.portfolio != null && this.portfolio.getPortfolioHoldings().contains(this)) {
+			this.portfolio.removeHolding(this);
+		}
 		this.portfolio = portfolio;
+		if (portfolio != null && !portfolio.getPortfolioHoldings().contains(this)) {
+			portfolio.addHolding(this);
+		}
 	}
 
 	// 종목 총 손익 = (종목 현재가 - 종목 평균 매입가) * 개수

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioCreateRequest.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioCreateRequest.java
@@ -39,6 +39,7 @@ public class PortfolioCreateRequest {
 	}
 
 	public Portfolio toEntity(Member member, PortfolioProperties properties) {
-		return Portfolio.noActive(name, securitiesFirm, budget, targetGain, maximumLoss, member, properties);
+		PortfolioDetail detail = PortfolioDetail.of(name, securitiesFirm, properties);
+		return Portfolio.noActive(detail, budget, targetGain, maximumLoss, member);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioCreateRequest.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioCreateRequest.java
@@ -4,7 +4,9 @@ import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.common.money.valiator.MoneyNumberWithZero;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.domain.entity.PortfolioDetail;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,6 +17,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PortfolioCreateRequest {
 	@NotBlank(message = "포트폴리오 이름은 필수 정보입니다")
+	@Pattern(regexp = PortfolioDetail.NAME_REGEXP, message = "유효하지 않은 포트폴리오 이름입니다.")
 	private String name;
 
 	@NotBlank(message = "증권사는 필수 정보입니다")

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioCreateRequest.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioCreateRequest.java
@@ -5,6 +5,7 @@ import co.fineants.api.domain.common.money.valiator.MoneyNumberWithZero;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.domain.portfolio.domain.entity.PortfolioDetail;
+import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.AccessLevel;
@@ -37,7 +38,7 @@ public class PortfolioCreateRequest {
 		return new PortfolioCreateRequest(name, securitiesFirm, budget, targetGain, maximumLoss);
 	}
 
-	public Portfolio toEntity(Member member) {
-		return Portfolio.noActive(name, securitiesFirm, budget, targetGain, maximumLoss, member);
+	public Portfolio toEntity(Member member, PortfolioProperties properties) {
+		return Portfolio.noActive(name, securitiesFirm, budget, targetGain, maximumLoss, member, properties);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioModifyRequest.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioModifyRequest.java
@@ -4,6 +4,7 @@ import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.common.money.valiator.MoneyNumberWithZero;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.domain.entity.PortfolioDetail;
 import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
@@ -29,6 +30,7 @@ public class PortfolioModifyRequest {
 	private Money maximumLoss;
 
 	public Portfolio toEntity(Member member, PortfolioProperties properties) {
-		return Portfolio.noActive(name, securitiesFirm, budget, targetGain, maximumLoss, member, properties);
+		PortfolioDetail detail = PortfolioDetail.of(name, securitiesFirm, properties);
+		return Portfolio.noActive(detail, budget, targetGain, maximumLoss, member);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioModifyRequest.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/dto/request/PortfolioModifyRequest.java
@@ -4,6 +4,7 @@ import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.common.money.valiator.MoneyNumberWithZero;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -27,7 +28,7 @@ public class PortfolioModifyRequest {
 	@MoneyNumberWithZero
 	private Money maximumLoss;
 
-	public Portfolio toEntity(Member member) {
-		return Portfolio.noActive(name, securitiesFirm, budget, targetGain, maximumLoss, member);
+	public Portfolio toEntity(Member member, PortfolioProperties properties) {
+		return Portfolio.noActive(name, securitiesFirm, budget, targetGain, maximumLoss, member, properties);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -56,7 +56,6 @@ import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 @NamedEntityGraph(name = "Portfolio.withAll", attributeNodes = {
@@ -69,7 +68,6 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString(exclude = {"member", "portfolioHoldings"})
 @Entity
 @Table(name = "portfolio", uniqueConstraints = {
 	@UniqueConstraint(columnNames = {"name", "member_id"})
@@ -540,5 +538,10 @@ public class Portfolio extends BaseEntity implements Notifiable {
 
 	public void setLocalDateTimeService(LocalDateTimeService localDateTimeService) {
 		this.localDateTimeService = localDateTimeService;
+	}
+
+	@Override
+	public String toString() {
+		return String.format("Portfolio(id=%d, name=%s, memberNickname=%s)", id, name, member.getNickname());
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -131,12 +131,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 			throw new BadRequestException(PortfolioErrorCode.MAXIMUM_LOSS_IS_EQUAL_GREATER_THAN_BUDGET);
 		}
 	}
-
-	public static Portfolio active(String name, String securitiesFirm, Money budget, Money targetGain,
-		Money maximumLoss, Member member) {
-		return active(null, name, securitiesFirm, budget, targetGain, maximumLoss, member);
-	}
-
+	
 	public static Portfolio active(Long id, String name, String securitiesFirm, Money budget, Money targetGain,
 		Money maximumLoss, Member member) {
 		return new Portfolio(id, name, securitiesFirm, budget, targetGain, maximumLoss, true, true, member);

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -104,6 +104,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	@Transient
 	private LocalDateTimeService localDateTimeService = new DefaultLocalDateTimeService();
 
+	// TODO: name, securitiesFirm을 묶은 PortfolioDetail 클래스 추가
 	private Portfolio(Long id, String name, String securitiesFirm, Money budget, Money targetGain, Money maximumLoss,
 		Boolean targetGainIsActive, Boolean maximumLossIsActive, Member member) {
 		validateBudget(budget, targetGain, maximumLoss);
@@ -131,7 +132,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 			throw new BadRequestException(PortfolioErrorCode.MAXIMUM_LOSS_IS_EQUAL_GREATER_THAN_BUDGET);
 		}
 	}
-	
+
 	public static Portfolio active(Long id, String name, String securitiesFirm, Money budget, Money targetGain,
 		Money maximumLoss, Member member) {
 		return new Portfolio(id, name, securitiesFirm, budget, targetGain, maximumLoss, true, true, member);

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -148,11 +148,19 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	}
 
 	//== 연관 관계 메소드 ==//
-	public void addHolding(PortfolioHolding portFolioHolding) {
-		if (!portfolioHoldings.contains(portFolioHolding)) {
-			portfolioHoldings.add(portFolioHolding);
-			portFolioHolding.setPortfolio(this);
+	public void addHolding(PortfolioHolding holding) {
+		if (portfolioHoldings.contains(holding)) {
+			return;
 		}
+		portfolioHoldings.add(holding);
+		if (holding.getPortfolio() != this) {
+			holding.setPortfolio(this);
+		}
+	}
+
+	public void removeHolding(PortfolioHolding holding) {
+		this.portfolioHoldings.remove(holding);
+		holding.setPortfolio(null);
 	}
 	//== 연관 관계 편의 메소드 종료 ==//
 

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -32,7 +32,6 @@ import co.fineants.api.domain.notification.domain.dto.response.NotifyMessage;
 import co.fineants.api.domain.notification.domain.entity.type.NotificationType;
 import co.fineants.api.domain.notification.repository.NotificationSentRepository;
 import co.fineants.api.domain.notificationpreference.domain.entity.NotificationPreference;
-import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import co.fineants.api.global.common.time.DefaultLocalDateTimeService;
 import co.fineants.api.global.common.time.LocalDateTimeService;
 import co.fineants.api.global.errors.errorcode.PortfolioErrorCode;
@@ -139,9 +138,8 @@ public class Portfolio extends BaseEntity implements Notifiable {
 		return portfolio;
 	}
 
-	public static Portfolio noActive(String name, String securitiesFirm, Money budget, Money targetGain,
-		Money maximumLoss, Member member, PortfolioProperties properties) {
-		PortfolioDetail detail = PortfolioDetail.of(name, securitiesFirm, properties);
+	public static Portfolio noActive(PortfolioDetail detail, Money budget, Money targetGain, Money maximumLoss,
+		Member member) {
 		Portfolio portfolio = new Portfolio(null, detail, budget, targetGain, maximumLoss, false, false);
 		portfolio.setMember(member);
 		return portfolio;

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -446,8 +446,8 @@ public class Portfolio extends BaseEntity implements Notifiable {
 		};
 	}
 
-	public boolean isSameName(Portfolio changePortfolio) {
-		return detail.isSameName(changePortfolio.detail);
+	public boolean equalName(Portfolio changePortfolio) {
+		return detail.equalName(changePortfolio.detail);
 	}
 
 	// 매입 이력을 포트폴리오에 추가시 현금이 충분한지 판단

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -106,8 +106,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	@Transient
 	private LocalDateTimeService localDateTimeService = new DefaultLocalDateTimeService();
 
-	private Portfolio(Long id, PortfolioDetail detail, Money budget,
-		Money targetGain, Money maximumLoss,
+	private Portfolio(Long id, PortfolioDetail detail, Money budget, Money targetGain, Money maximumLoss,
 		Boolean targetGainIsActive, Boolean maximumLossIsActive, Member member) {
 		validateBudget(budget, targetGain, maximumLoss);
 		this.id = id;
@@ -134,9 +133,8 @@ public class Portfolio extends BaseEntity implements Notifiable {
 		}
 	}
 
-	public static Portfolio active(Long id, String name, String securitiesFirm, Money budget, Money targetGain,
-		Money maximumLoss, Member member, PortfolioProperties properties) {
-		PortfolioDetail detail = PortfolioDetail.of(name, securitiesFirm, properties);
+	public static Portfolio active(Long id, PortfolioDetail detail, Money budget, Money targetGain,
+		Money maximumLoss, Member member) {
 		return new Portfolio(id, detail, budget, targetGain, maximumLoss, true, true, member);
 	}
 

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -54,6 +54,7 @@ import jakarta.persistence.Table;
 import jakarta.persistence.Transient;
 import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -72,6 +73,7 @@ import lombok.extern.slf4j.Slf4j;
 @Table(name = "portfolio", uniqueConstraints = {
 	@UniqueConstraint(columnNames = {"name", "member_id"})
 })
+@EqualsAndHashCode(of = {"name", "member"}, callSuper = false)
 public class Portfolio extends BaseEntity implements Notifiable {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -145,13 +147,14 @@ public class Portfolio extends BaseEntity implements Notifiable {
 		return new Portfolio(null, name, securitiesFirm, budget, targetGain, maximumLoss, false, false, member);
 	}
 
-	//== 연관관계 메소드 ==//
+	//== 연관 관계 메소드 ==//
 	public void addHolding(PortfolioHolding portFolioHolding) {
 		if (!portfolioHoldings.contains(portFolioHolding)) {
 			portfolioHoldings.add(portFolioHolding);
 			portFolioHolding.setPortfolio(this);
 		}
 	}
+	//== 연관 관계 편의 메소드 종료 ==//
 
 	public void change(Portfolio changePortfolio) {
 		this.name = changePortfolio.name;

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -107,7 +107,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	private LocalDateTimeService localDateTimeService = new DefaultLocalDateTimeService();
 
 	private Portfolio(Long id, PortfolioDetail detail, Money budget, Money targetGain, Money maximumLoss,
-		Boolean targetGainIsActive, Boolean maximumLossIsActive, Member member) {
+		Boolean targetGainIsActive, Boolean maximumLossIsActive) {
 		validateBudget(budget, targetGain, maximumLoss);
 		this.id = id;
 		this.detail = detail;
@@ -116,7 +116,6 @@ public class Portfolio extends BaseEntity implements Notifiable {
 		this.maximumLoss = maximumLoss;
 		this.targetGainIsActive = targetGainIsActive;
 		this.maximumLossIsActive = maximumLossIsActive;
-		this.member = member;
 	}
 
 	private void validateBudget(Money budget, Money targetGain, Money maximumLoss) {
@@ -135,13 +134,17 @@ public class Portfolio extends BaseEntity implements Notifiable {
 
 	public static Portfolio active(Long id, PortfolioDetail detail, Money budget, Money targetGain,
 		Money maximumLoss, Member member) {
-		return new Portfolio(id, detail, budget, targetGain, maximumLoss, true, true, member);
+		Portfolio portfolio = new Portfolio(id, detail, budget, targetGain, maximumLoss, true, true);
+		portfolio.setMember(member);
+		return portfolio;
 	}
 
 	public static Portfolio noActive(String name, String securitiesFirm, Money budget, Money targetGain,
 		Money maximumLoss, Member member, PortfolioProperties properties) {
 		PortfolioDetail detail = PortfolioDetail.of(name, securitiesFirm, properties);
-		return new Portfolio(null, detail, budget, targetGain, maximumLoss, false, false, member);
+		Portfolio portfolio = new Portfolio(null, detail, budget, targetGain, maximumLoss, false, false);
+		portfolio.setMember(member);
+		return portfolio;
 	}
 
 	//== 연관 관계 메소드 ==//
@@ -158,6 +161,10 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	public void removeHolding(PortfolioHolding holding) {
 		this.portfolioHoldings.remove(holding);
 		holding.setPortfolio(null);
+	}
+
+	public void setMember(Member member) {
+		this.member = member;
 	}
 	//== 연관 관계 편의 메소드 종료 ==//
 

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -37,19 +37,14 @@ public class PortfolioDetail {
 	/**
 	 * Return a PortfolioDetail instance.
 	 *
-	 * @param name the name 포트폴리오 이름
-	 * @param securitiesFirm the securities firm 증권사 이름
-	 * @param properties the properties 증권사 목록이 담긴 포트폴리오 프로퍼티
-	 * @return the portfolio detail 포트폴리오 상세 정보 객체
-	 * @throws IllegalArgumentException 포트폴리오 이름이 형식에 유효하지 않거나 증권사 이름이 properties 목록에 포함되지 않으면 예외 발생한다
+	 * @param name 포트폴리오 이름
+	 * @param securitiesFirm 증권사 이름
+	 * @param properties 증권사 목록이 담긴 포트폴리오 프로퍼티
+	 * @return 포트폴리오 상세 정보 객체
+	 * @throws IllegalArgumentException 포트폴리오 이름이 형식에 유효하지 않거나 증권사 이름이 목록에 포함되지 않으면 예외 발생한다
 	 */
 	public static PortfolioDetail of(String name, String securitiesFirm, PortfolioProperties properties) {
 		return new PortfolioDetail(name, securitiesFirm, properties);
-	}
-
-	@Override
-	public String toString() {
-		return String.format("(name=%s, securitiesFirm=%s)", name, securitiesFirm);
 	}
 
 	public void change(PortfolioDetail detail) {
@@ -67,5 +62,10 @@ public class PortfolioDetail {
 
 	public String getMaximumLossReachMessage() {
 		return String.format("%s이(가) 최대 손실율에 도달했습니다", name);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("(name=%s, securitiesFirm=%s)", name, securitiesFirm);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -57,7 +57,7 @@ public class PortfolioDetail {
 		this.securitiesFirm = detail.securitiesFirm;
 	}
 
-	public boolean isSameName(PortfolioDetail detail) {
+	public boolean equalName(PortfolioDetail detail) {
 		return this.name.equals(detail.name);
 	}
 

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -7,7 +7,8 @@ import jakarta.persistence.Column;
 
 public class PortfolioDetail {
 	// 한글 또는 영문자로 시작하고 최대 100글자
-	public static final Pattern NAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9 ]{0,99}$");
+	public static final String NAME_REGEXP = "^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9 ]{0,99}$";
+	private static final Pattern NAME_PATTERN = Pattern.compile(NAME_REGEXP);
 	@Column(name = "name", nullable = false)
 	private String name;
 	@Column(name = "securities_firm", nullable = false)

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -1,15 +1,22 @@
 package co.fineants.api.domain.portfolio.domain.entity;
 
+import java.util.regex.Pattern;
+
 import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import jakarta.persistence.Column;
 
 public class PortfolioDetail {
+	// 한글 또는 영문자로 시작하고 최대 100글자
+	public static final Pattern NAME_PATTERN = Pattern.compile("^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9 ]{0,99}$");
 	@Column(name = "name", nullable = false)
 	private String name;
 	@Column(name = "securities_firm", nullable = false)
 	private String securitiesFirm;
 
 	private PortfolioDetail(String name, String securitiesFirm, PortfolioProperties properties) {
+		if (name == null || !NAME_PATTERN.matcher(name).matches()) {
+			throw new IllegalArgumentException("Invalid Portfolio name: " + name);
+		}
 		if (!properties.contains(securitiesFirm)) {
 			throw new IllegalArgumentException("Unlisted securitiesFirm: " + securitiesFirm);
 		}

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -1,5 +1,6 @@
 package co.fineants.api.domain.portfolio.domain.entity;
 
+import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import jakarta.persistence.Column;
 
 public class PortfolioDetail {
@@ -8,13 +9,16 @@ public class PortfolioDetail {
 	@Column(name = "securities_firm", nullable = false)
 	private String securitiesFirm;
 
-	private PortfolioDetail(String name, String securitiesFirm) {
+	private PortfolioDetail(String name, String securitiesFirm, PortfolioProperties properties) {
+		if (!properties.contains(securitiesFirm)) {
+			throw new IllegalArgumentException("Unlisted securitiesFirm: " + securitiesFirm);
+		}
 		this.name = name;
 		this.securitiesFirm = securitiesFirm;
 	}
 
-	public static PortfolioDetail of(String name, String securitiesFirm) {
-		return new PortfolioDetail(name, securitiesFirm);
+	public static PortfolioDetail of(String name, String securitiesFirm, PortfolioProperties properties) {
+		return new PortfolioDetail(name, securitiesFirm, properties);
 	}
 
 	@Override

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -18,8 +18,10 @@ public class PortfolioDetail {
 	// 한글 또는 영문자로 시작하고 최대 100글자
 	public static final String NAME_REGEXP = "^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9 ]{0,99}$";
 	private static final Pattern NAME_PATTERN = Pattern.compile(NAME_REGEXP);
+	// 포트폴리오 이름
 	@Column(name = "name", nullable = false)
 	private String name;
+	// 증권사 이름
 	@Column(name = "securities_firm", nullable = false)
 	private String securitiesFirm;
 

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -1,0 +1,24 @@
+package co.fineants.api.domain.portfolio.domain.entity;
+
+import jakarta.persistence.Column;
+
+public class PortfolioDetail {
+	@Column(name = "name", nullable = false)
+	private String name;
+	@Column(name = "securities_firm", nullable = false)
+	private String securitiesFirm;
+
+	private PortfolioDetail(String name, String securitiesFirm) {
+		this.name = name;
+		this.securitiesFirm = securitiesFirm;
+	}
+
+	public static PortfolioDetail of(String name, String securitiesFirm) {
+		return new PortfolioDetail(name, securitiesFirm);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("(name=%s, securitiesFirm=%s)", name, securitiesFirm);
+	}
+}

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -4,7 +4,16 @@ import java.util.regex.Pattern;
 
 import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EqualsAndHashCode(of = {"name", "securitiesFirm"})
+@Getter
 public class PortfolioDetail {
 	// 한글 또는 영문자로 시작하고 최대 100글자
 	public static final String NAME_REGEXP = "^[가-힣a-zA-Z0-9][가-힣a-zA-Z0-9 ]{0,99}$";
@@ -41,5 +50,22 @@ public class PortfolioDetail {
 	@Override
 	public String toString() {
 		return String.format("(name=%s, securitiesFirm=%s)", name, securitiesFirm);
+	}
+
+	public void change(PortfolioDetail detail) {
+		this.name = detail.name;
+		this.securitiesFirm = detail.securitiesFirm;
+	}
+
+	public boolean isSameName(PortfolioDetail detail) {
+		return this.name.equals(detail.name);
+	}
+
+	public String getTargetGainReachMessage() {
+		return String.format("%s의 목표 수익률을 달성했습니다", name);
+	}
+
+	public String getMaximumLossReachMessage() {
+		return String.format("%s이(가) 최대 손실율에 도달했습니다", name);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -35,7 +35,7 @@ public class PortfolioDetail {
 	}
 
 	/**
-	 * Return a PortfolioDetail instance.
+	 * PortfolioDetail 객체를 생성하여 반환.
 	 *
 	 * @param name 포트폴리오 이름
 	 * @param securitiesFirm 증권사 이름
@@ -47,19 +47,40 @@ public class PortfolioDetail {
 		return new PortfolioDetail(name, securitiesFirm, properties);
 	}
 
+	/**
+	 * PortfolioDetail 객체의 name, securitiesFirm 필드를 변경한다.
+	 *
+	 * @param detail 변경하고자 하는 포트폴리오 상세 정보 객체
+	 */
 	public void change(PortfolioDetail detail) {
 		this.name = detail.name;
 		this.securitiesFirm = detail.securitiesFirm;
 	}
 
+	/**
+	 * PortfolioDetail 객체의 name 필드가 같은지 비교한다.
+	 *
+	 * @param detail 비교하고자 하는 PortfolioDetail 객체
+	 * @return name 필드가 같으면 true, 다르면 false
+	 */
 	public boolean equalName(PortfolioDetail detail) {
 		return this.name.equals(detail.name);
 	}
 
+	/**
+	 * 포트폴리오의 목표 수익율 달성 메시지를 생성하여 반환한다.
+	 *
+	 * @return 포트폴리오 목표 수익율 달성 메시지 (ex, 'portfolio1의 목표 수익률을 달성했습니다')
+	 */
 	public String getTargetGainReachMessage() {
 		return String.format("%s의 목표 수익률을 달성했습니다", name);
 	}
 
+	/**
+	 * 포트폴리오의 최대 손실율 도달 메시지를 생성하여 반환한다.
+	 *
+	 * @return 포트폴리오 최대 손실율 도달 메시지 (ex, 'portfolio1의 최대 손실율에 도달했습니다')
+	 */
 	public String getMaximumLossReachMessage() {
 		return String.format("%s이(가) 최대 손실율에 도달했습니다", name);
 	}

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetail.java
@@ -25,6 +25,15 @@ public class PortfolioDetail {
 		this.securitiesFirm = securitiesFirm;
 	}
 
+	/**
+	 * Return a PortfolioDetail instance.
+	 *
+	 * @param name the name 포트폴리오 이름
+	 * @param securitiesFirm the securities firm 증권사 이름
+	 * @param properties the properties 증권사 목록이 담긴 포트폴리오 프로퍼티
+	 * @return the portfolio detail 포트폴리오 상세 정보 객체
+	 * @throws IllegalArgumentException 포트폴리오 이름이 형식에 유효하지 않거나 증권사 이름이 properties 목록에 포함되지 않으면 예외 발생한다
+	 */
 	public static PortfolioDetail of(String name, String securitiesFirm, PortfolioProperties properties) {
 		return new PortfolioDetail(name, securitiesFirm, properties);
 	}

--- a/src/main/java/co/fineants/api/domain/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/repository/PortfolioRepository.java
@@ -13,8 +13,10 @@ import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
 
-	boolean existsByNameAndMember(String name, Member member);
+	@Query("select p from Portfolio p where p.detail.name = :name and p.member = :member")
+	Optional<Portfolio> findByNameAndMember(@Param("name") String name, @Param("member") Member member);
 
+	@Query("select p from Portfolio p where p.member.id = :memberId order by p.id desc")
 	List<Portfolio> findAllByMemberIdOrderByIdDesc(@Param("memberId") Long memberId);
 
 	@Query("select p from Portfolio p where p.member.id = :memberId order by p.createAt asc")

--- a/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
@@ -92,7 +92,7 @@ public class PortFolioService {
 		Portfolio originalPortfolio = findPortfolio(portfolioId);
 		Portfolio changePortfolio = request.toEntity(member, properties);
 
-		if (!originalPortfolio.isSameName(changePortfolio)) {
+		if (!originalPortfolio.equalName(changePortfolio)) {
 			validateUniquePortfolioName(changePortfolio.getName(), member);
 		}
 		originalPortfolio.change(changePortfolio);

--- a/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
@@ -22,6 +22,7 @@ import co.fineants.api.domain.portfolio.domain.dto.response.PortFolioCreateRespo
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioModifyResponse;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfoliosResponse;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import co.fineants.api.domain.portfolio.repository.PortfolioPropertiesRepository;
 import co.fineants.api.domain.portfolio.repository.PortfolioRepository;
 import co.fineants.api.domain.purchasehistory.repository.PurchaseHistoryRepository;
@@ -50,6 +51,7 @@ public class PortFolioService {
 	private final PortfolioGainHistoryRepository portfolioGainHistoryRepository;
 	private final CurrentPriceRedisRepository currentPriceRedisRepository;
 	private final PortfolioPropertiesRepository portfolioPropertiesRepository;
+	private final PortfolioProperties properties;
 
 	@Transactional
 	@Secured("ROLE_USER")
@@ -59,7 +61,7 @@ public class PortFolioService {
 		Member member = findMember(memberId);
 
 		validateUniquePortfolioName(request.getName(), member);
-		Portfolio portfolio = request.toEntity(member);
+		Portfolio portfolio = request.toEntity(member, properties);
 		return PortFolioCreateResponse.from(portfolioRepository.save(portfolio));
 	}
 
@@ -75,7 +77,7 @@ public class PortFolioService {
 	}
 
 	private void validateUniquePortfolioName(String name, Member member) {
-		if (portfolioRepository.existsByNameAndMember(name, member)) {
+		if (portfolioRepository.findByNameAndMember(name, member).isPresent()) {
 			throw new ConflictException(PortfolioErrorCode.DUPLICATE_NAME);
 		}
 	}
@@ -88,7 +90,7 @@ public class PortFolioService {
 		log.info("포트폴리오 수정 서비스 요청 : request={}, portfolioId={}, memberId={}", request, portfolioId, memberId);
 		Member member = findMember(memberId);
 		Portfolio originalPortfolio = findPortfolio(portfolioId);
-		Portfolio changePortfolio = request.toEntity(member);
+		Portfolio changePortfolio = request.toEntity(member, properties);
 
 		if (!originalPortfolio.isSameName(changePortfolio)) {
 			validateUniquePortfolioName(changePortfolio.getName(), member);

--- a/src/test/java/co/fineants/AbstractContainerBaseTest.java
+++ b/src/test/java/co/fineants/AbstractContainerBaseTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -42,6 +41,7 @@ import co.fineants.api.domain.member.domain.entity.Role;
 import co.fineants.api.domain.member.repository.RoleRepository;
 import co.fineants.api.domain.notificationpreference.domain.entity.NotificationPreference;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Market;
 import co.fineants.api.domain.stock.domain.entity.Stock;
@@ -101,8 +101,8 @@ public abstract class AbstractContainerBaseTest {
 	@Autowired
 	private RedisRepository redisRepository;
 
-	@LocalServerPort
-	private int port;
+	@Autowired
+	private PortfolioProperties properties;
 
 	@DynamicPropertySource
 	public static void overrideProps(DynamicPropertyRegistry registry) {
@@ -232,7 +232,8 @@ public abstract class AbstractContainerBaseTest {
 			budget,
 			targetGain,
 			maximumLoss,
-			member
+			member,
+			properties
 		);
 	}
 

--- a/src/test/java/co/fineants/AbstractContainerBaseTest.java
+++ b/src/test/java/co/fineants/AbstractContainerBaseTest.java
@@ -226,6 +226,7 @@ public abstract class AbstractContainerBaseTest {
 
 	protected Portfolio createPortfolio(Member member, String name, Money budget, Money targetGain, Money maximumLoss) {
 		return Portfolio.active(
+			null,
 			name,
 			"토스증권",
 			budget,

--- a/src/test/java/co/fineants/AbstractContainerBaseTest.java
+++ b/src/test/java/co/fineants/AbstractContainerBaseTest.java
@@ -41,6 +41,7 @@ import co.fineants.api.domain.member.domain.entity.Role;
 import co.fineants.api.domain.member.repository.RoleRepository;
 import co.fineants.api.domain.notificationpreference.domain.entity.NotificationPreference;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.domain.entity.PortfolioDetail;
 import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Market;
@@ -225,15 +226,14 @@ public abstract class AbstractContainerBaseTest {
 	}
 
 	protected Portfolio createPortfolio(Member member, String name, Money budget, Money targetGain, Money maximumLoss) {
+		PortfolioDetail detail = PortfolioDetail.of(name, "토스증권", properties);
 		return Portfolio.active(
 			null,
-			name,
-			"토스증권",
+			detail,
 			budget,
 			targetGain,
 			maximumLoss,
-			member,
-			properties
+			member
 		);
 	}
 

--- a/src/test/java/co/fineants/api/docs/RestDocsSupport.java
+++ b/src/test/java/co/fineants/api/docs/RestDocsSupport.java
@@ -42,6 +42,7 @@ import co.fineants.api.domain.notification.domain.entity.Notification;
 import co.fineants.api.domain.notification.domain.entity.PortfolioNotification;
 import co.fineants.api.domain.notification.domain.entity.StockTargetPriceNotification;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Market;
 import co.fineants.api.domain.stock.domain.entity.Stock;
@@ -60,6 +61,8 @@ public abstract class RestDocsSupport {
 	protected MockMvc mockMvc;
 
 	protected MemberAuthenticationArgumentResolver memberAuthenticationArgumentResolver;
+
+	private final PortfolioProperties properties = new PortfolioProperties(new String[] {"토스증권", "FineAnts"});
 
 	@BeforeEach
 	void setUp(RestDocumentationContextProvider provider) throws Exception {
@@ -105,7 +108,8 @@ public abstract class RestDocsSupport {
 			Money.won(1000000L),
 			Money.won(1500000L),
 			Money.won(900000L),
-			member
+			member,
+			properties
 		);
 	}
 

--- a/src/test/java/co/fineants/api/docs/RestDocsSupport.java
+++ b/src/test/java/co/fineants/api/docs/RestDocsSupport.java
@@ -42,6 +42,7 @@ import co.fineants.api.domain.notification.domain.entity.Notification;
 import co.fineants.api.domain.notification.domain.entity.PortfolioNotification;
 import co.fineants.api.domain.notification.domain.entity.StockTargetPriceNotification;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.domain.entity.PortfolioDetail;
 import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Market;
@@ -101,15 +102,14 @@ public abstract class RestDocsSupport {
 	}
 
 	protected Portfolio createPortfolio(Member member) {
+		PortfolioDetail detail = PortfolioDetail.of("내꿈은 워렌버핏", "토스증권", properties);
 		return Portfolio.active(
 			1L,
-			"내꿈은 워렌버핏",
-			"토스증권",
+			detail,
 			Money.won(1000000L),
 			Money.won(1500000L),
 			Money.won(900000L),
-			member,
-			properties
+			member
 		);
 	}
 

--- a/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
@@ -8,6 +8,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -19,6 +20,7 @@ import co.fineants.api.domain.common.money.Expression;
 import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.common.money.RateDivision;
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
+import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Stock;
@@ -166,6 +168,26 @@ class PortfolioHoldingTest extends AbstractContainerBaseTest {
 		assertThat(moneys)
 			.usingComparatorForType(Expression::compareTo, Expression.class)
 			.isEqualTo(expected.values());
+	}
+
+	@DisplayName("포트폴리오 종목에 포트폴리오를 설정한다")
+	@Test
+	void setPortfolio() {
+		// given
+		Member member = createMember();
+		Portfolio portfolio = createPortfolio(member);
+		Stock stock = createSamsungStock();
+		PortfolioHolding holding = createPortfolioHolding(portfolio, stock, 20000L);
+
+		Portfolio other = createPortfolio(member, "other");
+		// when
+		holding.setPortfolio(other);
+		// then
+		Assertions.assertThat(portfolio.getPortfolioHoldings()).isEmpty();
+		Assertions.assertThat(other.getPortfolioHoldings())
+			.hasSize(1)
+			.containsExactlyInAnyOrder(createPortfolioHolding(other, stock, 20000L));
+		Assertions.assertThat(holding.getPortfolio()).isEqualTo(other);
 	}
 
 	private List<StockDividend> createStockDividends(Stock stock) {

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetailTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetailTest.java
@@ -1,0 +1,21 @@
+package co.fineants.api.domain.portfolio.domain.entity;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PortfolioDetailTest {
+
+	@DisplayName("포트폴리오 상세 정보를 생성한다")
+	@Test
+	void of() {
+		// given
+		String name = "portfolio1";
+		String securitiesFirm = "토스증권";
+		// when
+		PortfolioDetail detail = PortfolioDetail.of(name, securitiesFirm);
+		// then
+		String expected = String.format("(name=%s, securitiesFirm=%s)", name, securitiesFirm);
+		Assertions.assertThat(detail.toString()).isEqualTo(expected);
+	}
+}

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetailTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetailTest.java
@@ -1,8 +1,14 @@
 package co.fineants.api.domain.portfolio.domain.entity;
 
+import java.util.stream.Stream;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import co.fineants.AbstractContainerBaseTest;
@@ -39,4 +45,30 @@ class PortfolioDetailTest extends AbstractContainerBaseTest {
 			.isInstanceOf(IllegalArgumentException.class)
 			.hasMessage("Unlisted securitiesFirm: " + securitiesFirm);
 	}
+
+	@DisplayName("포트폴리오 이름 형식을 지키지 않으면 예외가 발생한다")
+	@MethodSource("invalidPortfolioNames")
+	@NullAndEmptySource
+	@ParameterizedTest(name = "{index}: {0} 입력시 예외 발생")
+	void of_givenInvalidName_whenCreatingPortfolioDetail_thenThrowException(String name) {
+		// given
+		String securitiesFirm = "토스증권";
+		// when
+		Throwable throwable = Assertions.catchThrowable(() -> PortfolioDetail.of(name, securitiesFirm, properties));
+		// then
+		Assertions.assertThat(throwable)
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Invalid Portfolio name: " + name);
+	}
+
+	private static Stream<Arguments> invalidPortfolioNames() {
+		return Stream.of(
+			Arguments.of(
+				"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+				"이름이 100글자를 초과"),
+			Arguments.of(" portfolio1", "공백으로 시작함"),
+			Arguments.of("#!@$!@#!@#4!@4", "특수문자가 포함됨")
+		);
+	}
+
 }

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetailTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioDetailTest.java
@@ -3,8 +3,15 @@ package co.fineants.api.domain.portfolio.domain.entity;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 
-class PortfolioDetailTest {
+import co.fineants.AbstractContainerBaseTest;
+import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
+
+class PortfolioDetailTest extends AbstractContainerBaseTest {
+
+	@Autowired
+	private PortfolioProperties properties;
 
 	@DisplayName("포트폴리오 상세 정보를 생성한다")
 	@Test
@@ -13,9 +20,23 @@ class PortfolioDetailTest {
 		String name = "portfolio1";
 		String securitiesFirm = "토스증권";
 		// when
-		PortfolioDetail detail = PortfolioDetail.of(name, securitiesFirm);
+		PortfolioDetail detail = PortfolioDetail.of(name, securitiesFirm, properties);
 		// then
 		String expected = String.format("(name=%s, securitiesFirm=%s)", name, securitiesFirm);
-		Assertions.assertThat(detail.toString()).isEqualTo(expected);
+		Assertions.assertThat(detail.toString()).hasToString(expected);
+	}
+
+	@DisplayName("목록에 없는 증권사 이름가 주어지고 포트폴리오 상세 정보 인스턴스 생성시 예외가 발생한다")
+	@Test
+	void of_givenUnlistedSecuritiesFirm_whenCreatingPortfolioDetail_thenThrowException() {
+		// given
+		String name = "portfolio1";
+		String securitiesFirm = "없는 증권사";
+		// when
+		Throwable throwable = Assertions.catchThrowable(() -> PortfolioDetail.of(name, securitiesFirm, properties));
+		// then
+		Assertions.assertThat(throwable)
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("Unlisted securitiesFirm: " + securitiesFirm);
 	}
 }

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioTest.java
@@ -166,4 +166,20 @@ class PortfolioTest extends AbstractContainerBaseTest {
 			.extracting("sector")
 			.containsExactlyInAnyOrder("현금", "의약품", "전기전자");
 	}
+
+	@DisplayName("포트폴리오에 포트폴리오 종목을 추가한다")
+	@Test
+	void addHoldings() {
+		// given
+		Portfolio portfolio = createPortfolio(createMember());
+		Stock stock = createSamsungStock();
+		PortfolioHolding holding1 = PortfolioHolding.of(portfolio, stock, Money.won(20000L));
+		// when
+		portfolio.addHolding(holding1);
+		// then
+		assertThat(portfolio.getPortfolioHoldings())
+			.hasSize(1)
+			.containsExactlyInAnyOrder(PortfolioHolding.of(portfolio, stock, Money.won(20000L)));
+		assertThat(holding1.getPortfolio()).isEqualTo(portfolio);
+	}
 }

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/entity/PortfolioTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.assertj.core.api.Assertions;
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +19,7 @@ import co.fineants.api.domain.common.money.RateDivision;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioPieChartItem;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioSectorChartItem;
 import co.fineants.api.domain.holding.domain.entity.PortfolioHolding;
+import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Stock;
 
@@ -181,5 +183,16 @@ class PortfolioTest extends AbstractContainerBaseTest {
 			.hasSize(1)
 			.containsExactlyInAnyOrder(PortfolioHolding.of(portfolio, stock, Money.won(20000L)));
 		assertThat(holding1.getPortfolio()).isEqualTo(portfolio);
+	}
+
+	@DisplayName("포트폴리오 인스턴스 생성시 회원 객체 전달하면 회원도 같이 설정된다")
+	@Test
+	void setMember_givenMember_whenCreatingInstance_thenSetMember() {
+		// given
+		Member member = createMember();
+		// when
+		Portfolio portfolio = createPortfolio(member);
+		// then
+		Assertions.assertThat(portfolio.getMember()).isEqualTo(createMember());
 	}
 }

--- a/src/test/java/co/fineants/api/domain/portfolio/repository/PortfolioRepositoryTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/repository/PortfolioRepositoryTest.java
@@ -3,6 +3,7 @@ package co.fineants.api.domain.portfolio.repository;
 import static org.assertj.core.api.Assertions.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -43,10 +44,10 @@ class PortfolioRepositoryTest extends AbstractContainerBaseTest {
 		portfolioRepository.save(createPortfolio(member));
 
 		// when
-		boolean actual = portfolioRepository.existsByNameAndMember("내꿈은 워렌버핏", member);
+		Optional<Portfolio> portfolio = portfolioRepository.findByNameAndMember("내꿈은 워렌버핏", member);
 
 		// then
-		assertThat(actual).isTrue();
+		assertThat(portfolio).isPresent();
 	}
 
 	@DisplayName("회원 등록번호에 따른 포트폴리오들을 등록번호를 기준으로 내림차순으로 조회한다")

--- a/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Stream;
 
 import org.assertj.core.groups.Tuple;
@@ -326,7 +325,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 
 		long budget = 1000000L;
 		long maximumLoss = 900000L;
-		Map<String, Object> body = createModifiedPortfolioRequestBodyMap("내꿈은 찰리몽거", "미래애셋증권", budget, targetGain,
+		Map<String, Object> body = createModifiedPortfolioRequestBodyMap("내꿈은 찰리몽거", "미래에셋증권", budget, targetGain,
 			maximumLoss);
 
 		PortfolioModifyRequest request = ObjectMapperUtil.deserialize(ObjectMapperUtil.serialize(body),
@@ -380,7 +379,8 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		List<Portfolio> portfolios = new ArrayList<>();
 		for (int i = 1; i <= 25; i++) {
-			portfolios.add(createPortfolioWithRandomName(member));
+			String name = String.format("portfolio%d", i);
+			portfolios.add(createPortfolio(member, name));
 		}
 		portfolioRepository.saveAll(portfolios);
 
@@ -504,7 +504,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 
 		PortfolioGainHistory portfolioGainHistory = portfolioGainHistoryRepository.save(
 			PortfolioGainHistory.empty(portfolio));
-		Portfolio portfolio2 = portfolioRepository.save(createPortfolioWithRandomName(member));
+		Portfolio portfolio2 = portfolioRepository.save(createPortfolio(member, "portfolio2"));
 
 		List<Long> portfolioIds = Arrays.asList(portfolio.getId(), portfolio2.getId());
 		setAuthentication(member);
@@ -527,7 +527,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Member hacker = memberRepository.save(createMember("hacker"));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
-		Portfolio portfolio2 = portfolioRepository.save(createPortfolioWithRandomName(member));
+		Portfolio portfolio2 = portfolioRepository.save(createPortfolio(member, "portfolio2"));
 		List<Long> portfolioIds = Arrays.asList(portfolio.getId(), portfolio2.getId());
 
 		setAuthentication(hacker);
@@ -538,17 +538,6 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 		assertThat(throwable)
 			.isInstanceOf(FineAntsException.class)
 			.hasMessage(MemberErrorCode.FORBIDDEN_MEMBER.getMessage());
-	}
-
-	private Portfolio createPortfolioWithRandomName(Member member) {
-		String randomPostfix = UUID.randomUUID().toString().substring(0, 10);
-		return createPortfolio(
-			member,
-			"내꿈은 워렙퍼빗" + randomPostfix,
-			Money.won(1000000L),
-			Money.won(1500000L),
-			Money.won(900000L)
-		);
 	}
 
 	private static Stream<Arguments> provideInvalidTargetGain() {

--- a/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
@@ -104,7 +104,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 	}
 
 	@DisplayName("회원은 포트폴리오를 추가할때 목표수익금액이 예산보다 같거나 작으면 안된다")
-	@MethodSource("provideInvalidTargetGain")
+	@MethodSource("invalidTargetGain")
 	@ParameterizedTest
 	void addPortfolioWithTargetGainIsEqualLessThanBudget(Long targetGain) {
 		// given
@@ -129,7 +129,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 	}
 
 	@DisplayName("회원은 포트폴리오를 추가할때 최대손실율이 예산보다 같거나 크면 안된다")
-	@MethodSource("provideInvalidMaximumLoss")
+	@MethodSource("invalidMaximumLoss")
 	@ParameterizedTest
 	void addPortfolioWithMaximumLossIsEqualGreaterThanBudget(Long maximumLoss) {
 		// given
@@ -540,14 +540,14 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 			.hasMessage(MemberErrorCode.FORBIDDEN_MEMBER.getMessage());
 	}
 
-	private static Stream<Arguments> provideInvalidTargetGain() {
+	private static Stream<Arguments> invalidTargetGain() {
 		return Stream.of(
 			Arguments.of(900000L),
 			Arguments.of(1000000L)
 		);
 	}
 
-	private static Stream<Arguments> provideInvalidMaximumLoss() {
+	private static Stream<Arguments> invalidMaximumLoss() {
 		return Stream.of(
 			Arguments.of(1000000L),
 			Arguments.of(1100000L)

--- a/src/test/java/co/fineants/support/controller/ControllerTestSupport.java
+++ b/src/test/java/co/fineants/support/controller/ControllerTestSupport.java
@@ -29,6 +29,7 @@ import co.fineants.api.domain.holding.domain.entity.PortfolioHolding;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.member.domain.entity.MemberProfile;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Market;
 import co.fineants.api.domain.stock.domain.entity.Stock;
@@ -51,6 +52,9 @@ public abstract class ControllerTestSupport {
 
 	@Autowired
 	protected ObjectMapper objectMapper;
+
+	@Autowired
+	private PortfolioProperties properties;
 
 	@MockBean
 	protected MemberAuthenticationArgumentResolver memberAuthenticationArgumentResolver;
@@ -117,7 +121,8 @@ public abstract class ControllerTestSupport {
 			budget,
 			targetGain,
 			maximumLoss,
-			member
+			member,
+			properties
 		);
 	}
 

--- a/src/test/java/co/fineants/support/controller/ControllerTestSupport.java
+++ b/src/test/java/co/fineants/support/controller/ControllerTestSupport.java
@@ -29,6 +29,7 @@ import co.fineants.api.domain.holding.domain.entity.PortfolioHolding;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.member.domain.entity.MemberProfile;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.domain.entity.PortfolioDetail;
 import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
 import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Market;
@@ -114,15 +115,14 @@ public abstract class ControllerTestSupport {
 
 	protected Portfolio createPortfolio(Long id, Member member, String name, Money budget, Money targetGain,
 		Money maximumLoss) {
+		PortfolioDetail detail = PortfolioDetail.of(name, "토스증권", properties);
 		return Portfolio.active(
 			id,
-			name,
-			"토스증권",
+			detail,
 			budget,
 			targetGain,
 			maximumLoss,
-			member,
-			properties
+			member
 		);
 	}
 


### PR DESCRIPTION
## 구현한 것
- name, securitiesFirm 필드를 임베딩
- 엔티티 클래스의 생성자 및 정적 메서드 생성자 줄이기
- ToString 재정의
- 연관관계 편의 메서드 개선

## TO-BE
- budget, targetGain, maximumLoss를 하나로 묶은 임베딩 클래스 추가