### PR TITLE
[refactor] VerifyCode 코드 개선

### DIFF
--- a/src/main/java/co/fineants/api/domain/member/service/MemberService.java
+++ b/src/main/java/co/fineants/api/domain/member/service/MemberService.java
@@ -91,6 +91,7 @@ public class MemberService {
 	private final TokenManagementService tokenManagementService;
 	private final RoleRepository roleRepository;
 	private final TokenFactory tokenFactory;
+	private final VerifyCodeManagementService verifyCodeManagementService;
 
 	public void logout(HttpServletRequest request, HttpServletResponse response) {
 		// clear Authentication
@@ -188,7 +189,7 @@ public class MemberService {
 		String verifyCode = verifyCodeGenerator.generate();
 
 		// Redis에 생성한 검증 코드 임시 저장
-		tokenManagementService.saveEmailVerifCode(email, verifyCode);
+		verifyCodeManagementService.saveVerifyCode(email, verifyCode);
 
 		try {
 			// 사용자에게 검증 코드 메일 전송
@@ -287,7 +288,7 @@ public class MemberService {
 	@Transactional(readOnly = true)
 	@PermitAll
 	public void checkVerifyCode(String email, String code) {
-		Optional<String> verifyCode = tokenManagementService.get(email);
+		Optional<String> verifyCode = verifyCodeManagementService.getVerificationCode(email);
 		if (verifyCode.isEmpty() || !verifyCode.get().equals(code)) {
 			throw new BadRequestException(MemberErrorCode.VERIFICATION_CODE_CHECK_FAIL);
 		}

--- a/src/main/java/co/fineants/api/domain/member/service/RedisTokenManagementService.java
+++ b/src/main/java/co/fineants/api/domain/member/service/RedisTokenManagementService.java
@@ -1,7 +1,6 @@
 package co.fineants.api.domain.member.service;
 
 import java.time.Duration;
-import java.util.Optional;
 import java.util.Set;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -48,17 +47,6 @@ public class RedisTokenManagementService implements TokenManagementService {
 				redisTemplate.delete(key);
 			}
 		}
-	}
-
-	@Override
-	public Optional<String> get(String key) {
-		return Optional.ofNullable(redisTemplate.opsForValue().get(key));
-	}
-
-	@Override
-	public void saveEmailVerifCode(String email, String verifCode) {
-		Duration timeout = Duration.ofMinutes(5);
-		redisTemplate.opsForValue().set(email, verifCode, timeout);
 	}
 
 	private void banToken(String token, Duration timeout) {

--- a/src/main/java/co/fineants/api/domain/member/service/RedisVerifyCodeManagementService.java
+++ b/src/main/java/co/fineants/api/domain/member/service/RedisVerifyCodeManagementService.java
@@ -1,0 +1,26 @@
+package co.fineants.api.domain.member.service;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RedisVerifyCodeManagementService implements VerifyCodeManagementService {
+	private final RedisTemplate<String, String> redisTemplate;
+
+	@Override
+	public Optional<String> getVerificationCode(String email) {
+		return Optional.ofNullable(redisTemplate.opsForValue().get(email));
+	}
+
+	@Override
+	public void saveVerifyCode(String email, String verifyCode) {
+		Duration timeout = Duration.ofMinutes(5);
+		redisTemplate.opsForValue().set(email, verifyCode, timeout);
+	}
+}

--- a/src/main/java/co/fineants/api/domain/member/service/TokenManagementService.java
+++ b/src/main/java/co/fineants/api/domain/member/service/TokenManagementService.java
@@ -1,7 +1,5 @@
 package co.fineants.api.domain.member.service;
 
-import java.util.Optional;
-
 public interface TokenManagementService {
 	void banRefreshToken(String token);
 
@@ -10,9 +8,4 @@ public interface TokenManagementService {
 	boolean isAlreadyLogout(String token);
 
 	void clear();
-
-	// TODO: vericy code와 token 도메인 개념을 분리
-	Optional<String> get(String key);
-
-	void saveEmailVerifCode(String email, String verifCode);
 }

--- a/src/main/java/co/fineants/api/domain/member/service/VerifyCodeManagementService.java
+++ b/src/main/java/co/fineants/api/domain/member/service/VerifyCodeManagementService.java
@@ -1,0 +1,9 @@
+package co.fineants.api.domain.member.service;
+
+import java.util.Optional;
+
+public interface VerifyCodeManagementService {
+	Optional<String> getVerificationCode(String email);
+
+	void saveVerifyCode(String email, String verifyCode);
+}

--- a/src/test/java/co/fineants/api/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/member/service/MemberServiceTest.java
@@ -95,27 +95,27 @@ class MemberServiceTest extends AbstractContainerBaseTest {
 
 	@Autowired
 	private WatchStockRepository watchStockRepository;
-
 	private AmazonS3Service mockAmazonS3Service;
-
-	private TokenManagementService mockedTokenManagementService;
+	private VerifyCodeManagementService mockedVerifyCodeManagementService;
 
 	@BeforeEach
 	void setUp() {
 		MemberServiceTestConfig config = new MemberServiceTestConfig();
 		mockAmazonS3Service = config.mockAmazonS3Service();
 		EmailService mockedEmailService = config.mockEmailService();
-		mockedTokenManagementService = config.mockTokenManagementService();
+		TokenManagementService mockedTokenManagementService = config.mockTokenManagementService();
 		VerifyCodeGenerator mockedVerifyCodeGenerator = config.mockVerifyCodeGenerator();
+		mockedVerifyCodeManagementService = config.mockVerifyCodeManagementService();
 		memberService = this.memberService.toBuilder()
 			.amazonS3Service(mockAmazonS3Service)
 			.emailService(mockedEmailService)
 			.tokenManagementService(mockedTokenManagementService)
 			.verifyCodeGenerator(mockedVerifyCodeGenerator)
+			.verifyCodeManagementService(mockedVerifyCodeManagementService)
 			.build();
 		given(mockAmazonS3Service.upload(ArgumentMatchers.any(MultipartFile.class)))
 			.willReturn("profileUrl");
-		given(mockedTokenManagementService.get("dragonbead95@naver.com"))
+		given(mockedVerifyCodeManagementService.getVerificationCode("dragonbead95@naver.com"))
 			.willReturn(Optional.of("123456"));
 		given(mockedVerifyCodeGenerator.generate()).willReturn("123456");
 	}
@@ -400,8 +400,7 @@ class MemberServiceTest extends AbstractContainerBaseTest {
 		memberService.sendVerifyCode(request);
 
 		// then
-		verify(mockedTokenManagementService, times(1))
-			.saveEmailVerifCode("dragonbead95@naver.com", "123456");
+		verify(mockedVerifyCodeManagementService, times(1)).saveVerifyCode("dragonbead95@naver.com", "123456");
 	}
 
 	@DisplayName("사용자는 검증코드를 제출하여 검증코드가 일치하는지 검사한다")

--- a/src/test/java/co/fineants/config/MemberServiceTestConfig.java
+++ b/src/test/java/co/fineants/config/MemberServiceTestConfig.java
@@ -5,6 +5,7 @@ import org.springframework.boot.test.context.TestConfiguration;
 
 import co.fineants.api.domain.member.service.TokenManagementService;
 import co.fineants.api.domain.member.service.VerifyCodeGenerator;
+import co.fineants.api.domain.member.service.VerifyCodeManagementService;
 import co.fineants.api.infra.mail.EmailService;
 import co.fineants.api.infra.s3.service.AmazonS3Service;
 
@@ -25,5 +26,9 @@ public class MemberServiceTestConfig {
 
 	public VerifyCodeGenerator mockVerifyCodeGenerator() {
 		return Mockito.mock(VerifyCodeGenerator.class);
+	}
+
+	public VerifyCodeManagementService mockVerifyCodeManagementService() {
+		return Mockito.mock(VerifyCodeManagementService.class);
 	}
 }


### PR DESCRIPTION
## 구현한 것

- 기존 토큰 관리 서비스에서 관리하는 verifyCode를 별도의 인터페이스로 분리
- 테스트 코드에서 모킹 처리하도록 수정
