### PR TITLE
[feat] CookieDomainProvider 인터페이스 선언 및 구현클래스 추가

### DIFF
--- a/src/main/java/co/fineants/api/global/security/factory/CookieDomainProvider.java
+++ b/src/main/java/co/fineants/api/global/security/factory/CookieDomainProvider.java
@@ -1,0 +1,5 @@
+package co.fineants.api.global.security.factory;
+
+public interface CookieDomainProvider {
+	String domain();
+}

--- a/src/main/java/co/fineants/api/global/security/factory/DeployCookieDomainProvider.java
+++ b/src/main/java/co/fineants/api/global/security/factory/DeployCookieDomainProvider.java
@@ -1,0 +1,14 @@
+package co.fineants.api.global.security.factory;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile(value = {"release", "production"})
+public class DeployCookieDomainProvider implements CookieDomainProvider {
+
+	@Override
+	public String domain() {
+		return ".fineants.co";
+	}
+}

--- a/src/main/java/co/fineants/api/global/security/factory/LocalCookieDomainProvider.java
+++ b/src/main/java/co/fineants/api/global/security/factory/LocalCookieDomainProvider.java
@@ -1,0 +1,13 @@
+package co.fineants.api.global.security.factory;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Component
+@Profile(value = {"local", "test"})
+public class LocalCookieDomainProvider implements CookieDomainProvider {
+	@Override
+	public String domain() {
+		return null;
+	}
+}

--- a/src/main/java/co/fineants/api/global/security/factory/TokenFactory.java
+++ b/src/main/java/co/fineants/api/global/security/factory/TokenFactory.java
@@ -4,14 +4,19 @@ import org.springframework.http.ResponseCookie;
 import org.springframework.stereotype.Component;
 
 import co.fineants.api.global.security.oauth.dto.Token;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Component
+@RequiredArgsConstructor
 @Slf4j
 public class TokenFactory {
 
+	private final CookieDomainProvider provider;
+
 	public ResponseCookie createAccessTokenCookie(Token token) {
 		return token.createAccessTokenCookie()
+			.domain(provider.domain())
 			.sameSite("None")
 			.path("/")
 			.secure(true)
@@ -21,6 +26,7 @@ public class TokenFactory {
 
 	public ResponseCookie createRefreshTokenCookie(Token token) {
 		return token.createRefreshTokenCookie()
+			.domain(provider.domain())
 			.sameSite("None")
 			.path("/")
 			.secure(true)


### PR DESCRIPTION
## 구현한 것

- 배포환경에서 도메인 이름 .fineants.co를 제공하는 provider 구현
