### PR TITLE
[fix] 테스트 실패 해결

### DIFF
--- a/src/test/java/co/fineants/api/infra/s3/service/AmazonS3StockServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/AmazonS3StockServiceTest.java
@@ -24,6 +24,7 @@ class AmazonS3StockServiceTest extends AbstractContainerBaseTest {
 		// given
 		Stock stock = Stock.of("000370", "한화손해보험보통주", "\"Hanwha General Insurance Co.,Ltd.\"", "KR7000370007", "보험",
 			Market.KOSPI);
+		List<Stock> previousStocks = amazonS3StockService.fetchStocks();
 		// when
 		amazonS3StockService.writeStocks(List.of(stock));
 		// then
@@ -35,6 +36,8 @@ class AmazonS3StockServiceTest extends AbstractContainerBaseTest {
 				Stock::getSector, Stock::getMarket)
 			.containsExactly("000370", "한화손해보험보통주", "\"Hanwha General Insurance Co.,Ltd.\"", "KR7000370007", "보험",
 				Market.KOSPI);
+		// rollback
+		amazonS3StockService.writeStocks(previousStocks);
 	}
 
 	@DisplayName("종목 정보를 S3에서 가져온 다음에 csv 파일에 작성하면 정상적으로 CSV 파일에 저장된다")


### PR DESCRIPTION


## 구현한 것
- CI-CD 과정에서 테스트 실패 해결
- 원인: 테스트 실행 순서에서 csv 파일에 종목 저장 테스트 후에 다른 테스트 실행시 개수가 맞지 않아서
- 해결방법: csv 파일에 종목 저장하는 테스트에 테스트가 끝나고 롤백하는 코드(다시 종목을 작성하는)를 추가하여 해결