### PR TITLE
[refactor] 포트폴리오 손익 내역 쿼리 개선

### DIFF
--- a/src/main/java/co/fineants/api/domain/BaseEntity.java
+++ b/src/main/java/co/fineants/api/domain/BaseEntity.java
@@ -6,6 +6,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import lombok.AllArgsConstructor;
@@ -21,8 +22,10 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder(toBuilder = true)
 public abstract class BaseEntity {
 	@CreatedDate
+	@Column(name = "create_at")
 	private LocalDateTime createAt;
 
 	@LastModifiedDate
+	@Column(name = "modified_at")
 	private LocalDateTime modifiedAt;
 }

--- a/src/main/java/co/fineants/api/domain/gainhistory/domain/entity/PortfolioGainHistory.java
+++ b/src/main/java/co/fineants/api/domain/gainhistory/domain/entity/PortfolioGainHistory.java
@@ -16,8 +16,10 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -27,6 +29,12 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode(of = {"totalGain", "dailyGain", "cash", "currentValuation", "portfolio"}, callSuper = false)
+@Table(
+	name = "portfolio_gain_history",
+	indexes = {
+		@Index(name = "idx_portfolio_id_create_at", columnList = "portfolio_id, create_at")
+	}
+)
 public class PortfolioGainHistory extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/co/fineants/api/domain/gainhistory/domain/entity/PortfolioGainHistory.java
+++ b/src/main/java/co/fineants/api/domain/gainhistory/domain/entity/PortfolioGainHistory.java
@@ -16,10 +16,8 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.Index;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -29,12 +27,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @EqualsAndHashCode(of = {"totalGain", "dailyGain", "cash", "currentValuation", "portfolio"}, callSuper = false)
-@Table(
-	name = "portfolio_gain_history",
-	indexes = {
-		@Index(name = "idx_portfolio_id_create_at", columnList = "portfolio_id, create_at")
-	}
-)
 public class PortfolioGainHistory extends BaseEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepository.java
+++ b/src/main/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepository.java
@@ -3,6 +3,7 @@ package co.fineants.api.domain.gainhistory.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -19,9 +20,9 @@ public interface PortfolioGainHistoryRepository extends JpaRepository<PortfolioG
 		where p.portfolio.id = :portfolioId and p.createAt <= :createAt
 		order by p.createAt desc
 		""")
-	List<PortfolioGainHistory> findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
-		@Param("portfolioId") Long portfolioId, @Param("createAt") LocalDateTime createAt);
-	
+	List<PortfolioGainHistory> findFirstLatestPortfolioGainHistory(
+		@Param("portfolioId") Long portfolioId, @Param("createAt") LocalDateTime createAt, Pageable pageable);
+
 	@Query(value = """
 		select date(p.create_at) as date, sum(p.cash + p.current_valuation) as totalValuation
 		from fineAnts.portfolio_gain_history p

--- a/src/main/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepository.java
+++ b/src/main/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepository.java
@@ -21,10 +21,7 @@ public interface PortfolioGainHistoryRepository extends JpaRepository<PortfolioG
 		""")
 	List<PortfolioGainHistory> findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
 		@Param("portfolioId") Long portfolioId, @Param("createAt") LocalDateTime createAt);
-
-	@Query("select p from PortfolioGainHistory p where p.portfolio.id = :portfolioId")
-	List<PortfolioGainHistory> findAllByPortfolioId(@Param("portfolioId") Long portfolioId);
-
+	
 	@Query(value = """
 		select date(p.create_at) as date, sum(p.cash + p.current_valuation) as totalValuation
 		from fineAnts.portfolio_gain_history p

--- a/src/main/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepository.java
+++ b/src/main/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepository.java
@@ -37,4 +37,8 @@ public interface PortfolioGainHistoryRepository extends JpaRepository<PortfolioG
 	@Modifying
 	@Query("delete from PortfolioGainHistory p where p.portfolio.id = :portfolioId")
 	int deleteAllByPortfolioId(@Param("portfolioId") Long portfolioId);
+
+	@Modifying
+	@Query("delete from PortfolioGainHistory p where p.portfolio.id in (:portfolioIds)")
+	void deleteAllByPortfolioIds(@Param("portfolioIds") List<Long> portfolioIds);
 }

