### PR TITLE
[feat] 포트폴리오 이름 목록 API에 캐시 추가

### DIFF
--- a/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
@@ -81,8 +81,9 @@ public class PortFolioRestController {
 
 	// 포트폴리오 다수 삭제
 	@DeleteMapping
-	public ApiResponse<Void> deletePortfolios(@RequestBody PortfoliosDeleteRequest request) {
-		portFolioService.deletePortfolios(request.getPortfolioIds());
+	public ApiResponse<Void> deletePortfolios(@RequestBody PortfoliosDeleteRequest request,
+		@MemberAuthenticationPrincipal MemberAuthentication authentication) {
+		portFolioService.deletePortfolios(request.getPortfolioIds(), authentication.getId());
 		return ApiResponse.success(PortfolioSuccessCode.OK_DELETE_PORTFOLIO);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/dto/response/PortfolioNameItem.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/dto/response/PortfolioNameItem.java
@@ -2,13 +2,11 @@ package co.fineants.api.domain.portfolio.domain.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
 
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PortfolioNameItem {
 	@JsonProperty
 	private final Long id;
@@ -16,6 +14,14 @@ public class PortfolioNameItem {
 	private final String name;
 	@JsonProperty
 	private final LocalDateTime dateCreated;
+
+	@JsonCreator
+	private PortfolioNameItem(@JsonProperty("id") Long id, @JsonProperty("name") String name,
+		@JsonProperty("dateCreated") LocalDateTime dateCreated) {
+		this.id = id;
+		this.name = name;
+		this.dateCreated = dateCreated;
+	}
 
 	public static PortfolioNameItem from(Portfolio portfolio) {
 		return new PortfolioNameItem(

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/dto/response/PortfolioNameItem.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/dto/response/PortfolioNameItem.java
@@ -6,7 +6,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import lombok.EqualsAndHashCode;
 
+@EqualsAndHashCode(of = {"id", "name"})
 public class PortfolioNameItem {
 	@JsonProperty
 	private final Long id;

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/dto/response/PortfolioNameResponse.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/dto/response/PortfolioNameResponse.java
@@ -5,6 +5,9 @@ import java.util.List;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import lombok.EqualsAndHashCode;
+
+@EqualsAndHashCode
 public class PortfolioNameResponse {
 	@JsonProperty
 	private final List<PortfolioNameItem> portfolios;

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/dto/response/PortfolioNameResponse.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/dto/response/PortfolioNameResponse.java
@@ -2,15 +2,17 @@ package co.fineants.api.domain.portfolio.domain.dto.response;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import lombok.AccessLevel;
-import lombok.RequiredArgsConstructor;
-
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class PortfolioNameResponse {
 	@JsonProperty
 	private final List<PortfolioNameItem> portfolios;
+
+	@JsonCreator
+	private PortfolioNameResponse(@JsonProperty("portfolios") List<PortfolioNameItem> portfolios) {
+		this.portfolios = portfolios;
+	}
 
 	public static PortfolioNameResponse from(List<PortfolioNameItem> items) {
 		return new PortfolioNameResponse(items);

--- a/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -172,6 +173,7 @@ public class PortFolioService {
 	}
 
 	@Transactional(readOnly = true)
+	@Cacheable(value = "myAllPortfolioNames", key = "#memberId")
 	@Secured("ROLE_USER")
 	public PortfolioNameResponse readMyAllPortfolioNames(@NotNull Long memberId) {
 		List<PortfolioNameItem> items = portfolioRepository.findAllByMemberIdOrderByIdDesc(memberId).stream()

--- a/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
@@ -62,6 +63,7 @@ public class PortFolioService {
 
 	@Transactional
 	@Secured("ROLE_USER")
+	@CacheEvict(value = "myAllPortfolioNames", key = "#memberId")
 	public PortFolioCreateResponse createPortfolio(PortfolioCreateRequest request, Long memberId) {
 		validateSecuritiesFirm(request.getSecuritiesFirm());
 
@@ -90,6 +92,7 @@ public class PortFolioService {
 	}
 
 	@Transactional
+	@CacheEvict(value = "myAllPortfolioNames", key = "#memberId")
 	@Authorized(serviceClass = PortfolioAuthorizedService.class)
 	@Secured("ROLE_USER")
 	public PortfolioModifyResponse updatePortfolio(PortfolioModifyRequest request, @ResourceId Long portfolioId,
@@ -109,6 +112,7 @@ public class PortFolioService {
 	}
 
 	@Transactional
+	@CacheEvict(value = "myAllPortfolioNames", key = "#memberId")
 	@Authorized(serviceClass = PortfolioAuthorizedService.class)
 	@Secured("ROLE_USER")
 	public void deletePortfolio(@ResourceId Long portfolioId, Long memberId) {
@@ -133,9 +137,11 @@ public class PortFolioService {
 	}
 
 	@Transactional
+	@CacheEvict(value = "myAllPortfolioNames", key = "#memberId")
 	@Authorized(serviceClass = PortfolioAuthorizedService.class)
 	@Secured("ROLE_USER")
-	public void deletePortfolios(@ResourceIds List<Long> portfolioIds) {
+	public void deletePortfolios(@ResourceIds List<Long> portfolioIds, @NotNull Long memberId) {
+		log.info("portfolio multiple delete service request: portfolioIds={}, memberId={}", portfolioIds, memberId);
 		for (Long portfolioId : portfolioIds) {
 			Portfolio portfolio = findPortfolio(portfolioId);
 			List<Long> portfolioStockIds = portfolioHoldingRepository.findAllByPortfolio(portfolio).stream()

--- a/src/main/java/co/fineants/api/global/config/CacheConfig.java
+++ b/src/main/java/co/fineants/api/global/config/CacheConfig.java
@@ -47,16 +47,4 @@ public class CacheConfig {
 			.withInitialCacheConfigurations(cacheConfigurations) // 캐시별 설정 추가
 			.build();
 	}
-
-	@Bean(name = "cacheObjectMapper")
-	public ObjectMapper cacheObjectMapper(ObjectMapper objectMapper) {
-		ObjectMapper cacheObjectMapper = new ObjectMapper();
-		cacheObjectMapper.setConfig(objectMapper.getSerializationConfig());
-		cacheObjectMapper.setVisibility(objectMapper.getVisibilityChecker());
-		cacheObjectMapper.activateDefaultTyping(
-			cacheObjectMapper.getPolymorphicTypeValidator(),
-			ObjectMapper.DefaultTyping.EVERYTHING
-		);
-		return cacheObjectMapper;
-	}
 }

--- a/src/main/java/co/fineants/api/global/config/CacheConfig.java
+++ b/src/main/java/co/fineants/api/global/config/CacheConfig.java
@@ -39,8 +39,9 @@ public class CacheConfig {
 
 		// 캐시별 만료 시간 설정
 		Map<String, RedisCacheConfiguration> cacheConfigurations = new HashMap<>();
-		cacheConfigurations.put("tickerSymbols", defaultCacheConfig.entryTtl(Duration.ofMinutes(5))); // 5 minute TTL
-		cacheConfigurations.put("lineChartCache", defaultCacheConfig.entryTtl(Duration.ofHours(24))); // 24 hourTTL
+		cacheConfigurations.put("tickerSymbols", defaultCacheConfig.entryTtl(Duration.ofMinutes(5)));
+		cacheConfigurations.put("lineChartCache", defaultCacheConfig.entryTtl(Duration.ofHours(24)));
+		cacheConfigurations.put("myAllPortfolioNames", defaultCacheConfig.entryTtl(Duration.ofMinutes(5)));
 
 		return RedisCacheManager.builder(redisConnectionFactory)
 			.cacheDefaults(defaultCacheConfig)

--- a/src/main/java/co/fineants/api/global/config/jackson/JacksonConfig.java
+++ b/src/main/java/co/fineants/api/global/config/jackson/JacksonConfig.java
@@ -72,4 +72,16 @@ public class JacksonConfig {
 	public JsonDeserializer<Count> countJsonDeserializer() {
 		return new CountJsonDeserializer();
 	}
+
+	@Bean(name = "cacheObjectMapper")
+	public ObjectMapper cacheObjectMapper(ObjectMapper objectMapper) {
+		ObjectMapper cacheObjectMapper = new ObjectMapper();
+		cacheObjectMapper.setConfig(objectMapper.getSerializationConfig());
+		cacheObjectMapper.setVisibility(objectMapper.getVisibilityChecker());
+		cacheObjectMapper.activateDefaultTyping(
+			cacheObjectMapper.getPolymorphicTypeValidator(),
+			ObjectMapper.DefaultTyping.EVERYTHING
+		);
+		return cacheObjectMapper;
+	}
 }

--- a/src/main/java/co/fineants/api/global/config/jackson/JacksonConfig.java
+++ b/src/main/java/co/fineants/api/global/config/jackson/JacksonConfig.java
@@ -78,6 +78,8 @@ public class JacksonConfig {
 		ObjectMapper cacheObjectMapper = new ObjectMapper();
 		cacheObjectMapper.setConfig(objectMapper.getSerializationConfig());
 		cacheObjectMapper.setVisibility(objectMapper.getVisibilityChecker());
+		cacheObjectMapper.registerModule(new JavaTimeModule());
+		cacheObjectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
 		cacheObjectMapper.activateDefaultTyping(
 			cacheObjectMapper.getPolymorphicTypeValidator(),
 			ObjectMapper.DefaultTyping.EVERYTHING

--- a/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
@@ -527,7 +527,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 		List<Long> portfolioIds = Arrays.asList(portfolio.getId(), portfolio2.getId());
 		setAuthentication(member);
 		// when
-		service.deletePortfolios(portfolioIds);
+		service.deletePortfolios(portfolioIds, member.getId());
 
 		// then
 		assertThat(portfolioRepository.existsById(portfolio.getId())).isFalse();
@@ -550,7 +550,7 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 
 		setAuthentication(hacker);
 		// when
-		Throwable throwable = catchThrowable(() -> service.deletePortfolios(portfolioIds));
+		Throwable throwable = catchThrowable(() -> service.deletePortfolios(portfolioIds, member.getId()));
 
 		// then
 		assertThat(throwable)

--- a/src/test/java/co/fineants/api/global/config/jackson/CacheObjectMapperTest.java
+++ b/src/test/java/co/fineants/api/global/config/jackson/CacheObjectMapperTest.java
@@ -11,12 +11,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.portfolio.domain.dto.response.DashboardLineChartResponse;
-import co.fineants.api.global.config.CacheConfig;
 
 class CacheObjectMapperTest {
 
-	private final ObjectMapper cacheObjectMapper = new CacheConfig().cacheObjectMapper(
-		new JacksonConfig().objectMapper());
+	private final JacksonConfig config = new JacksonConfig();
+	private final ObjectMapper cacheObjectMapper = config.cacheObjectMapper(config.objectMapper());
 
 	@DisplayName("티커 심볼이 담긴 Set 컬렉션을 직렬화하면 클래스 이름 정보가 포함되어 있다")
 	@Test

--- a/src/test/java/co/fineants/api/global/config/jackson/CacheObjectMapperTest.java
+++ b/src/test/java/co/fineants/api/global/config/jackson/CacheObjectMapperTest.java
@@ -1,5 +1,6 @@
 package co.fineants.api.global.config.jackson;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -70,6 +71,7 @@ class CacheObjectMapperTest extends AbstractContainerBaseTest {
 		JsonProcessingException {
 		// given
 		Portfolio portfolio = createPortfolio(createMember());
+		portfolio.setCreateAt(LocalDateTime.of(2024, 10, 23, 12, 0, 0));
 		PortfolioNameResponse response = PortfolioNameResponse.from(List.of(PortfolioNameItem.from(portfolio)));
 		String json = cacheObjectMapper.writeValueAsString(response);
 		// when

--- a/src/test/java/co/fineants/api/global/config/jackson/CacheObjectMapperTest.java
+++ b/src/test/java/co/fineants/api/global/config/jackson/CacheObjectMapperTest.java
@@ -1,21 +1,29 @@
 package co.fineants.api.global.config.jackson;
 
+import java.util.List;
 import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import co.fineants.AbstractContainerBaseTest;
 import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.portfolio.domain.dto.response.DashboardLineChartResponse;
+import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameItem;
+import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameResponse;
+import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 
-class CacheObjectMapperTest {
+class CacheObjectMapperTest extends AbstractContainerBaseTest {
 
-	private final JacksonConfig config = new JacksonConfig();
-	private final ObjectMapper cacheObjectMapper = config.cacheObjectMapper(config.objectMapper());
+	@Autowired
+	@Qualifier("cacheObjectMapper")
+	private ObjectMapper cacheObjectMapper;
 
 	@DisplayName("티커 심볼이 담긴 Set 컬렉션을 직렬화하면 클래스 이름 정보가 포함되어 있다")
 	@Test
@@ -53,6 +61,21 @@ class CacheObjectMapperTest {
 		DashboardLineChartResponse actual = cacheObjectMapper.readValue(json, DashboardLineChartResponse.class);
 		// then
 		DashboardLineChartResponse expected = DashboardLineChartResponse.of("2024-10-22", Money.won(10000));
+		Assertions.assertThat(actual).isEqualTo(expected);
+	}
+
+	@DisplayName("PortfolioNameResponse 객체를 직렬화/역직렬화를 수행한다")
+	@Test
+	void givenPortfolioNameResponse_whenSerializationAndDeserialization_thenReturnJsonAndMoney() throws
+		JsonProcessingException {
+		// given
+		Portfolio portfolio = createPortfolio(createMember());
+		PortfolioNameResponse response = PortfolioNameResponse.from(List.of(PortfolioNameItem.from(portfolio)));
+		String json = cacheObjectMapper.writeValueAsString(response);
+		// when
+		PortfolioNameResponse actual = cacheObjectMapper.readValue(json, PortfolioNameResponse.class);
+		// then
+		PortfolioNameResponse expected = PortfolioNameResponse.from(List.of(PortfolioNameItem.from(portfolio)));
 		Assertions.assertThat(actual).isEqualTo(expected);
 	}
 }


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 이름 목록 API에 캐시 추가

## 성능측정 결과
- 평균 TPS : { 40.8 } → { 56.4 }
	- 약 1.38배 개선
- Peek TPS : { 48.5 } → { 65.5 }
	- 약 1.35배 개선
- Mean Test Time : { 236.94ms } → { 176.23ms }
	- 약 1.34배 단축
- Executed Tests : { 2,382 } → { 3,167 }
	- 약 1.32배 개선
