### PR TITLE
[refactor] 포트폴리오 종목 및 계산기 개선

### DIFF
--- a/src/main/java/co/fineants/api/domain/dividend/domain/entity/DividendDates.java
+++ b/src/main/java/co/fineants/api/domain/dividend/domain/entity/DividendDates.java
@@ -1,6 +1,7 @@
 package co.fineants.api.domain.dividend.domain.entity;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.format.DateTimeFormatter;
 
 import org.apache.logging.log4j.util.Strings;
@@ -54,8 +55,8 @@ public class DividendDates {
 		return purchaseDate.isBefore(exDividendDate);
 	}
 
-	public Integer getPaymentDateMonth() {
-		return paymentDate.getMonthValue();
+	public Month getPaymentDateMonth() {
+		return paymentDate.getMonth();
 	}
 
 	public boolean isCurrentYearRecordDate(LocalDate localDate) {

--- a/src/main/java/co/fineants/api/domain/dividend/domain/entity/DividendDates.java
+++ b/src/main/java/co/fineants/api/domain/dividend/domain/entity/DividendDates.java
@@ -132,4 +132,11 @@ public class DividendDates {
 	public boolean isPurchaseDateBeforeExDividendDate(PurchaseHistory history) {
 		return history.isPurchaseDateBeforeExDividendDate(exDividendDate.atStartOfDay());
 	}
+
+	public boolean isCurrentMonthPaymentDate(LocalDate today) {
+		if (paymentDate == null) {
+			return false;
+		}
+		return paymentDate.getMonth() == today.getMonth() && paymentDate.getYear() == today.getYear();
+	}
 }

--- a/src/main/java/co/fineants/api/domain/dividend/domain/entity/StockDividend.java
+++ b/src/main/java/co/fineants/api/domain/dividend/domain/entity/StockDividend.java
@@ -164,4 +164,8 @@ public class StockDividend extends BaseEntity {
 	public boolean isPurchaseDateBeforeExDividendDate(PurchaseHistory history) {
 		return dividendDates.isPurchaseDateBeforeExDividendDate(history);
 	}
+
+	public boolean isCurrentMonthPaymentDate(LocalDate today) {
+		return dividendDates.isCurrentMonthPaymentDate(today);
+	}
 }

--- a/src/main/java/co/fineants/api/domain/dividend/domain/entity/StockDividend.java
+++ b/src/main/java/co/fineants/api/domain/dividend/domain/entity/StockDividend.java
@@ -1,6 +1,7 @@
 package co.fineants.api.domain.dividend.domain.entity;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.List;
 
 import co.fineants.api.domain.BaseEntity;
@@ -117,7 +118,7 @@ public class StockDividend extends BaseEntity {
 		return history.canReceiveDividendOn(dividendDates);
 	}
 
-	public Integer getMonthValueByPaymentDate() {
+	public Month getMonthByPaymentDate() {
 		return dividendDates.getPaymentDateMonth();
 	}
 

--- a/src/main/java/co/fineants/api/domain/holding/domain/chart/DividendChart.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/chart/DividendChart.java
@@ -1,6 +1,7 @@
 package co.fineants.api.domain.holding.domain.chart;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.List;
 import java.util.Map;
 
@@ -11,7 +12,6 @@ import co.fineants.api.domain.common.money.Currency;
 import co.fineants.api.domain.common.money.Expression;
 import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioDividendChartItem;
-import co.fineants.api.domain.kis.repository.PriceRepository;
 import co.fineants.api.domain.portfolio.domain.calculator.PortfolioCalculator;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import lombok.RequiredArgsConstructor;
@@ -19,21 +19,20 @@ import lombok.RequiredArgsConstructor;
 @Component
 @RequiredArgsConstructor
 public class DividendChart {
-
-	private final PriceRepository manager;
 	private final PortfolioCalculator calculator;
 
 	public List<PortfolioDividendChartItem> createItemsBy(Portfolio portfolio, LocalDate currentLocalDate) {
-		Map<Integer, Expression> totalDividendMap = calculator.calTotalDividendBy(portfolio, currentLocalDate);
+		Map<Month, Expression> totalDividendMap = calculator.calTotalDividendBy(portfolio, currentLocalDate);
 
 		Bank bank = Bank.getInstance();
 		Currency to = Currency.KRW;
 		return totalDividendMap.entrySet().stream()
 			.map(entry -> {
-				int month = entry.getKey();
+				Month month = entry.getKey();
 				Money dividend = entry.getValue().reduce(bank, to);
-				return PortfolioDividendChartItem.create(month, dividend);
+				return PortfolioDividendChartItem.create(month.getValue(), dividend);
 			})
+			.sorted()
 			.toList();
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioDividendChartItem.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioDividendChartItem.java
@@ -1,5 +1,7 @@
 package co.fineants.api.domain.holding.domain.dto.response;
 
+import org.jetbrains.annotations.NotNull;
+
 import co.fineants.api.domain.common.money.Money;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -11,7 +13,7 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @ToString
-public class PortfolioDividendChartItem {
+public class PortfolioDividendChartItem implements Comparable<PortfolioDividendChartItem> {
 	private int month;
 	private Money amount;
 
@@ -24,5 +26,10 @@ public class PortfolioDividendChartItem {
 			month,
 			amount
 		);
+	}
+
+	@Override
+	public int compareTo(@NotNull PortfolioDividendChartItem item) {
+		return Integer.compare(this.month, item.month);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
@@ -47,7 +47,7 @@ public class PortfolioHoldingDetailItem {
 		Expression dailyChange = calculator.calDailyChange(holding, closingPrice);
 		Expression dailyChangeRate = calculator.calDailyChangeRate(holding, closingPrice);
 		Expression totalGain = calculator.calTotalGainBy(holding);
-		Percentage totalReturnPercentage = calculator.calTotalReturnPercentage(holding);
+		Percentage totalReturnPercentage = calculator.calTotalGainPercentage(holding);
 		Expression annualExpectedDividend = calculator.calAnnualExpectedDividendBy(holding);
 		return PortfolioHoldingDetailItem.builder()
 			.id(holding.getId())

--- a/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
@@ -42,6 +42,7 @@ public class PortfolioHoldingDetailItem {
 		Currency to = Currency.KRW;
 		Expression totalCurrentValuation = calculator.calTotalCurrentValuation(holding);
 		Expression currentPrice = calculator.fetchCurrentPrice(holding);
+		Expression averageCostPerShare = calculator.calAverageCostPerShareBy(holding);
 		Expression annualDividendYield = calculator.calAnnualExpectedDividendYieldBy(holding);
 		Expression dailyChange = calculator.calDailyChange(holding, closingPrice);
 		Expression dailyChangeRate = calculator.calDailyChangeRate(holding, closingPrice);
@@ -52,7 +53,7 @@ public class PortfolioHoldingDetailItem {
 			.id(holding.getId())
 			.currentValuation(toWon(totalCurrentValuation))
 			.currentPrice(toWon(currentPrice.reduce(bank, to)))
-			.averageCostPerShare(toWon(holding.calculateAverageCostPerShare()))
+			.averageCostPerShare(toWon(averageCostPerShare))
 			.numShares(holding.calculateNumShares())
 			.dailyChange(toWon(dailyChange))
 			.dailyChangeRate(toPercentage(dailyChangeRate))

--- a/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
@@ -47,6 +47,7 @@ public class PortfolioHoldingDetailItem {
 		Expression dailyChangeRate = calculator.calDailyChangeRate(holding, closingPrice);
 		Expression totalGain = calculator.calTotalGainBy(holding);
 		Percentage totalReturnPercentage = calculator.calTotalReturnPercentage(holding);
+		Expression annualExpectedDividend = calculator.calAnnualExpectedDividendBy(holding);
 		return PortfolioHoldingDetailItem.builder()
 			.id(holding.getId())
 			.currentValuation(toWon(totalCurrentValuation))
@@ -57,7 +58,7 @@ public class PortfolioHoldingDetailItem {
 			.dailyChangeRate(toPercentage(dailyChangeRate))
 			.totalGain(toWon(totalGain))
 			.totalReturnRate(totalReturnPercentage)
-			.annualDividend(toWon(holding.calculateAnnualExpectedDividend()))
+			.annualDividend(toWon(annualExpectedDividend))
 			.annualDividendYield(toPercentage(annualDividendYield))
 			.dateAdded(holding.getCreateAt())
 			.build();

--- a/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
@@ -43,6 +43,7 @@ public class PortfolioHoldingDetailItem {
 		Expression totalCurrentValuation = calculator.calTotalCurrentValuation(holding);
 		Expression currentPrice = calculator.fetchCurrentPrice(holding);
 		Expression averageCostPerShare = calculator.calAverageCostPerShareBy(holding);
+		Count numShares = calculator.calNumSharesBy(holding);
 		Expression annualDividendYield = calculator.calAnnualExpectedDividendYieldBy(holding);
 		Expression dailyChange = calculator.calDailyChange(holding, closingPrice);
 		Expression dailyChangeRate = calculator.calDailyChangeRate(holding, closingPrice);
@@ -54,7 +55,7 @@ public class PortfolioHoldingDetailItem {
 			.currentValuation(toWon(totalCurrentValuation))
 			.currentPrice(toWon(currentPrice.reduce(bank, to)))
 			.averageCostPerShare(toWon(averageCostPerShare))
-			.numShares(holding.calculateNumShares())
+			.numShares(numShares)
 			.dailyChange(toWon(dailyChange))
 			.dailyChangeRate(toPercentage(dailyChangeRate))
 			.totalGain(toWon(totalGain))

--- a/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingDetailItem.java
@@ -40,7 +40,7 @@ public class PortfolioHoldingDetailItem {
 		PortfolioCalculator calculator) {
 		Bank bank = Bank.getInstance();
 		Currency to = Currency.KRW;
-		Expression totalCurrentValuation = calculator.calTotalCurrentValuation(holding);
+		Expression totalCurrentValuation = calculator.calTotalCurrentValuationBy(holding);
 		Expression currentPrice = calculator.fetchCurrentPrice(holding);
 		Expression averageCostPerShare = calculator.calAverageCostPerShareBy(holding);
 		Count numShares = calculator.calNumSharesBy(holding);

--- a/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingItem.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingItem.java
@@ -24,7 +24,7 @@ public class PortfolioHoldingItem {
 		StockItem stockItem = StockItem.from(portfolioHolding.getStock());
 		PortfolioHoldingDetailItem holdingDetailItem = PortfolioHoldingDetailItem.from(portfolioHolding,
 			lastDayClosingPrice, calculator);
-		List<PurchaseHistoryItem> purchaseHistory = portfolioHolding.getPurchaseHistory().stream()
+		List<PurchaseHistoryItem> purchaseHistory = portfolioHolding.getPurchaseHistories().stream()
 			.map(PurchaseHistoryItem::from)
 			.toList();
 		return new PortfolioHoldingItem(stockItem, holdingDetailItem, purchaseHistory);

--- a/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingRealTimeItem.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingRealTimeItem.java
@@ -33,7 +33,7 @@ public class PortfolioHoldingRealTimeItem {
 		PortfolioCalculator calculator) {
 		Bank bank = Bank.getInstance();
 		Currency to = Currency.KRW;
-		Expression totalCurrentValuation = calculator.calTotalCurrentValuation(holding);
+		Expression totalCurrentValuation = calculator.calTotalCurrentValuationBy(holding);
 		Expression currentPrice = calculator.fetchCurrentPrice(holding);
 		Expression dailyChange = calculator.calDailyChange(holding, closingPrice);
 		Expression dailyChangeRate = calculator.calDailyChangeRate(holding, closingPrice);

--- a/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingRealTimeItem.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/dto/response/PortfolioHoldingRealTimeItem.java
@@ -38,7 +38,7 @@ public class PortfolioHoldingRealTimeItem {
 		Expression dailyChange = calculator.calDailyChange(holding, closingPrice);
 		Expression dailyChangeRate = calculator.calDailyChangeRate(holding, closingPrice);
 		Expression totalGain = calculator.calTotalGainBy(holding);
-		Percentage totalReturnPercentage = calculator.calTotalReturnPercentage(holding);
+		Percentage totalReturnPercentage = calculator.calTotalGainPercentage(holding);
 		return new PortfolioHoldingRealTimeItem(
 			holding.getId(),
 			totalCurrentValuation.reduce(bank, to),

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -9,7 +9,6 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.hibernate.annotations.BatchSize;
-import org.jetbrains.annotations.NotNull;
 
 import co.fineants.api.domain.BaseEntity;
 import co.fineants.api.domain.common.count.Count;
@@ -135,32 +134,6 @@ public class PortfolioHolding extends BaseEntity {
 		return purchaseHistories.stream()
 			.map(PurchaseHistory::calInvestmentAmount)
 			.reduce(Money.wonZero(), Expression::plus);
-	}
-
-	/**
-	 * 포트폴리오 종목의 평가 금액을 계산 후 반환.
-	 * <p>
-	 * CurrentValuation = CurrentPrice * NumShares
-	 * </p>
-	 * @param currentPrice 종목의 현재가
-	 * @return 포트폴리오 종목의 평가 금액
-	 */
-	public Expression calculateCurrentValuation(@NotNull Expression currentPrice) {
-		return currentPrice.times(calculateNumShares().intValue());
-	}
-
-	/**
-	 * 포트폴리오 종목의 예상 연간 배당율을 계산 후 반환.
-	 * <p>
-	 * AnnualExpectedDividendYield = (AnnualExpectedDividend / CurrentValuation)
-	 * </p>
-	 * @param currentPrice 종목 현재가
-	 * @return 예상 연간 배당율
-	 */
-	public RateDivision calculateAnnualExpectedDividendYield(Expression currentPrice) {
-		Expression annualDividend = calculateAnnualExpectedDividend();
-		Expression currentValuation = calculateCurrentValuation(currentPrice);
-		return annualDividend.divide(currentValuation);
 	}
 
 	private Expression calculateAnnualDividend() {

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -62,9 +62,8 @@ public class PortfolioHolding extends BaseEntity {
 		this.purchaseHistories = new ArrayList<>();
 	}
 
-	private PortfolioHolding(LocalDateTime createAt, LocalDateTime modifiedAt, Long id, Portfolio portfolio,
-		Stock stock) {
-		super(createAt, modifiedAt);
+	private PortfolioHolding(Long id, Portfolio portfolio, Stock stock) {
+		super(LocalDateTime.now(), LocalDateTime.now());
 		this.id = id;
 		this.portfolio = portfolio;
 		this.stock = stock;
@@ -79,7 +78,7 @@ public class PortfolioHolding extends BaseEntity {
 	}
 
 	public static PortfolioHolding of(Long id, Portfolio portfolio, Stock stock) {
-		return new PortfolioHolding(LocalDateTime.now(), null, id, portfolio, stock);
+		return new PortfolioHolding(id, portfolio, stock);
 	}
 
 	//== 연관관계 메소드 ==//

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -2,8 +2,10 @@ package co.fineants.api.domain.holding.domain.entity;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -127,13 +129,16 @@ public class PortfolioHolding extends BaseEntity {
 	 * @param currentLocalDate 기준 일자
 	 * @return 월별 배당금 합계 맵
 	 */
-	public Map<Integer, Expression> createMonthlyDividendMap(LocalDate currentLocalDate) {
-		Map<Integer, Expression> monthlyDividends = stock.createMonthlyDividends(purchaseHistories, currentLocalDate);
-		Map<Integer, Expression> monthlyExpectedDividends = stock.createMonthlyExpectedDividends(purchaseHistories,
+	public Map<Month, Expression> createMonthlyDividendMap(LocalDate currentLocalDate) {
+		Map<Month, Expression> result = new EnumMap<>(Month.class);
+		Map<Month, Expression> monthlyDividends = stock.createMonthlyDividends(purchaseHistories, currentLocalDate);
+		Map<Month, Expression> monthlyExpectedDividends = stock.createMonthlyExpectedDividends(purchaseHistories,
 			currentLocalDate);
+		monthlyDividends.forEach(
+			(month, dividend) -> result.merge(month, dividend, Expression::plus));
 		monthlyExpectedDividends.forEach(
-			(month, dividend) -> monthlyDividends.merge(month, dividend, Expression::plus));
-		return monthlyDividends;
+			(month, dividend) -> result.merge(month, dividend, Expression::plus));
+		return result;
 	}
 
 	/**

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -142,7 +142,7 @@ public class PortfolioHolding extends BaseEntity {
 	 */
 	public Expression calculateTotalInvestmentAmount() {
 		return purchaseHistories.stream()
-			.map(PurchaseHistory::calculateInvestmentAmount)
+			.map(PurchaseHistory::calInvestmentAmount)
 			.reduce(Money.wonZero(), Expression::plus);
 	}
 
@@ -239,7 +239,6 @@ public class PortfolioHolding extends BaseEntity {
 	 * @param currentLocalDate 기준 일자
 	 * @return 월별 배당금 합계 맵
 	 */
-	// 월별 배당금 계산, key=월, value=배당금 합계
 	public Map<Integer, Expression> createMonthlyDividendMap(LocalDate currentLocalDate) {
 		Map<Integer, Expression> monthlyDividends = stock.createMonthlyDividends(purchaseHistories, currentLocalDate);
 		Map<Integer, Expression> monthlyExpectedDividends = stock.createMonthlyExpectedDividends(purchaseHistories,

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -254,7 +254,7 @@ public class PortfolioHolding extends BaseEntity {
 		return PortfolioPieChartItem.stock(name, currentValuation, weightPercentage, totalGain, totalReturnPercentage);
 	}
 
-	public Expression getLastDayClosingPrice(ClosingPriceRepository manager) {
+	public Expression fetchClosingPrice(ClosingPriceRepository manager) {
 		return stock.getClosingPrice(manager);
 	}
 

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -22,6 +22,7 @@ import co.fineants.api.domain.common.money.RateDivision;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioPieChartItem;
 import co.fineants.api.domain.kis.repository.ClosingPriceRepository;
 import co.fineants.api.domain.kis.repository.PriceRepository;
+import co.fineants.api.domain.portfolio.domain.calculator.PortfolioCalculator;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Stock;
@@ -100,6 +101,10 @@ public class PortfolioHolding extends BaseEntity {
 	 * <p>
 	 * TotalGain = (CurrentPrice - AverageCostPerShare) * NumShares
 	 * </p>
+	 * <p>
+	 * calculateAverageCostPerShare()와 calculateNumShares()를 사용하여 계산된다.
+	 * 두 메서드는 public API로써 제공되어 변경시 영향을 받는다
+	 * </p>
 	 * @param currentPrice 종목의 현재가
 	 * @return 포트폴리오 종목의 총 손익
 	 */
@@ -118,6 +123,16 @@ public class PortfolioHolding extends BaseEntity {
 	 */
 	public Expression calculateAverageCostPerShare() {
 		return calculateTotalInvestmentAmount().divide(calculateNumShares());
+	}
+
+	/**
+	 * 매입 이력들의 평균 매입가 계산 후 반환.
+	 *
+	 * @param calculator 포트폴리오 계산기 객체
+	 * @return 평균 매입가
+	 */
+	public Expression calculateAverageCostPerShare(PortfolioCalculator calculator) {
+		return calculator.calAverageCostPerShare(purchaseHistories);
 	}
 
 	/**

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -179,7 +179,14 @@ public class PortfolioHolding extends BaseEntity {
 		return currentPrice.times(calculateNumShares().intValue());
 	}
 
-	// 예상 연간 배당율 = (예상 연간 배당금 / 현재 가치) * 100
+	/**
+	 * 포트폴리오 종목의 예상 연간 배당율을 계산 후 반환.
+	 * <p>
+	 * AnnualExpectedDividendYield = (AnnualExpectedDividend / CurrentValuation)
+	 * </p>
+	 * @param currentPrice 종목 현재가
+	 * @return 예상 연간 배당율
+	 */
 	public RateDivision calculateAnnualExpectedDividendYield(Expression currentPrice) {
 		Expression annualDividend = calculateAnnualExpectedDividend();
 		Expression currentValuation = calculateCurrentValuation(currentPrice);
@@ -187,7 +194,7 @@ public class PortfolioHolding extends BaseEntity {
 	}
 
 	// 연간 배당금 = 종목의 배당금 합계
-	public Expression calculateAnnualDividend() {
+	private Expression calculateAnnualDividend() {
 		List<StockDividend> stockDividends = stock.getCurrentYearDividends();
 
 		Expression totalDividend = Money.zero();
@@ -228,7 +235,6 @@ public class PortfolioHolding extends BaseEntity {
 
 	// 월별 배당금 계산, key=월, value=배당금 합계
 	public Map<Integer, Expression> createMonthlyDividendMap(LocalDate currentLocalDate) {
-		log.debug("currentLocalDate : {}", currentLocalDate);
 		Map<Integer, Expression> monthlyDividends = stock.createMonthlyDividends(purchaseHistory, currentLocalDate);
 		Map<Integer, Expression> monthlyExpectedDividends = stock.createMonthlyExpectedDividends(purchaseHistory,
 			currentLocalDate);

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -164,21 +164,7 @@ public class PortfolioHolding extends BaseEntity {
 			.map(PurchaseHistory::calInvestmentAmount)
 			.reduce(Money.wonZero(), Expression::plus);
 	}
-
-	/**
-	 * 포트폴리오 종목의 총 손익율 계산 후 반환.
-	 * <p>
-	 * TotalGainRate = (TotalGain / TotalInvestmentAmount)
-	 * </p>
-	 * @param currentPrice 종목의 현재가
-	 * @return 종목의 총 손익율
-	 */
-	public RateDivision calculateTotalGainRate(Expression currentPrice) {
-		Expression totalGain = calculateTotalGain(currentPrice);
-		Expression totalInvestmentAmount = calculateTotalInvestmentAmount();
-		return totalGain.divide(totalInvestmentAmount);
-	}
-
+	
 	/**
 	 * 포트폴리오 종목의 평가 금액을 계산 후 반환.
 	 * <p>

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -78,7 +78,7 @@ public class PortfolioHolding extends BaseEntity {
 		return new PortfolioHolding(id, portfolio, stock);
 	}
 
-	//== 연관관계 메소드 ==//
+	//== 연관관계 메소드 시작 ==//
 	public void addPurchaseHistory(PurchaseHistory purchaseHistory) {
 		if (!this.purchaseHistories.contains(purchaseHistory)) {
 			this.purchaseHistories.add(purchaseHistory);
@@ -95,7 +95,8 @@ public class PortfolioHolding extends BaseEntity {
 			portfolio.addHolding(this);
 		}
 	}
-	
+	//== 연관관계 메소드 종료 ==//
+
 	/**
 	 * 매입 이력들의 평균 매입가 계산 후 반환.
 	 *

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -106,19 +106,6 @@ public class PortfolioHolding extends BaseEntity {
 		return calculator.calAverageCostPerShare(purchaseHistories);
 	}
 
-	/**
-	 * 포트폴리오 종목 매입 개수 계산 후 반환.
-	 * <p>
-	 * NumShares = sum(PurchaseHistory.NumShares)
-	 * </p>
-	 * @return 종목 매입 합계
-	 */
-	public Count calculateNumShares() {
-		return purchaseHistories.stream()
-			.map(PurchaseHistory::getNumShares)
-			.reduce(Count.zero(), Count::add);
-	}
-
 	public Count calculateNumShares(PortfolioCalculator calculator) {
 		return calculator.calNumShares(purchaseHistories);
 	}

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -69,10 +69,6 @@ public class PortfolioHolding extends BaseEntity {
 		this.stock = stock;
 	}
 
-	public static PortfolioHolding empty(Portfolio portfolio, Stock stock) {
-		return of(portfolio, stock);
-	}
-
 	public static PortfolioHolding of(Portfolio portfolio, Stock stock) {
 		return of(null, portfolio, stock);
 	}
@@ -234,6 +230,15 @@ public class PortfolioHolding extends BaseEntity {
 			.reduce(Money.zero(), Expression::plus);
 	}
 
+	/**
+	 * 포트폴리오 종목의 월별 배당금 합계를 가진 맵을 생성 후 반환.
+	 * <p>
+	 * 결과 맵의 배당금 합계에는 실제 월별 배당금과 예상되는 월별 배당금 합계가 포함되어 있습니다.
+	 * </p>
+	 *
+	 * @param currentLocalDate 기준 일자
+	 * @return 월별 배당금 합계 맵
+	 */
 	// 월별 배당금 계산, key=월, value=배당금 합계
 	public Map<Integer, Expression> createMonthlyDividendMap(LocalDate currentLocalDate) {
 		Map<Integer, Expression> monthlyDividends = stock.createMonthlyDividends(purchaseHistories, currentLocalDate);
@@ -244,13 +249,21 @@ public class PortfolioHolding extends BaseEntity {
 		return monthlyDividends;
 	}
 
+	/**
+	 * 포트폴리오 종목의 파이차트 요소를 생성후 반환.
+	 * @param weight 종목의 비중
+	 * @param currentValuation 현재 평가금액
+	 * @param totalGain 총 손익
+	 * @param totalGainRate 총 손익율
+	 * @return 파이차트 요소
+	 */
 	public PortfolioPieChartItem createPieChartItem(RateDivision weight, Expression currentValuation,
-		Expression totalGain, Percentage totalReturnPercentage) {
+		Expression totalGain, Percentage totalGainRate) {
 		String name = stock.getCompanyName();
 
 		Bank bank = Bank.getInstance();
 		Percentage weightPercentage = weight.toPercentage(bank, Currency.KRW);
-		return PortfolioPieChartItem.stock(name, currentValuation, weightPercentage, totalGain, totalReturnPercentage);
+		return PortfolioPieChartItem.stock(name, currentValuation, weightPercentage, totalGain, totalGainRate);
 	}
 
 	public Optional<Money> fetchPrice(PriceRepository repository) {

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -95,36 +95,7 @@ public class PortfolioHolding extends BaseEntity {
 			portfolio.addHolding(this);
 		}
 	}
-
-	/**
-	 * 포트폴리오 종목의 총 손익을 계산 후 반환.
-	 * <p>
-	 * TotalGain = (CurrentPrice - AverageCostPerShare) * NumShares
-	 * </p>
-	 * <p>
-	 * calculateAverageCostPerShare()와 calculateNumShares()를 사용하여 계산된다.
-	 * 두 메서드는 public API로써 제공되어 변경시 영향을 받는다
-	 * </p>
-	 * @param currentPrice 종목의 현재가
-	 * @return 포트폴리오 종목의 총 손익
-	 */
-	public Expression calculateTotalGain(@NotNull Expression currentPrice) {
-		Expression averageCostPerShare = calculateAverageCostPerShare();
-		int numShares = calculateNumShares().intValue();
-		return currentPrice.minus(averageCostPerShare).times(numShares);
-	}
-
-	/**
-	 * 포트폴리오 종목의 평균 매입가 계산 후 반환.
-	 * <p>
-	 * AverageCostPerShare = TotalInvestmentAmount / NumShares
-	 * </p>
-	 * @return 종목 평균 매입가
-	 */
-	public Expression calculateAverageCostPerShare() {
-		return calculateTotalInvestmentAmount().divide(calculateNumShares());
-	}
-
+	
 	/**
 	 * 매입 이력들의 평균 매입가 계산 후 반환.
 	 *
@@ -164,7 +135,7 @@ public class PortfolioHolding extends BaseEntity {
 			.map(PurchaseHistory::calInvestmentAmount)
 			.reduce(Money.wonZero(), Expression::plus);
 	}
-	
+
 	/**
 	 * 포트폴리오 종목의 평가 금액을 계산 후 반환.
 	 * <p>

--- a/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/entity/PortfolioHolding.java
@@ -148,6 +148,10 @@ public class PortfolioHolding extends BaseEntity {
 			.reduce(Count.zero(), Count::add);
 	}
 
+	public Count calculateNumShares(PortfolioCalculator calculator) {
+		return calculator.calNumShares(purchaseHistories);
+	}
+
 	/**
 	 * 포트폴리오 종목의 총 투자금액 계산 후 반환.
 	 * <p>
@@ -300,5 +304,9 @@ public class PortfolioHolding extends BaseEntity {
 	public String toString() {
 		return String.format("PortfolioHolding(id=%d, portfolio=%d, stock=%s)", id, portfolio.getId(),
 			stock.getTickerSymbol());
+	}
+
+	public Expression calculateTotalInvestmentAmount(PortfolioCalculator calculator) {
+		return calculator.calTotalInvestment(purchaseHistories);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioHoldingDetailFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioHoldingDetailFactory.java
@@ -24,7 +24,7 @@ public class PortfolioHoldingDetailFactory {
 		return portfolio.getPortfolioHoldings().stream()
 			.map(portfolioHolding -> PortfolioHoldingItem.from(
 				portfolioHolding,
-				portfolioHolding.getLastDayClosingPrice(closingPriceRepository),
+				portfolioHolding.fetchClosingPrice(closingPriceRepository),
 				calculator)
 			)
 			.toList();
@@ -35,7 +35,7 @@ public class PortfolioHoldingDetailFactory {
 		return portfolio.getPortfolioHoldings().stream()
 			.map(portfolioHolding -> PortfolioHoldingRealTimeItem.of(
 				portfolioHolding,
-				portfolioHolding.getLastDayClosingPrice(closingPriceRepository),
+				portfolioHolding.fetchClosingPrice(closingPriceRepository),
 				calculator
 			))
 			.toList();

--- a/src/main/java/co/fineants/api/domain/holding/repository/PortfolioHoldingRepository.java
+++ b/src/main/java/co/fineants/api/domain/holding/repository/PortfolioHoldingRepository.java
@@ -31,18 +31,9 @@ public interface PortfolioHoldingRepository extends JpaRepository<PortfolioHoldi
 		@Param("portfolioHoldingId") Long portfolioHoldingId,
 		@Param("portfolioId") Long portfolioId);
 
-	@Query("select p from PortfolioHolding p join fetch p.stock join fetch p.purchaseHistory "
-		+ "where p.stock.tickerSymbol in (:tickerSymbols)")
-	List<PortfolioHolding> findAllByTickerSymbolsWithStockAndPurchaseHistory(
-		@Param("tickerSymbols") List<String> tickerSymbols);
-
-	@Query("select count(p) > 0 from PortfolioHolding p "
-		+ "where p.id = :portfolioHoldingId and p.portfolio.member.id = :memberId")
-	boolean existsByIdAndMemberId(
-		@Param("portfolioHoldingId") Long portfolioHoldingId,
-		@Param("memberId") Long memberId);
-
-	int deleteAllByPortfolioId(Long portFolioId);
+	@Modifying
+	@Query("delete from PortfolioHolding p where p.portfolio.id = :portFolioId")
+	int deleteAllByPortfolioId(@Param("portFolioId") Long portFolioId);
 
 	@Modifying
 	@Query("delete from PortfolioHolding p where p.id in :holdingIds")

--- a/src/main/java/co/fineants/api/domain/holding/service/PortfolioHoldingService.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/PortfolioHoldingService.java
@@ -87,7 +87,7 @@ public class PortfolioHoldingService {
 
 		PortfolioHolding holding = portfolioHoldingRepository.findByPortfolioIdAndTickerSymbol(portfolioId,
 				request.getTickerSymbol())
-			.orElseGet(() -> PortfolioHolding.empty(portfolio, stock));
+			.orElseGet(() -> PortfolioHolding.of(portfolio, stock));
 		PortfolioHolding saveHolding = portfolioHoldingRepository.save(holding);
 
 		if (request.isPurchaseHistoryComplete()) {

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -227,7 +227,7 @@ public class PortfolioCalculator {
 	 * @param holdings 포트폴리오 종목 리스트
 	 * @return 포트폴리오의 당월 예상 배당금 합계
 	 */
-	public Expression calCurrentMonthDividend(List<PortfolioHolding> holdings) {
+	public Expression calCurrentMonthDividendBy(List<PortfolioHolding> holdings) {
 		return holdings.stream()
 			.map(PortfolioHolding::calculateCurrentMonthDividend)
 			.reduce(Money.zero(), Expression::plus);

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -111,7 +111,7 @@ public class PortfolioCalculator {
 	 *
 	 * @param holdings 포트폴리오 종목 리스트
 	 * @return 포트폴리오 총 손익 계산 합계
-	 * @throws NoSuchElementException 포트폴리오 종목(PortfolioHolding)에 따른 현재가가 저장소에 없으면 예외 발생
+	 * @throws IllegalStateException 포트폴리오 종목(PortfolioHolding) 중 하나라도 계산에 실패하면 예외 발생
 	 */
 	public Expression calTotalGainBy(List<PortfolioHolding> holdings) {
 		return holdings.stream()

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -42,7 +42,7 @@ public class PortfolioCalculator {
 	public Expression calTotalGainBy(Portfolio portfolio) {
 		try {
 			return portfolio.calTotalGain(this);
-		} catch (NoSuchElementException e) {
+		} catch (IllegalStateException e) {
 			throw new IllegalStateException(
 				String.format("Failed to calculate total gain for portfolio, portfolio:%s", portfolio), e);
 		}

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -435,4 +435,8 @@ public class PortfolioCalculator {
 	public Expression fetchCurrentPrice(PortfolioHolding holding) {
 		return this.calculateWithCurrentPrice(holding, currentPrice -> currentPrice);
 	}
+
+	public Expression calAnnualExpectedDividendBy(PortfolioHolding holding) {
+		return holding.calculateAnnualExpectedDividend();
+	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -397,8 +397,7 @@ public class PortfolioCalculator {
 	 * @return 포트폴리오 종목 비중
 	 */
 	public RateDivision calCurrentValuationWeightBy(PortfolioHolding holding, Expression totalAsset) {
-		Expression currentValuation = this.calculateWithCurrentPrice(holding, holding::calculateCurrentValuation);
-		return currentValuation.divide(totalAsset);
+		return this.calTotalCurrentValuationBy(holding).divide(totalAsset);
 	}
 
 	public Map<String, List<Expression>> calSectorChartBy(Portfolio portfolio) {

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -539,6 +539,14 @@ public class PortfolioCalculator {
 			.reduce(Money.wonZero(), Expression::plus);
 	}
 
+	/**
+	 * 포트폴리오 종목 매입 개수 계산 후 반환.
+	 * <p>
+	 * NumShares = sum(PurchaseHistory.NumShares)
+	 * </p>
+	 * @param histories 매입 이력 리스트
+	 * @return 종목 매입 합계
+	 */
 	public Count calNumShares(List<PurchaseHistory> histories) {
 		return histories.stream()
 			.map(PurchaseHistory::getNumShares)

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -193,7 +193,7 @@ public class PortfolioCalculator {
 	 */
 	public Expression calTotalCurrentValuation(List<PortfolioHolding> holdings) {
 		return holdings.stream()
-			.map(this::calTotalCurrentValuation)
+			.map(this::calTotalCurrentValuationBy)
 			.reduce(Money.zero(), Expression::plus);
 	}
 
@@ -204,9 +204,10 @@ public class PortfolioCalculator {
 	 * @return 포트폴리오 종목의 총 평가 금액
 	 * @throws IllegalStateException 포트폴리오 종목의 총 평가 금액 계산 실패시 예외 발생
 	 */
-	public Expression calTotalCurrentValuation(PortfolioHolding holding) {
+	public Expression calTotalCurrentValuationBy(PortfolioHolding holding) {
 		try {
-			return this.calculateWithCurrentPrice(holding, holding::calculateCurrentValuation);
+			int numShares = this.calNumSharesBy(holding).intValue();
+			return this.calculateWithCurrentPrice(holding, currentPrice -> currentPrice.times(numShares));
 		} catch (NoSuchElementException e) {
 			throw new IllegalStateException(
 				String.format("Failed to calculate totalCurrentValuation for holding, holding:%s", holding), e);

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -127,7 +127,9 @@ public class PortfolioCalculator {
 
 	/**
 	 * 포트폴리오 종목의 총 손익을 계산 후 반환.
-	 *
+	 * <p>
+	 * TotalGain = (CurrentPrice - AverageCostPerShare) * NumShares
+	 * </p>
 	 * @param holding 포트폴리오 종목 객체
 	 * @return 포트폴리오 종목의 총 손익
 	 * @throws IllegalStateException 포트폴리오 종목의 총 손익 계산 실패시 예외 발생

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -533,7 +533,7 @@ public class PortfolioCalculator {
 			.reduce(Count.zero(), Count::add);
 	}
 
-	private Count calNumSharesBy(PortfolioHolding holding) {
+	public Count calNumSharesBy(PortfolioHolding holding) {
 		return holding.calculateNumShares(this);
 	}
 

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -48,10 +48,28 @@ public class PortfolioCalculator {
 		}
 	}
 
+	/**
+	 * 포트폴리오의 총 손익율 계산 후 반환.
+	 *
+	 * @param portfolio 포트폴리오 객체
+	 * @return 포트폴리오 총 손익율
+	 * @throws IllegalStateException 포트폴리오의 총 손익율 계산이 실패하면 예외 발생
+	 */
 	public Expression calTotalGainRateBy(Portfolio portfolio) {
-		return portfolio.calTotalGainRate(this);
+		try {
+			return portfolio.calTotalGainRate(this);
+		} catch (NoSuchElementException e) {
+			throw new IllegalStateException(
+				String.format("Failed to calculate totalGainRate for portfolio, portfolio:%s", portfolio), e);
+		}
 	}
 
+	/**
+	 * 포트폴리오의 총 투자 금액 계산 후 반환.
+	 *
+	 * @param portfolio 포트폴리오 객체
+	 * @return 포트폴리오의 총 투자 금액
+	 */
 	public Expression calTotalInvestmentBy(Portfolio portfolio) {
 		return portfolio.calTotalInvestment(this);
 	}
@@ -101,8 +119,20 @@ public class PortfolioCalculator {
 			.reduce(Money.zero(), Expression::plus);
 	}
 
+	/**
+	 * 포트폴리오 종목의 총 손익을 계산 후 반환.
+	 *
+	 * @param holding 포트폴리오 종목 객체
+	 * @return 포트폴리오 종목의 총 손익
+	 * @throws IllegalStateException 포트폴리오 종목의 총 손익 계산 실패시 예외 발생
+	 */
 	public Expression calTotalGainBy(PortfolioHolding holding) {
-		return this.calculateWithCurrentPrice(holding, holding::calculateTotalGain);
+		try {
+			return this.calculateWithCurrentPrice(holding, holding::calculateTotalGain);
+		} catch (NoSuchElementException e) {
+			throw new IllegalStateException(
+				String.format("Failed to calculate totalGain for holding, holding:%s", holding), e);
+		}
 	}
 
 	private Expression calculateWithCurrentPrice(PortfolioHolding holding, Function<Money, Expression> calFunction) {
@@ -148,7 +178,7 @@ public class PortfolioCalculator {
 	 * </p>
 	 * @param holdings 포트폴리오에 등록된 종목 리스트
 	 * @return 포트폴리오 평가 금액
-	 * @throws NoSuchElementException 포트폴리오 종목(PortfolioHolding)에 따른 현재가가 저장소에 없으면 예외 발생
+	 * @throws IllegalStateException 포트폴리오 평가 금액 계산이 실패하면 예외 발생
 	 */
 	public Expression calTotalCurrentValuation(List<PortfolioHolding> holdings) {
 		return holdings.stream()
@@ -156,10 +186,27 @@ public class PortfolioCalculator {
 			.reduce(Money.zero(), Expression::plus);
 	}
 
+	/**
+	 * 포트폴리오 종목의 총 평가 금액 계산 후 반환.
+	 *
+	 * @param holding 포트폴리오 종목 객체
+	 * @return 포트폴리오 종목의 총 평가 금액
+	 * @throws IllegalStateException 포트폴리오 종목의 총 평가 금액 계산 실패시 예외 발생
+	 */
 	public Expression calTotalCurrentValuation(PortfolioHolding holding) {
-		return this.calculateWithCurrentPrice(holding, holding::calculateCurrentValuation);
+		try {
+			return this.calculateWithCurrentPrice(holding, holding::calculateCurrentValuation);
+		} catch (NoSuchElementException e) {
+			throw new IllegalStateException(
+				String.format("Failed to calculate totalCurrentValuation for holding, holding:%s", holding), e);
+		}
 	}
 
+	/**
+	 * 포트폴리오의 총 자산 계산 후 반환.
+	 * @param portfolio 포트폴리오 객체
+	 * @return 포트폴리오 총 자산
+	 */
 	public Expression calTotalAssetBy(Portfolio portfolio) {
 		return portfolio.calTotalAsset(this);
 	}

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -199,7 +199,9 @@ public class PortfolioCalculator {
 
 	/**
 	 * 포트폴리오 종목의 총 평가 금액 계산 후 반환.
-	 *
+	 * <p>
+	 * CurrentValuation = CurrentPrice * NumShares
+	 * </p>
 	 * @param holding 포트폴리오 종목 객체
 	 * @return 포트폴리오 종목의 총 평가 금액
 	 * @throws IllegalStateException 포트폴리오 종목의 총 평가 금액 계산 실패시 예외 발생
@@ -408,7 +410,7 @@ public class PortfolioCalculator {
 		Map<String, List<Expression>> sector = holdings.stream()
 			.collect(Collectors.groupingBy(portfolioHolding -> portfolioHolding.getStock().getSector(),
 				Collectors.mapping(
-					holding -> this.calculateWithCurrentPrice(holding, holding::calculateCurrentValuation),
+					this::calTotalCurrentValuationBy,
 					Collectors.toList())));
 		sector.put("현금", List.of(balance));
 		return sector;
@@ -462,8 +464,18 @@ public class PortfolioCalculator {
 			);
 	}
 
+	/**
+	 * 포트폴리오 종목의 예상 연간 배당율을 계산 후 반환.
+	 * <p>
+	 * AnnualExpectedDividendYield = (AnnualExpectedDividend / CurrentValuation)
+	 * </p>
+	 * @param holding 포트폴리오 종목 객체
+	 * @return 예상 연간 배당율
+	 */
 	public Expression calAnnualExpectedDividendYieldBy(PortfolioHolding holding) {
-		return this.calculateWithCurrentPrice(holding, holding::calculateAnnualExpectedDividendYield);
+		Expression annualDividend = this.calAnnualExpectedDividendBy(holding);
+		Expression currentValuation = this.calTotalCurrentValuationBy(holding);
+		return annualDividend.divide(currentValuation);
 	}
 
 	public Percentage calTotalGainPercentage(PortfolioHolding holding) {

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -178,7 +178,7 @@ public class PortfolioCalculator {
 	 */
 	public Expression calTotalInvestmentOfHolding(List<PortfolioHolding> holdings) {
 		return holdings.stream()
-			.map(PortfolioHolding::calculateTotalInvestmentAmount)
+			.map(this::calTotalInvestmentBy)
 			.reduce(Money.wonZero(), Expression::plus);
 	}
 

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculator.java
@@ -1,6 +1,7 @@
 package co.fineants.api.domain.portfolio.domain.calculator;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -468,11 +469,11 @@ public class PortfolioCalculator {
 			.toList();
 	}
 
-	public Map<Integer, Expression> calTotalDividendBy(Portfolio portfolio, LocalDate currentLocalDate) {
+	public Map<Month, Expression> calTotalDividendBy(Portfolio portfolio, LocalDate currentLocalDate) {
 		return portfolio.calTotalDividend(this, currentLocalDate);
 	}
 
-	public Map<Integer, Expression> calTotalDividend(List<PortfolioHolding> holdings, LocalDate currentLocalDate) {
+	public Map<Month, Expression> calTotalDividend(List<PortfolioHolding> holdings, LocalDate currentLocalDate) {
 		return holdings.stream()
 			.flatMap(holding ->
 				holding.createMonthlyDividendMap(currentLocalDate).entrySet().stream()

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -371,7 +371,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	}
 
 	public Expression calCurrentMonthDividend(PortfolioCalculator calculator) {
-		return calculator.calCurrentMonthDividend(Collections.unmodifiableList(portfolioHoldings));
+		return calculator.calCurrentMonthDividendBy(Collections.unmodifiableList(portfolioHoldings));
 	}
 
 	public Expression calAnnualDividend(LocalDateTimeService dateTimeService, PortfolioCalculator calculator) {

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -325,9 +325,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 		return manager.hasTargetGainSendHistory(id);
 	}
 
-	public boolean hasMaxLossSentHistory(NotificationSentRepository manager) {
-		return manager.hasMaxLossSendHistory(id);
-	}
+	//== Portfolio 계산 메서드 시작 ==//
 
 	/**
 	 * 포트폴리오의 총 손익을 계산 후 반환.
@@ -336,13 +334,16 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	 * @return 포트폴리오 총 손익
 	 * @throws IllegalStateException 포트폴리오 종목(PortfolioHolding)에 따른 현재가가 저장소에 없으면 예외 발생
 	 */
-	//== Portfolio 계산 메서드 시작 ==//
 	public Expression calTotalGain(PortfolioCalculator calculator) {
 		return calculator.calTotalGainBy(Collections.unmodifiableList(portfolioHoldings));
 	}
 
+	public boolean hasMaxLossSentHistory(NotificationSentRepository manager) {
+		return manager.hasMaxLossSendHistory(id);
+	}
+
 	public Expression calTotalInvestment(PortfolioCalculator calculator) {
-		return calculator.calTotalInvestment(Collections.unmodifiableList(portfolioHoldings));
+		return calculator.calTotalInvestmentOfHolding(Collections.unmodifiableList(portfolioHoldings));
 	}
 
 	/**

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -431,7 +431,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 		return portfolioHoldings.stream()
 			.map(holding -> {
 				RateDivision weight = calculator.calCurrentValuationWeightBy(holding, totalAsset);
-				Expression currentValuation = calculator.calTotalCurrentValuation(holding);
+				Expression currentValuation = calculator.calTotalCurrentValuationBy(holding);
 				Expression totalGain = calculator.calTotalGainBy(holding);
 				Percentage totalReturnRate = calculator.calTotalGainPercentage(holding);
 				return holding.createPieChartItem(weight, currentValuation, totalGain, totalReturnRate);

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -1,6 +1,7 @@
 package co.fineants.api.domain.portfolio.domain.entity;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -438,7 +439,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 			}).toList();
 	}
 
-	public Map<Integer, Expression> calTotalDividend(PortfolioCalculator calculator, LocalDate currentLocalDate) {
+	public Map<Month, Expression> calTotalDividend(PortfolioCalculator calculator, LocalDate currentLocalDate) {
 		return calculator.calTotalDividend(Collections.unmodifiableList(portfolioHoldings), currentLocalDate);
 	}
 	//== Portfolio 계산 메서드 시작 ==//

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -433,7 +433,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 				RateDivision weight = calculator.calCurrentValuationWeightBy(holding, totalAsset);
 				Expression currentValuation = calculator.calTotalCurrentValuation(holding);
 				Expression totalGain = calculator.calTotalGainBy(holding);
-				Percentage totalReturnRate = calculator.calTotalReturnPercentage(holding);
+				Percentage totalReturnRate = calculator.calTotalGainPercentage(holding);
 				return holding.createPieChartItem(weight, currentValuation, totalGain, totalReturnRate);
 			}).toList();
 	}

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -345,6 +345,13 @@ public class Portfolio extends BaseEntity implements Notifiable {
 		return calculator.calTotalInvestment(Collections.unmodifiableList(portfolioHoldings));
 	}
 
+	/**
+	 * 포트폴리오의 총 손익율을 계산 후 반환.
+	 *
+	 * @param calculator 포트폴리오 계산기 객체
+	 * @return 포트폴리오 총 손익율
+	 * @throws java.util.NoSuchElementException 포트폴리오 종목(PortfolioHolding)에 따른 현재가가 저장소에 없으면 예외 발생
+	 */
 	public Expression calTotalGainRate(PortfolioCalculator calculator) {
 		return calculator.calTotalGainRate(Collections.unmodifiableList(portfolioHoldings));
 	}

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -334,7 +334,7 @@ public class Portfolio extends BaseEntity implements Notifiable {
 	 *
 	 * @param calculator 포트폴리오 계산기 객체
 	 * @return 포트폴리오 총 손익
-	 * @throws java.util.NoSuchElementException 포트폴리오 종목(PortfolioHolding)에 따른 현재가가 저장소에 없으면 예외 발생
+	 * @throws IllegalStateException 포트폴리오 종목(PortfolioHolding)에 따른 현재가가 저장소에 없으면 예외 발생
 	 */
 	//== Portfolio 계산 메서드 시작 ==//
 	public Expression calTotalGain(PortfolioCalculator calculator) {

--- a/src/main/java/co/fineants/api/domain/purchasehistory/domain/entity/PurchaseHistory.java
+++ b/src/main/java/co/fineants/api/domain/purchasehistory/domain/entity/PurchaseHistory.java
@@ -91,8 +91,14 @@ public class PurchaseHistory extends BaseEntity {
 		this.portfolioHolding = holding;
 	}
 
-	// 투자 금액 = 주당 매입가 * 개수
-	public Expression calculateInvestmentAmount() {
+	/**
+	 * 매입 이력 투자 금액 계산 후 반환.
+	 * <p>
+	 * InvestmentAmount = PurchasePricePerShare * NumShares
+	 * </p>
+	 * @return 매입 이력 투자 금액
+	 */
+	public Expression calInvestmentAmount() {
 		return purchasePricePerShare.times(numShares.intValue());
 	}
 

--- a/src/main/java/co/fineants/api/domain/purchasehistory/domain/entity/PurchaseHistory.java
+++ b/src/main/java/co/fineants/api/domain/purchasehistory/domain/entity/PurchaseHistory.java
@@ -93,7 +93,7 @@ public class PurchaseHistory extends BaseEntity {
 
 	// 투자 금액 = 주당 매입가 * 개수
 	public Expression calculateInvestmentAmount() {
-		return purchasePricePerShare.times(numShares.getValue().intValue());
+		return purchasePricePerShare.times(numShares.intValue());
 	}
 
 	public PurchaseHistory change(PurchaseHistory history) {

--- a/src/main/java/co/fineants/api/domain/purchasehistory/service/PurchaseHistoryService.java
+++ b/src/main/java/co/fineants/api/domain/purchasehistory/service/PurchaseHistoryService.java
@@ -57,7 +57,7 @@ public class PurchaseHistoryService {
 			.orElseThrow(() -> new FineAntsException(PortfolioHoldingErrorCode.NOT_FOUND_PORTFOLIO_HOLDING));
 		PurchaseHistory history = request.toEntity(findHolding);
 
-		verifyCashSufficientForPurchase(portfolio, (Money)history.calculateInvestmentAmount());
+		verifyCashSufficientForPurchase(portfolio, (Money)history.calInvestmentAmount());
 
 		PurchaseHistory newPurchaseHistory = repository.save(history);
 		// 매입 이력 알림 이벤트를 위한 매입 이력 데이터 추가

--- a/src/main/java/co/fineants/api/domain/stock/domain/dto/response/StockResponse.java
+++ b/src/main/java/co/fineants/api/domain/stock/domain/dto/response/StockResponse.java
@@ -1,6 +1,8 @@
 package co.fineants.api.domain.stock.domain.dto.response;
 
+import java.time.Month;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import co.fineants.api.domain.common.money.Bank;
 import co.fineants.api.domain.common.money.Currency;
@@ -77,7 +79,9 @@ public class StockResponse {
 			.annualDividend(stock.getAnnualDividend().reduce(bank, to))
 			.annualDividendYield(
 				stock.getAnnualDividendYield(currentPriceRedisRepository).toPercentage(bank, to))
-			.dividendMonths(stock.getDividendMonths())
+			.dividendMonths(stock.getDividendMonths().stream()
+				.map(Month::getValue)
+				.collect(Collectors.toList()))
 			.build();
 	}
 }

--- a/src/main/java/co/fineants/api/domain/stock/domain/entity/Stock.java
+++ b/src/main/java/co/fineants/api/domain/stock/domain/entity/Stock.java
@@ -83,7 +83,7 @@ public class Stock extends BaseEntity {
 	public List<StockDividend> getCurrentMonthDividends() {
 		LocalDate today = localDateTimeService.getLocalDateWithNow();
 		return stockDividends.stream()
-			.filter(dividend -> dividend.equalPaymentDate(today))
+			.filter(dividend -> dividend.isCurrentMonthPaymentDate(today))
 			.toList();
 	}
 

--- a/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
@@ -53,29 +53,6 @@ class PortfolioHoldingTest extends AbstractContainerBaseTest {
 		assertThat(totalInvestmentAmount).isEqualByComparingTo(Money.won(100000L));
 	}
 
-	@DisplayName("한 종목의 평균 매입가를 계산한다")
-	@Test
-	void calculateAverageCostPerShare() {
-		// given
-		Portfolio portfolio = createPortfolio(createMember());
-		Stock stock = createSamsungStock();
-		PortfolioHolding portFolioHolding = PortfolioHolding.of(portfolio, stock);
-
-		PurchaseHistory purchaseHistory1 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.won(10000), "첫구매", portFolioHolding);
-		PurchaseHistory purchaseHistory2 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.won(10000), "첫구매", portFolioHolding);
-
-		portFolioHolding.addPurchaseHistory(purchaseHistory1);
-		portFolioHolding.addPurchaseHistory(purchaseHistory2);
-
-		// when
-		Expression money = portFolioHolding.calculateAverageCostPerShare();
-
-		// then
-		assertThat(money).isEqualByComparingTo(Money.won(10000.0));
-	}
-
 	@DisplayName("한 종목의 총 손익을 계산한다")
 	@Test
 	void calculateTotalGain() {

--- a/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
@@ -52,31 +52,6 @@ class PortfolioHoldingTest extends AbstractContainerBaseTest {
 		assertThat(totalInvestmentAmount).isEqualByComparingTo(Money.won(100000L));
 	}
 
-	@DisplayName("한 종목의 총 손익을 계산한다")
-	@Test
-	void calculateTotalGain() {
-		// given
-		Portfolio portfolio = createPortfolio(createMember());
-		Stock stock = createSamsungStock();
-		PortfolioHolding portFolioHolding = PortfolioHolding.of(portfolio, stock);
-
-		PurchaseHistory purchaseHistory1 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.won(10000), "첫구매", portFolioHolding);
-		PurchaseHistory purchaseHistory2 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.won(10000), "첫구매", portFolioHolding);
-
-		portFolioHolding.addPurchaseHistory(purchaseHistory1);
-		portFolioHolding.addPurchaseHistory(purchaseHistory2);
-
-		Expression currentPrice = Money.won(20_000L);
-		// when
-		Expression result = portFolioHolding.calculateTotalGain(currentPrice);
-
-		// then
-		Money won = Bank.getInstance().toWon(result);
-		assertThat(won).isEqualByComparingTo(Money.won(100000L));
-	}
-
 	@DisplayName("포트폴리오 종목의 월별 배당금을 계산한다")
 	@Test
 	void calculateMonthlyDividends() {

--- a/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
@@ -18,7 +18,6 @@ import co.fineants.api.domain.common.money.Bank;
 import co.fineants.api.domain.common.money.Currency;
 import co.fineants.api.domain.common.money.Expression;
 import co.fineants.api.domain.common.money.Money;
-import co.fineants.api.domain.common.money.RateDivision;
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
@@ -76,33 +75,6 @@ class PortfolioHoldingTest extends AbstractContainerBaseTest {
 		// then
 		Money won = Bank.getInstance().toWon(result);
 		assertThat(won).isEqualByComparingTo(Money.won(100000L));
-	}
-
-	@DisplayName("한 종목의 총 손익율 계산한다")
-	@Test
-	void calculateTotalReturnRate() {
-		// given
-		Portfolio portfolio = createPortfolio(createMember());
-		Stock stock = createSamsungStock();
-		PortfolioHolding portFolioHolding = PortfolioHolding.of(portfolio, stock);
-
-		PurchaseHistory purchaseHistory1 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.won(10000), "첫구매", portFolioHolding);
-		PurchaseHistory purchaseHistory2 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.won(10000), "첫구매", portFolioHolding);
-
-		portFolioHolding.addPurchaseHistory(purchaseHistory1);
-		portFolioHolding.addPurchaseHistory(purchaseHistory2);
-
-		Expression currentPrice = Money.won(20_000L);
-		// when
-		RateDivision result = portFolioHolding.calculateTotalGainRate(currentPrice);
-
-		// then
-		Expression totalGain = Money.won(100000);
-		Expression totalInvestmentAmount = Money.won(100000);
-		RateDivision expected = totalGain.divide(totalInvestmentAmount);
-		assertThat(result).isEqualByComparingTo(expected);
 	}
 
 	@DisplayName("포트폴리오 종목의 월별 배당금을 계산한다")

--- a/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
@@ -85,7 +85,6 @@ class PortfolioHoldingTest extends AbstractContainerBaseTest {
 		Stock stock = createSamsungStock();
 		List<StockDividend> stockDividends = createStockDividends(stock);
 		stockDividends.forEach(stock::addStockDividend);
-		Long currentPrice = 60000L;
 		PortfolioHolding portfolioHolding = createPortfolioHolding(portfolio, stock);
 
 		PurchaseHistory purchaseHistory = createPurchaseHistory(null, LocalDateTime.of(2023, 3, 1, 9, 30),

--- a/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
@@ -4,7 +4,8 @@ import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashMap;
+import java.time.Month;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
@@ -25,7 +26,7 @@ import co.fineants.api.domain.purchasehistory.domain.entity.PurchaseHistory;
 import co.fineants.api.domain.stock.domain.entity.Stock;
 
 class PortfolioHoldingTest extends AbstractContainerBaseTest {
-
+	
 	@DisplayName("포트폴리오 종목의 월별 배당금을 계산한다")
 	@Test
 	void calculateMonthlyDividends() {
@@ -40,22 +41,16 @@ class PortfolioHoldingTest extends AbstractContainerBaseTest {
 			Count.from(3), Money.won(50000), "첫구매", portfolioHolding);
 		portfolioHolding.addPurchaseHistory(purchaseHistory);
 		// when
-		Map<Integer, Expression> result = portfolioHolding.createMonthlyDividendMap(LocalDate.of(2023, 12, 15));
+		Map<Month, Expression> result = portfolioHolding.createMonthlyDividendMap(LocalDate.of(2023, 12, 15));
 
 		// then
-		Map<Integer, Expression> expected = new HashMap<>();
-		expected.put(1, Money.zero());
-		expected.put(2, Money.zero());
-		expected.put(3, Money.zero());
-		expected.put(4, Money.zero());
-		expected.put(5, Money.won(1083L));
-		expected.put(6, Money.zero());
-		expected.put(7, Money.zero());
-		expected.put(8, Money.won(1083L));
-		expected.put(9, Money.zero());
-		expected.put(10, Money.zero());
-		expected.put(11, Money.won(1083L));
-		expected.put(12, Money.zero());
+		Map<Month, Expression> expected = new EnumMap<>(Month.class);
+		for (Month month : Month.values()) {
+			expected.put(month, Money.zero());
+		}
+		expected.put(Month.MAY, Money.won(1083L));
+		expected.put(Month.AUGUST, Money.won(1083L));
+		expected.put(Month.NOVEMBER, Money.won(1083L));
 		assertThat(result.keySet())
 			.isEqualTo(expected.keySet());
 

--- a/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/domain/entity/PortfolioHoldingTest.java
@@ -26,32 +26,6 @@ import co.fineants.api.domain.stock.domain.entity.Stock;
 
 class PortfolioHoldingTest extends AbstractContainerBaseTest {
 
-	@DisplayName("한 종목의 총 투자 금액을 계산한다")
-	@Test
-	void calculateTotalInvestmentAmount() {
-		// given
-		Portfolio portfolio = createPortfolio(createMember());
-		Stock stock = createSamsungStock();
-		PortfolioHolding portFolioHolding = PortfolioHolding.of(portfolio, stock);
-
-		PurchaseHistory purchaseHistory1 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.won(10000), "첫구매", portFolioHolding);
-		PurchaseHistory purchaseHistory2 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.dollar(10), "첫구매", portFolioHolding);
-
-		portFolioHolding.addPurchaseHistory(purchaseHistory1);
-		portFolioHolding.addPurchaseHistory(purchaseHistory2);
-
-		Bank.getInstance().addRate(Currency.KRW, Currency.USD, 1000);
-		Bank.getInstance().addRate(Currency.USD, Currency.KRW, (double)1 / 1000);
-		// when
-		Expression result = portFolioHolding.calculateTotalInvestmentAmount();
-
-		// then
-		Money totalInvestmentAmount = Bank.getInstance().reduce(result, Currency.KRW);
-		assertThat(totalInvestmentAmount).isEqualByComparingTo(Money.won(100000L));
-	}
-
 	@DisplayName("포트폴리오 종목의 월별 배당금을 계산한다")
 	@Test
 	void calculateMonthlyDividends() {

--- a/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
@@ -544,7 +544,7 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 		LocalDateTime purchaseDate = LocalDateTime.of(2023, 9, 26, 9, 30, 0);
 		Count numShares = Count.from(5);
 		Money purchasePerShare = Money.won(10000);
@@ -638,7 +638,7 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 		Stock stock = stockRepository.save(createSamsungStock());
 
 		PortfolioHolding portfolioHolding = portFolioHoldingRepository.save(
-			PortfolioHolding.empty(portfolio, stock)
+			PortfolioHolding.of(portfolio, stock)
 		);
 
 		LocalDateTime purchaseDate = LocalDateTime.of(2023, 9, 26, 9, 30, 0);

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
@@ -5,6 +5,8 @@ import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Month;
+import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -300,22 +302,17 @@ class PortfolioCalculatorTest extends AbstractContainerBaseTest {
 
 		LocalDate currentLocalDate = LocalDate.of(2024, 1, 16);
 		// when
-		Map<Integer, Expression> actual = calculator.calTotalDividendBy(portfolio, currentLocalDate);
+		Map<Month, Expression> actual = calculator.calTotalDividendBy(portfolio, currentLocalDate);
 		// then
-		Map<Integer, Expression> expected = Map.ofEntries(
-			Map.entry(1, Money.zero()),
-			Map.entry(2, Money.zero()),
-			Map.entry(3, Money.zero()),
-			Map.entry(4, Money.won(1083)),
-			Map.entry(5, Money.won(1083)),
-			Map.entry(6, Money.zero()),
-			Map.entry(7, Money.zero()),
-			Map.entry(8, Money.won(1083)),
-			Map.entry(9, Money.zero()),
-			Map.entry(10, Money.zero()),
-			Map.entry(11, Money.won(1083)),
-			Map.entry(12, Money.zero())
-		);
+		Map<Month, Expression> expected = new EnumMap<>(Month.class);
+		for (Month month : Month.values()) {
+			expected.put(month, Money.zero());
+		}
+		expected.put(Month.APRIL, Money.won(1083L));
+		expected.put(Month.MAY, Money.won(1083L));
+		expected.put(Month.AUGUST, Money.won(1083L));
+		expected.put(Month.NOVEMBER, Money.won(1083L));
+
 		Bank bank = Bank.getInstance();
 		actual.replaceAll((k, v) -> v instanceof Sum ? bank.toWon(v) : v);
 		Assertions.assertThat(actual)

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
@@ -357,4 +357,27 @@ class PortfolioCalculatorTest extends AbstractContainerBaseTest {
 		Expression expected = Money.won(1083);
 		Assertions.assertThat(actual).isEqualByComparingTo(expected);
 	}
+
+	@DisplayName("한 종목의 평균 매입가를 계산한다")
+	@Test
+	void calculateAverageCostPerShare() {
+		// given
+		Portfolio portfolio = createPortfolio(createMember());
+		Stock stock = createSamsungStock();
+		PortfolioHolding portFolioHolding = PortfolioHolding.of(portfolio, stock);
+
+		PurchaseHistory purchaseHistory1 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
+			Money.won(10000), "첫구매", portFolioHolding);
+		PurchaseHistory purchaseHistory2 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
+			Money.won(10000), "첫구매", portFolioHolding);
+
+		portFolioHolding.addPurchaseHistory(purchaseHistory1);
+		portFolioHolding.addPurchaseHistory(purchaseHistory2);
+
+		// when
+		Expression money = calculator.calAverageCostPerShareBy(portFolioHolding);
+
+		// then
+		assertThat(money).isEqualByComparingTo(Money.won(10000.0));
+	}
 }

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
@@ -209,7 +209,7 @@ class PortfolioCalculatorTest extends AbstractContainerBaseTest {
 		long currentPrice = 50_000L;
 		currentPriceRepository.savePrice(stock, currentPrice);
 		// when
-		Percentage actual = calculator.calTotalReturnPercentage(holding);
+		Percentage actual = calculator.calTotalGainPercentage(holding);
 		// then
 		Percentage expected = Percentage.from(0.25);
 		Assertions.assertThat(actual).isEqualByComparingTo(expected);

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
@@ -364,20 +364,44 @@ class PortfolioCalculatorTest extends AbstractContainerBaseTest {
 		// given
 		Portfolio portfolio = createPortfolio(createMember());
 		Stock stock = createSamsungStock();
-		PortfolioHolding portFolioHolding = PortfolioHolding.of(portfolio, stock);
+		PortfolioHolding holding = PortfolioHolding.of(portfolio, stock);
 
 		PurchaseHistory purchaseHistory1 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.won(10000), "첫구매", portFolioHolding);
+			Money.won(10000), "첫구매", holding);
 		PurchaseHistory purchaseHistory2 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
-			Money.won(10000), "첫구매", portFolioHolding);
+			Money.won(10000), "첫구매", holding);
 
-		portFolioHolding.addPurchaseHistory(purchaseHistory1);
-		portFolioHolding.addPurchaseHistory(purchaseHistory2);
+		holding.addPurchaseHistory(purchaseHistory1);
+		holding.addPurchaseHistory(purchaseHistory2);
 
 		// when
-		Expression money = calculator.calAverageCostPerShareBy(portFolioHolding);
+		Expression money = calculator.calAverageCostPerShareBy(holding);
 
 		// then
 		assertThat(money).isEqualByComparingTo(Money.won(10000.0));
+	}
+
+	@DisplayName("포트폴리오 종목의 주식 개수를 계산한다")
+	@Test
+	void calNumSharesBy() {
+		// given
+		Portfolio portfolio = createPortfolio(createMember());
+		Stock stock = createSamsungStock();
+		PortfolioHolding holding = PortfolioHolding.of(portfolio, stock);
+
+		PurchaseHistory purchaseHistory1 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
+			Money.won(10000), "첫구매", holding);
+		PurchaseHistory purchaseHistory2 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
+			Money.won(10000), "첫구매", holding);
+
+		holding.addPurchaseHistory(purchaseHistory1);
+		holding.addPurchaseHistory(purchaseHistory2);
+
+		// when
+		Count actual = calculator.calNumSharesBy(holding);
+
+		// then
+		Count expected = Count.from(10);
+		assertThat(actual).isEqualByComparingTo(expected);
 	}
 }

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
@@ -404,4 +404,27 @@ class PortfolioCalculatorTest extends AbstractContainerBaseTest {
 		Count expected = Count.from(10);
 		assertThat(actual).isEqualByComparingTo(expected);
 	}
+
+	@DisplayName("한 종목의 총 투자 금액을 계산한다")
+	@Test
+	void calculateTotalInvestmentAmount() {
+		// given
+		Portfolio portfolio = createPortfolio(createMember());
+		Stock stock = createSamsungStock();
+		PortfolioHolding holding = PortfolioHolding.of(portfolio, stock);
+
+		PurchaseHistory purchaseHistory1 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
+			Money.won(10000), "첫구매", holding);
+		PurchaseHistory purchaseHistory2 = createPurchaseHistory(null, LocalDateTime.now(), Count.from(5),
+			Money.won(10000), "첫구매", holding);
+
+		holding.addPurchaseHistory(purchaseHistory1);
+		holding.addPurchaseHistory(purchaseHistory2);
+		// when
+		Expression actual = calculator.calTotalInvestmentBy(holding);
+
+		// then
+		Money expected = Money.won(100000);
+		assertThat(actual).isEqualByComparingTo(expected);
+	}
 }

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
@@ -337,4 +337,24 @@ class PortfolioCalculatorTest extends AbstractContainerBaseTest {
 		Expression expected = Money.won(10_000L);
 		Assertions.assertThat(actual).isEqualByComparingTo(expected);
 	}
+
+	@DisplayName("포트폴리오 종목의 예상 연간 배당금을 계산한다")
+	@Test
+	void calAnnualExpectedDividendBy() {
+		Portfolio portfolio = createPortfolio(createMember());
+		Stock stock = createSamsungStock();
+		long currentPrice = 50_000L;
+		currentPriceRepository.savePrice(stock, currentPrice);
+		createStockDividendWith(stock).forEach(stock::addStockDividend);
+		PortfolioHolding holding = createPortfolioHolding(portfolio, stock);
+		PurchaseHistory history = createPurchaseHistory(null, LocalDateTime.now(), Count.from(3), Money.won(40000L),
+			"메모", holding);
+		holding.addPurchaseHistory(history);
+		portfolio.addHolding(holding);
+		// when
+		Expression actual = calculator.calAnnualExpectedDividendBy(holding);
+		// then
+		Expression expected = Money.won(1083);
+		Assertions.assertThat(actual).isEqualByComparingTo(expected);
+	}
 }

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
@@ -196,7 +196,7 @@ class PortfolioCalculatorTest extends AbstractContainerBaseTest {
 
 	@DisplayName("포트폴리오 종목의 손익율을 계산한다")
 	@Test
-	void calTotalReturnRate() {
+	void calTotalGainRate() {
 		// given
 		Portfolio portfolio = createPortfolio(createMember());
 		Stock stock = createSamsungStock();

--- a/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/domain/calculator/PortfolioCalculatorTest.java
@@ -196,7 +196,7 @@ class PortfolioCalculatorTest extends AbstractContainerBaseTest {
 
 	@DisplayName("포트폴리오 종목의 손익율을 계산한다")
 	@Test
-	void calTotalGainRate() {
+	void calTotalGainPercentage() {
 		// given
 		Portfolio portfolio = createPortfolio(createMember());
 		Stock stock = createSamsungStock();

--- a/src/test/java/co/fineants/api/domain/portfolio/service/DashboardServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/service/DashboardServiceTest.java
@@ -148,7 +148,7 @@ class DashboardServiceTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		portfolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		portfolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 
 		currentPriceRedisRepository.savePrice(KisCurrentPrice.create(stock.getTickerSymbol(), 50000L));
 		// when

--- a/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
@@ -403,7 +403,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding portfolioHolding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding portfolioHolding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 
 		LocalDateTime purchaseDate = LocalDateTime.of(2023, 9, 26, 9, 30, 0);
 		Count numShares = Count.from(3);

--- a/src/test/java/co/fineants/api/domain/purchasehistory/domain/entity/PurchaseHistoryTest.java
+++ b/src/test/java/co/fineants/api/domain/purchasehistory/domain/entity/PurchaseHistoryTest.java
@@ -26,7 +26,7 @@ class PurchaseHistoryTest {
 		);
 		Bank bank = Bank.getInstance();
 		// when
-		Expression result = purchaseHistory.calculateInvestmentAmount();
+		Expression result = purchaseHistory.calInvestmentAmount();
 
 		// then
 		Money actual = bank.reduce(result, KRW);

--- a/src/test/java/co/fineants/api/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/purchasehistory/service/PurchaseHistoryServiceTest.java
@@ -98,7 +98,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		Portfolio portfolio = portfolioRepository.save(
 			createPortfolio(member, "내꿈은 워렌버핏", Money.won(budget), Money.won(targetGain), Money.won(maximumLoss)));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 
 		LocalDateTime now = LocalDateTime.now();
 		Money money = Money.won(50000.0);
@@ -163,7 +163,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 
 		PurchaseHistoryCreateRequest request = PurchaseHistoryCreateRequest.builder()
 			.purchaseDate(LocalDateTime.now())
@@ -191,7 +191,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		Member hacker = memberRepository.save(createMember("hacker"));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 
 		LocalDateTime now = LocalDateTime.now();
 		Money money = Money.won(50000.0);
@@ -219,7 +219,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 		PurchaseHistory history = purchaseHistoryRepository.save(
 			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(50000), "첫구매",
 				holding));
@@ -260,7 +260,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		Member hacker = memberRepository.save(createMember("hacker"));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 		PurchaseHistory history = purchaseHistoryRepository.save(
 			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(50000), "첫구매",
 				holding));
@@ -290,7 +290,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 		PurchaseHistory history = purchaseHistoryRepository.save(
 			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(50000), "첫구매",
 				holding));
@@ -320,7 +320,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		Member member = memberRepository.save(createMember());
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 		purchaseHistoryRepository.save(purchaseHistoryRepository.save(
 			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(50000), "첫구매",
 				holding)));
@@ -351,7 +351,7 @@ class PurchaseHistoryServiceTest extends AbstractContainerBaseTest {
 		Member hacker = memberRepository.save(createMember("hacker"));
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
 		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.empty(portfolio, stock));
+		PortfolioHolding holding = portFolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
 		PurchaseHistory history = purchaseHistoryRepository.save(
 			createPurchaseHistory(null, LocalDateTime.of(2023, 9, 26, 9, 30, 0), Count.from(3), Money.won(50000), "첫구매",
 				holding));


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 종목의 계산 로직을 객체지향적으로 PortfolioCalculator로 이전하도록 개선

## TO-BE
- 남은 계산 메서드들을 계산기로 이전
- javadoc 추가
- 계산 메서드들에 대한 테스트 코드 작성
