### PR TITLE
[performance] JMH 추가 및 성능 측정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     // asciidoctor
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    // jmh
+    id "me.champeau.jmh" version "0.7.1"
 }
 
 group = 'codesquad.fineants'
@@ -96,12 +98,17 @@ dependencies {
     // Csv Reader
     implementation 'org.apache.commons:commons-csv:1.11.0'
 
-    //QueryDsl
+    // QueryDsl
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+
     // java.lang.NoClassDefFoundError 대응을 위해 추가
     annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
     annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
+
+    // JMH
+    testImplementation 'org.openjdk.jmh:jmh-core:1.37'
+    testImplementation 'org.openjdk.jmh:jmh-generator-annprocess:1.37'
 }
 
 tasks.named('test') {

--- a/src/jmh/java/co/fineants/api/domain/portfolio/service/PortfolioCacheServiceBenchMark.java
+++ b/src/jmh/java/co/fineants/api/domain/portfolio/service/PortfolioCacheServiceBenchMark.java
@@ -1,0 +1,56 @@
+package co.fineants.api.domain.portfolio.service;
+
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import co.fineants.FineAntsApplication;
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Warmup(iterations = 1)
+@Fork(1)
+@Measurement(iterations = 10)
+public class PortfolioCacheServiceTest {
+
+	private ConfigurableApplicationContext context;
+	private PortfolioCacheService service;
+
+	@Setup
+	public void init() {
+
+		context = new SpringApplicationBuilder()
+			.sources(FineAntsApplication.class)
+			.web(WebApplicationType.NONE)
+			.build()
+			.run();
+		context.registerShutdownHook();
+		service = context.getBean(PortfolioCacheService.class);
+	}
+
+	@TearDown
+	public void closeContext() {
+		context.close();
+	}
+
+	@Benchmark
+	public Set<String> getTickerSymbolsFromPortfolioBy() {
+		Long portfolioId = 1L;
+		return service.getTickerSymbolsFromPortfolioBy(portfolioId);
+	}
+}

--- a/src/jmh/java/co/fineants/api/domain/portfolio/service/PortfolioCacheServiceBenchMark.java
+++ b/src/jmh/java/co/fineants/api/domain/portfolio/service/PortfolioCacheServiceBenchMark.java
@@ -14,8 +14,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.springframework.boot.WebApplicationType;
-import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.SpringApplication;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import co.fineants.FineAntsApplication;
@@ -23,22 +22,16 @@ import co.fineants.FineAntsApplication;
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
-@Warmup(iterations = 1)
 @Fork(1)
-@Measurement(iterations = 10)
-public class PortfolioCacheServiceTest {
+@Warmup(iterations = 1)
+public class PortfolioCacheServiceBenchMark {
 
 	private ConfigurableApplicationContext context;
 	private PortfolioCacheService service;
 
 	@Setup
 	public void init() {
-
-		context = new SpringApplicationBuilder()
-			.sources(FineAntsApplication.class)
-			.web(WebApplicationType.NONE)
-			.build()
-			.run();
+		context = SpringApplication.run(FineAntsApplication.class);
 		context.registerShutdownHook();
 		service = context.getBean(PortfolioCacheService.class);
 	}
@@ -49,6 +42,7 @@ public class PortfolioCacheServiceTest {
 	}
 
 	@Benchmark
+	@Measurement(iterations = 1, time = 1, timeUnit = TimeUnit.MINUTES)
 	public Set<String> getTickerSymbolsFromPortfolioBy() {
 		Long portfolioId = 1L;
 		return service.getTickerSymbolsFromPortfolioBy(portfolioId);


### PR DESCRIPTION
## 구현한 것

- JMH 라이브러리 추가
- 포트폴리오 캐시 서비스의 메서드 성능 측정 추가

## 성능 측정 결과
캐싱 이전 측정 결과
<img width="694" alt="image" src="https://github.com/user-attachments/assets/e5985614-cf22-44ed-a658-389fc5bc6264">

캐싱 이후 측정 결과
<img width="695" alt="image" src="https://github.com/user-attachments/assets/c09a0001-9041-4ea5-945a-e4d9e0fe9b08">

수치 변화
- 평균 시간 : { 5.029 ms } → { 0.448 }
	- 약 11.22배 개선
