### PR TITLE
[refactor] 매입 이력 추가 서비스 수정

### DIFF
--- a/src/main/java/co/fineants/api/domain/purchasehistory/service/PurchaseHistoryService.java
+++ b/src/main/java/co/fineants/api/domain/purchasehistory/service/PurchaseHistoryService.java
@@ -60,8 +60,6 @@ public class PurchaseHistoryService {
 		verifyCashSufficientForPurchase(portfolio, (Money)history.calInvestmentAmount());
 
 		PurchaseHistory newPurchaseHistory = repository.save(history);
-		// 매입 이력 알림 이벤트를 위한 매입 이력 데이터 추가
-		findHolding.addPurchaseHistory(newPurchaseHistory);
 
 		purchaseHistoryEventPublisher.publishPushNotificationEvent(portfolioId, memberId);
 		log.info("매입이력 저장 결과 : newPurchaseHistory={}", newPurchaseHistory);


### PR DESCRIPTION
## 구현한 것

- 매입 이력 추가 서비스에서 포트폴리오 종목의 매입 이력 리스트에 직전에 추가한 매입 이력 추가 코드를 제거함
- 제거 이유는 이벤트 리스너가 비동기 및 `@TransactionalEventListener` 설정으로 인한 불필요해져서입니다.
- 매입 이력 추가 서비스 후 알림이 저장되었는지 테스트 추가