--- a/src/main/java/co/fineants/api/domain/gainhistory/service/PortfolioGainHistoryService.java
+++ b/src/main/java/co/fineants/api/domain/gainhistory/service/PortfolioGainHistoryService.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,8 +34,8 @@ public class PortfolioGainHistoryService {
 		List<PortfolioGainHistory> portfolioGainHistories = new ArrayList<>();
 		for (Portfolio portfolio : portfolios) {
 			PortfolioGainHistory latestHistory =
-				repository.findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
-						portfolio.getId(), LocalDateTime.now())
+				repository.findFirstLatestPortfolioGainHistory(
+						portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 					.stream()
 					.findFirst()
 					.orElseGet(() -> PortfolioGainHistory.empty(portfolio));

--- a/src/main/java/co/fineants/api/domain/gainhistory/service/PortfolioGainHistoryService.java
+++ b/src/main/java/co/fineants/api/domain/gainhistory/service/PortfolioGainHistoryService.java
@@ -37,7 +37,7 @@ public class PortfolioGainHistoryService {
 				repository.findFirstLatestPortfolioGainHistory(
 						portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 					.stream()
-					.findFirst()
+					.findAny()
 					.orElseGet(() -> PortfolioGainHistory.empty(portfolio));
 			PortfolioGainHistory history = latestHistory.createNewHistory(calculator);
 			portfolioGainHistories.add(repository.save(history));

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioDetailFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioDetailFactory.java
@@ -8,7 +8,6 @@ import co.fineants.api.domain.gainhistory.domain.entity.PortfolioGainHistory;
 import co.fineants.api.domain.gainhistory.repository.PortfolioGainHistoryRepository;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioDetailRealTimeItem;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioDetailResponse;
-import co.fineants.api.domain.kis.repository.CurrentPriceRedisRepository;
 import co.fineants.api.domain.portfolio.domain.calculator.PortfolioCalculator;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.global.common.time.LocalDateTimeService;
@@ -18,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PortfolioDetailFactory {
 
-	private final CurrentPriceRedisRepository manager;
 	private final PortfolioGainHistoryRepository portfolioGainHistoryRepository;
 	private final LocalDateTimeService localDateTimeService;
 	private final PortfolioCalculator calculator;

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioDetailFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioDetailFactory.java
@@ -2,6 +2,7 @@ package co.fineants.api.domain.holding.domain.factory;
 
 import java.time.LocalDateTime;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Component;
 
 import co.fineants.api.domain.gainhistory.domain.entity.PortfolioGainHistory;
@@ -23,8 +24,8 @@ public class PortfolioDetailFactory {
 
 	public PortfolioDetailResponse createPortfolioDetailItem(Portfolio portfolio) {
 		PortfolioGainHistory history =
-			portfolioGainHistoryRepository.findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
-					portfolio.getId(), LocalDateTime.now())
+			portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
+					portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 				.stream()
 				.findFirst()
 				.orElseGet(() -> PortfolioGainHistory.empty(portfolio));
@@ -33,8 +34,8 @@ public class PortfolioDetailFactory {
 
 	public PortfolioDetailRealTimeItem createPortfolioDetailRealTimeItem(Portfolio portfolio) {
 		PortfolioGainHistory history =
-			portfolioGainHistoryRepository.findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
-					portfolio.getId(), LocalDateTime.now())
+			portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
+					portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 				.stream()
 				.findFirst()
 				.orElseGet(() -> PortfolioGainHistory.empty(portfolio));

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioDetailFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioDetailFactory.java
@@ -27,7 +27,7 @@ public class PortfolioDetailFactory {
 			portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
 					portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 				.stream()
-				.findFirst()
+				.findAny()
 				.orElseGet(() -> PortfolioGainHistory.empty(portfolio));
 		return PortfolioDetailResponse.of(portfolio, history, localDateTimeService, calculator);
 	}
@@ -37,7 +37,7 @@ public class PortfolioDetailFactory {
 			portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
 					portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 				.stream()
-				.findFirst()
+				.findAny()
 				.orElseGet(() -> PortfolioGainHistory.empty(portfolio));
 		return PortfolioDetailRealTimeItem.of(portfolio, history, calculator);
 	}

--- a/src/main/java/co/fineants/api/domain/member/service/MemberService.java
+++ b/src/main/java/co/fineants/api/domain/member/service/MemberService.java
@@ -315,7 +315,6 @@ public class MemberService {
 			.map(Portfolio::getId)
 			.toList();
 		portfolioGainHistoryRepository.deleteAllByPortfolioIds(portfolioIds);
-
 		purchaseHistoryRepository.deleteAllByPortfolioHoldingIdIn(
 			portfolioHoldings.stream().map(PortfolioHolding::getId).toList());
 		portfolioHoldingRepository.deleteAll(portfolioHoldings);

--- a/src/main/java/co/fineants/api/domain/member/service/MemberService.java
+++ b/src/main/java/co/fineants/api/domain/member/service/MemberService.java
@@ -18,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import co.fineants.api.domain.fcm.repository.FcmRepository;
-import co.fineants.api.domain.gainhistory.domain.entity.PortfolioGainHistory;
 import co.fineants.api.domain.gainhistory.repository.PortfolioGainHistoryRepository;
 import co.fineants.api.domain.holding.domain.entity.PortfolioHolding;
 import co.fineants.api.domain.holding.repository.PortfolioHoldingRepository;
@@ -311,12 +310,14 @@ public class MemberService {
 		List<PortfolioHolding> portfolioHoldings = new ArrayList<>();
 		portfolios.forEach(
 			portfolio -> portfolioHoldings.addAll(portfolioHoldingRepository.findAllByPortfolio(portfolio)));
-		List<PortfolioGainHistory> portfolioGainHistories = new ArrayList<>();
-		portfolios.forEach(portfolio -> portfolioGainHistories.addAll(
-			portfolioGainHistoryRepository.findAllByPortfolioId(portfolio.getId())));
+		// 포트폴리오에 속한 모든 포트폴리오 손익 내역 데이터 삭제
+		List<Long> portfolioIds = portfolios.stream()
+			.map(Portfolio::getId)
+			.toList();
+		portfolioGainHistoryRepository.deleteAllByPortfolioIds(portfolioIds);
+
 		purchaseHistoryRepository.deleteAllByPortfolioHoldingIdIn(
 			portfolioHoldings.stream().map(PortfolioHolding::getId).toList());
-		portfolioGainHistoryRepository.deleteAll(portfolioGainHistories);
 		portfolioHoldingRepository.deleteAll(portfolioHoldings);
 		portfolioRepository.deleteAll(portfolios);
 		List<WatchList> watchList = watchListRepository.findByMember(member);

--- a/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -181,8 +182,8 @@ public class PortFolioService {
 			.collect(Collectors.toMap(
 				portfolio -> portfolio,
 				portfolio ->
-					portfolioGainHistoryRepository.findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
-							portfolio.getId(), LocalDateTime.now())
+					portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
+							portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 						.stream()
 						.findFirst()
 						.orElseGet(() -> PortfolioGainHistory.empty(portfolio))

--- a/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
@@ -185,7 +185,7 @@ public class PortFolioService {
 					portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
 							portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 						.stream()
-						.findFirst()
+						.findAny()
 						.orElseGet(() -> PortfolioGainHistory.empty(portfolio))
 			));
 

--- a/src/test/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepositoryTest.java
+++ b/src/test/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepositoryTest.java
@@ -32,22 +32,6 @@ class PortfolioGainHistoryRepositoryTest extends AbstractDataJpaBaseTest {
 	@Autowired
 	private PortfolioRepository portfolioRepository;
 
-	@DisplayName("포트폴리오 등록번호를 가진 손익내역들을 조회한다")
-	@Test
-	void findAllByPortfolioId() {
-		// given
-		Member member = memberRepository.save(TestDataFactory.createMember());
-		Portfolio portfolio = portfolioRepository.save(TestDataFactory.createPortfolio(member));
-		portfolioGainHistoryRepository.save(PortfolioGainHistory.empty(portfolio));
-
-		// when
-		List<PortfolioGainHistory> histories = portfolioGainHistoryRepository.findAllByPortfolioId(
-			portfolio.getId());
-
-		// then
-		assertThat(histories).hasSize(1);
-	}
-
 	@DisplayName("사용자는 제일 최근의 포트폴리오 손익 내역을 조회합니다")
 	@Test
 	void findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc() {

--- a/src/test/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepositoryTest.java
+++ b/src/test/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepositoryTest.java
@@ -138,4 +138,34 @@ class PortfolioGainHistoryRepositoryTest extends AbstractDataJpaBaseTest {
 		// then
 		Assertions.assertThat(actual).hasSize(1);
 	}
+
+	@DisplayName("여러개의 포트폴리오의 포트폴리오 손익 내역 데이터를 삭제한다")
+	@Test
+	void deleteAllByPortfolioIds() {
+		// given
+		Member member = memberRepository.save(TestDataFactory.createMember());
+		Portfolio portfolio = portfolioRepository.save(TestDataFactory.createPortfolio(member, "포트폴리오1"));
+		Portfolio portfolio2 = portfolioRepository.save(TestDataFactory.createPortfolio(member, "포트폴리오2"));
+		PortfolioGainHistory portfolioGainHistory1 = PortfolioGainHistory.create(
+			Money.won(10000L),
+			Money.won(10000L),
+			Money.won(1000000L),
+			Money.won(110000L),
+			portfolio
+		);
+		PortfolioGainHistory portfolioGainHistory2 = PortfolioGainHistory.create(
+			Money.won(10000L),
+			Money.won(10000L),
+			Money.won(1000000L),
+			Money.won(110000L),
+			portfolio2
+		);
+		portfolioGainHistoryRepository.saveAll(List.of(portfolioGainHistory1, portfolioGainHistory2));
+		// when
+		portfolioGainHistoryRepository.deleteAllByPortfolioIds(List.of(portfolio.getId(), portfolio2.getId()));
+		// then
+		List<PortfolioGainHistory> actual = portfolioGainHistoryRepository.findAll();
+		Assertions.assertThat(actual).isEmpty();
+		;
+	}
 }

--- a/src/test/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepositoryTest.java
+++ b/src/test/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepositoryTest.java
@@ -9,6 +9,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import co.fineants.AbstractDataJpaBaseTest;
@@ -43,9 +44,10 @@ class PortfolioGainHistoryRepositoryTest extends AbstractDataJpaBaseTest {
 
 		// when
 		PortfolioGainHistory history =
-			portfolioGainHistoryRepository.findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
+			portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
 					portfolio.getId(),
-					LocalDateTime.now())
+					LocalDateTime.now(),
+					PageRequest.of(0, 1))
 				.stream()
 				.findFirst()
 				.orElseThrow();
@@ -82,8 +84,8 @@ class PortfolioGainHistoryRepositoryTest extends AbstractDataJpaBaseTest {
 
 		// when
 		PortfolioGainHistory result =
-			portfolioGainHistoryRepository.findFirstByPortfolioAndCreateAtIsLessThanEqualOrderByCreateAtDesc(
-					portfolio.getId(), LocalDateTime.now())
+			portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
+					portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 				.stream()
 				.findFirst()
 				.orElseThrow();

--- a/src/test/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepositoryTest.java
+++ b/src/test/java/co/fineants/api/domain/gainhistory/repository/PortfolioGainHistoryRepositoryTest.java
@@ -47,9 +47,8 @@ class PortfolioGainHistoryRepositoryTest extends AbstractDataJpaBaseTest {
 			portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
 					portfolio.getId(),
 					LocalDateTime.now(),
-					PageRequest.of(0, 1))
-				.stream()
-				.findFirst()
+					PageRequest.of(0, 1)).stream()
+				.findAny()
 				.orElseThrow();
 
 		// then
@@ -87,7 +86,7 @@ class PortfolioGainHistoryRepositoryTest extends AbstractDataJpaBaseTest {
 			portfolioGainHistoryRepository.findFirstLatestPortfolioGainHistory(
 					portfolio.getId(), LocalDateTime.now(), PageRequest.of(0, 1))
 				.stream()
-				.findFirst()
+				.findAny()
 				.orElseThrow();
 
 		// then


### PR DESCRIPTION
## 구현한 것

- 300만건의 데이터가 존재하는 상태에서 쿼리에 대한 성능을 개선

## TODO
- 데이터베이스 마이그레이션을 학습하여 복합 인덱스를 추가하는 스크립트 작성