### PR TITLE
[fix] 테스트 실패 해결

### DIFF
--- a/src/main/java/co/fineants/api/global/security/ajax/config/ActuatorSecurityConfig.java
+++ b/src/main/java/co/fineants/api/global/security/ajax/config/ActuatorSecurityConfig.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class ActuatorSecurityConfig {
-	private static final String ACTUATOR_ENDPOINT = "/actuator/**";
 	private final UserDetailsService actuatorUserDetailService;
 	private final ActuatorProperties actuatorProperties;
 
@@ -26,8 +25,12 @@ public class ActuatorSecurityConfig {
 		http
 			.httpBasic(configurer -> {
 			})
+			.securityMatcher("/actuator", "/actuator/**", "/login")
 			.authorizeHttpRequests(configurer ->
-				configurer.requestMatchers(ACTUATOR_ENDPOINT).hasRole(actuatorProperties.getRoleName())
+				configurer
+					.requestMatchers("/actuator").hasRole(actuatorProperties.getRoleName())
+					.requestMatchers("/actuator/**").hasRole(actuatorProperties.getRoleName())
+					.requestMatchers("/login").permitAll()
 					.anyRequest().authenticated()
 			)
 			.formLogin(configurer -> {


### PR DESCRIPTION
## 구현한 것

- 테스트 실행중에 Actuator 시큐리티 필터가 우선순위가 높아서 oauth 관련 테스트가 실패하는 문제를 해결함
- Actuator 시큐리티 필터에 SecurityMatcher를 추가하여 해결
