### PR TITLE
[feat] 포트폴리오 쿼리 성능 개선

### DIFF
--- a/src/docs/asciidoc/api/portfolio.adoc
+++ b/src/docs/asciidoc/api/portfolio.adoc
@@ -28,6 +28,7 @@ include::{snippets}/portfolio-search/response-fields.adoc[]
 
 ==== HTTP Request
 
+include::{snippets}/portfolio-search-names/query-parameters.adoc[]
 include::{snippets}/portfolio-search-names/http-request.adoc[]
 
 ==== HTTP Response

--- a/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
@@ -65,7 +65,7 @@ public class PortFolioRestController {
 	public ApiResponse<CustomPageResponse<PortfolioNameItem>> searchMyAllPortfolioNames(
 		@ModelAttribute CustomPageRequest pageable,
 		@MemberAuthenticationPrincipal MemberAuthentication authentication) {
-		Page<Portfolio> page = portFolioService.readMyAllPortfolioNamesUsingPaging(authentication.getId(),
+		Page<Portfolio> page = portFolioService.getPagedPortfolioNames(authentication.getId(),
 			pageable.of());
 		List<PortfolioNameItem> items = page.stream()
 			.map(PortfolioNameItem::from)

--- a/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
@@ -1,5 +1,9 @@
 package co.fineants.api.domain.portfolio.controller;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,10 +19,12 @@ import co.fineants.api.domain.portfolio.domain.dto.request.PortfolioCreateReques
 import co.fineants.api.domain.portfolio.domain.dto.request.PortfolioModifyRequest;
 import co.fineants.api.domain.portfolio.domain.dto.request.PortfoliosDeleteRequest;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortFolioCreateResponse;
+import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameItem;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameResponse;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfoliosResponse;
 import co.fineants.api.domain.portfolio.service.PortFolioService;
 import co.fineants.api.global.api.ApiResponse;
+import co.fineants.api.global.common.page.CustomPageRequest;
 import co.fineants.api.global.security.oauth.dto.MemberAuthentication;
 import co.fineants.api.global.security.oauth.resolver.MemberAuthenticationPrincipal;
 import co.fineants.api.global.success.PortfolioSuccessCode;
@@ -58,6 +64,18 @@ public class PortFolioRestController {
 		@MemberAuthenticationPrincipal MemberAuthentication authentication) {
 		return ApiResponse.success(PortfolioSuccessCode.OK_SEARCH_PORTFOLIO_NAMES,
 			portFolioService.readMyAllPortfolioNames(authentication.getId()));
+	}
+
+	@GetMapping("/names_pageable")
+	public ApiResponse<Page<PortfolioNameItem>> searchMyAllPortfolioNames_Pageable(
+		CustomPageRequest pageable,
+		@MemberAuthenticationPrincipal MemberAuthentication authentication) {
+		List<PortfolioNameItem> items = portFolioService.readMyAllPortfolioNamesUsingPaging(authentication.getId(),
+				pageable.of()).stream()
+			.map(PortfolioNameItem::from)
+			.toList();
+		Page<PortfolioNameItem> page = new PageImpl<>(items);
+		return ApiResponse.success(PortfolioSuccessCode.OK_SEARCH_PORTFOLIO_NAMES, page);
 	}
 
 	// 포트폴리오 수정

--- a/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
@@ -20,11 +20,12 @@ import co.fineants.api.domain.portfolio.domain.dto.request.PortfolioModifyReques
 import co.fineants.api.domain.portfolio.domain.dto.request.PortfoliosDeleteRequest;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortFolioCreateResponse;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameItem;
-import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameResponse;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfoliosResponse;
+import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.domain.portfolio.service.PortFolioService;
 import co.fineants.api.global.api.ApiResponse;
 import co.fineants.api.global.common.page.CustomPageRequest;
+import co.fineants.api.global.common.page.CustomPageResponse;
 import co.fineants.api.global.security.oauth.dto.MemberAuthentication;
 import co.fineants.api.global.security.oauth.resolver.MemberAuthenticationPrincipal;
 import co.fineants.api.global.success.PortfolioSuccessCode;
@@ -60,22 +61,17 @@ public class PortFolioRestController {
 
 	// 포트폴리오 이름 목록 조회
 	@GetMapping("/names")
-	public ApiResponse<PortfolioNameResponse> searchMyAllPortfolioNames(
-		@MemberAuthenticationPrincipal MemberAuthentication authentication) {
-		return ApiResponse.success(PortfolioSuccessCode.OK_SEARCH_PORTFOLIO_NAMES,
-			portFolioService.readMyAllPortfolioNames(authentication.getId()));
-	}
-
-	@GetMapping("/names_pageable")
-	public ApiResponse<Page<PortfolioNameItem>> searchMyAllPortfolioNames_Pageable(
+	public ApiResponse<CustomPageResponse<PortfolioNameItem>> searchMyAllPortfolioNames(
 		CustomPageRequest pageable,
 		@MemberAuthenticationPrincipal MemberAuthentication authentication) {
-		List<PortfolioNameItem> items = portFolioService.readMyAllPortfolioNamesUsingPaging(authentication.getId(),
-				pageable.of()).stream()
+		Page<Portfolio> page = portFolioService.readMyAllPortfolioNamesUsingPaging(authentication.getId(),
+			pageable.of());
+		List<PortfolioNameItem> items = page.stream()
 			.map(PortfolioNameItem::from)
 			.toList();
-		Page<PortfolioNameItem> page = new PageImpl<>(items);
-		return ApiResponse.success(PortfolioSuccessCode.OK_SEARCH_PORTFOLIO_NAMES, page);
+		Page<PortfolioNameItem> data = new PageImpl<>(items, pageable.of(), page.getTotalElements());
+		CustomPageResponse<PortfolioNameItem> response = new CustomPageResponse<>(data, "portfolios");
+		return ApiResponse.success(PortfolioSuccessCode.OK_SEARCH_PORTFOLIO_NAMES, response);
 	}
 
 	// 포트폴리오 수정

--- a/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/controller/PortFolioRestController.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -62,7 +63,7 @@ public class PortFolioRestController {
 	// 포트폴리오 이름 목록 조회
 	@GetMapping("/names")
 	public ApiResponse<CustomPageResponse<PortfolioNameItem>> searchMyAllPortfolioNames(
-		CustomPageRequest pageable,
+		@ModelAttribute CustomPageRequest pageable,
 		@MemberAuthenticationPrincipal MemberAuthentication authentication) {
 		Page<Portfolio> page = portFolioService.readMyAllPortfolioNamesUsingPaging(authentication.getId(),
 			pageable.of());

--- a/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/domain/entity/Portfolio.java
@@ -398,6 +398,6 @@ public class Portfolio extends BaseEntity {
 
 	@Override
 	public String toString() {
-		return String.format("Portfolio(id=%d, detail=%s, memberNickname=%s)", id, detail, member.getNickname());
+		return String.format("Portfolio(id=%d, detail=%s)", id, detail);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/repository/PortfolioRepository.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/repository/PortfolioRepository.java
@@ -3,6 +3,8 @@ package co.fineants.api.domain.portfolio.repository;
 import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -18,6 +20,9 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
 
 	@Query("select p from Portfolio p where p.member.id = :memberId order by p.id desc")
 	List<Portfolio> findAllByMemberIdOrderByIdDesc(@Param("memberId") Long memberId);
+
+	@Query("select p from Portfolio p where p.member.id = :memberId")
+	Page<Portfolio> findAllByMemberIdAndPageable(@Param("memberId") Long memberId, Pageable pageable);
 
 	@Query("select p from Portfolio p where p.member.id = :memberId order by p.createAt asc")
 	List<Portfolio> findAllByMemberId(@Param("memberId") Long memberId);

--- a/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
@@ -1,14 +1,12 @@
 package co.fineants.api.domain.portfolio.service;
 
 import java.time.LocalDateTime;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -28,8 +26,6 @@ import co.fineants.api.domain.portfolio.domain.dto.request.PortfolioCreateReques
 import co.fineants.api.domain.portfolio.domain.dto.request.PortfolioModifyRequest;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortFolioCreateResponse;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioModifyResponse;
-import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameItem;
-import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameResponse;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfoliosResponse;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.domain.portfolio.properties.PortfolioProperties;
@@ -194,20 +190,10 @@ public class PortFolioService {
 		return PortfoliosResponse.of(portfolios, portfolioGainHistoryMap, currentPriceRedisRepository, calculator);
 	}
 
-	@Transactional(readOnly = true)
-	@Cacheable(value = "myAllPortfolioNames", key = "#memberId")
-	@Secured("ROLE_USER")
-	public PortfolioNameResponse readMyAllPortfolioNames(@NotNull Long memberId) {
-		List<PortfolioNameItem> items = portfolioRepository.findAllByMemberIdOrderByIdDesc(memberId).stream()
-			.sorted(Comparator.comparing(Portfolio::getCreateAt).reversed())
-			.map(PortfolioNameItem::from)
-			.toList();
-		return PortfolioNameResponse.from(items);
-	}
-
+	// TODO: 캐시 추가
 	@Transactional(readOnly = true)
 	@Secured("ROLE_USER")
-	public Page<Portfolio> readMyAllPortfolioNamesUsingPaging(@NotNull Long memberId, Pageable pageable) {
+	public Page<Portfolio> getPagedPortfolioNames(@NotNull Long memberId, @NotNull Pageable pageable) {
 		return portfolioRepository.findAllByMemberIdAndPageable(memberId, pageable);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
+++ b/src/main/java/co/fineants/api/domain/portfolio/service/PortFolioService.java
@@ -9,7 +9,9 @@ import java.util.stream.Collectors;
 import org.jetbrains.annotations.NotNull;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -201,5 +203,11 @@ public class PortFolioService {
 			.map(PortfolioNameItem::from)
 			.toList();
 		return PortfolioNameResponse.from(items);
+	}
+
+	@Transactional(readOnly = true)
+	@Secured("ROLE_USER")
+	public Page<Portfolio> readMyAllPortfolioNamesUsingPaging(@NotNull Long memberId, Pageable pageable) {
+		return portfolioRepository.findAllByMemberIdAndPageable(memberId, pageable);
 	}
 }

--- a/src/main/java/co/fineants/api/global/common/page/CustomPageRequest.java
+++ b/src/main/java/co/fineants/api/global/common/page/CustomPageRequest.java
@@ -1,0 +1,38 @@
+package co.fineants.api.global.common.page;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CustomPageRequest {
+	private int page;
+	private int size;
+	private Sort.Direction direction;
+
+	public CustomPageRequest(Integer page, Integer size, Sort.Direction direction) {
+		setPage(page);
+		setSize(size);
+		setDirection(direction);
+	}
+
+	private void setPage(Integer page) {
+		this.page = page == null || page <= 0 ? 1 : page;
+	}
+
+	private void setSize(Integer size) {
+		int defaultSize = 10;
+		int maxSize = 50;
+		this.size = size == null || size > maxSize || size <= 0 ? defaultSize : size;
+	}
+
+	private void setDirection(Sort.Direction direction) {
+		this.direction = direction == null ? Sort.Direction.DESC : direction;
+	}
+
+	public PageRequest of() {
+		Sort sort = Sort.by(direction, "createAt");
+		return PageRequest.of(page - 1, size, sort);
+	}
+}

--- a/src/main/java/co/fineants/api/global/common/page/CustomPageResponse.java
+++ b/src/main/java/co/fineants/api/global/common/page/CustomPageResponse.java
@@ -1,0 +1,58 @@
+package co.fineants.api.global.common.page;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class CustomPageResponse<T> {
+	@JsonAnyGetter
+	private final Map<String, List<T>> content;
+	@JsonProperty("pageable")
+	private final Pageable pageable;
+	@JsonProperty("first")
+	private final boolean first;
+	@JsonProperty("last")
+	private final boolean last;
+	@JsonProperty("totalElements")
+	private final long totalElements;
+	@JsonProperty("totalPages")
+	private final int totalPages;
+	@JsonProperty("size")
+	private final int size;
+	@JsonProperty("number")
+	private final int number;
+	@JsonProperty("sort")
+	private final Sort sort;
+	@JsonProperty("numberOfElements")
+	private final int numberOfElements;
+	@JsonProperty("empty")
+	private final boolean empty;
+
+	public CustomPageResponse(Page<T> page, String contentKeyName) {
+		this.content = Map.of(contentKeyName, page.getContent());
+		this.pageable = page.getPageable();
+		this.first = page.isFirst();
+		this.last = page.isLast();
+		this.totalElements = page.getTotalElements();
+		this.totalPages = page.getTotalPages();
+		this.size = page.getSize();
+		this.number = page.getNumber();
+		this.sort = page.getSort();
+		this.numberOfElements = page.getNumberOfElements();
+		this.empty = page.isEmpty();
+	}
+
+	@Override
+	public String toString() {
+		return String.format(
+			"CustomPageResponse [content=%s, pageable=%s, first=%s, last=%s, totalElements=%s, totalPages=%s, size=%s, number=%s, sort=%s, numberOfElements=%s, empty=%s]",
+			content, pageable, first, last, totalElements, totalPages, size, number, sort,
+			numberOfElements, empty);
+	}
+}

--- a/src/main/java/co/fineants/api/global/config/FlywayConfig.java
+++ b/src/main/java/co/fineants/api/global/config/FlywayConfig.java
@@ -1,0 +1,17 @@
+package co.fineants.api.global.config;
+
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayConfig {
+
+	@Bean
+	public FlywayMigrationStrategy flywayMigrationStrategy() {
+		return flyway -> {
+			flyway.repair();
+			flyway.migrate();
+		};
+	}
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -13,7 +13,6 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
-    defer-datasource-initialization: false
     show-sql: true
     generate-ddl: false
   sql:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -13,7 +13,6 @@ spring:
       hibernate:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
-    defer-datasource-initialization: true
     show-sql: true
 logging:
   level:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -14,6 +14,8 @@ spring:
         format_sql: true
         dialect: org.hibernate.dialect.MySQL8Dialect
     show-sql: true
+  flyway:
+    enabled: false
 logging:
   level:
     co: debug

--- a/src/main/resources/db/mysql/migration/V4__add_index_portfolio.sql
+++ b/src/main/resources/db/mysql/migration/V4__add_index_portfolio.sql
@@ -1,0 +1,1 @@
+CREATE INDEX idx_member_create_at ON portfolio (member_id, create_at DESC);

--- a/src/test/java/co/fineants/api/docs/portfolio/PortfolioRestControllerDocsTest.java
+++ b/src/test/java/co/fineants/api/docs/portfolio/PortfolioRestControllerDocsTest.java
@@ -211,7 +211,7 @@ class PortfolioRestControllerDocsTest extends RestDocsSupport {
 		Member member = createMember();
 		Portfolio portfolio = createPortfolio(member);
 		Pageable pageable = new CustomPageRequest(0, 10, Sort.Direction.DESC).of();
-		given(portFolioService.readMyAllPortfolioNamesUsingPaging(member.getId(), pageable))
+		given(portFolioService.getPagedPortfolioNames(member.getId(), pageable))
 			.willReturn(new PageImpl<>(List.of(portfolio), pageable, 1));
 
 		// when & then

--- a/src/test/java/co/fineants/api/docs/portfolio/PortfolioRestControllerDocsTest.java
+++ b/src/test/java/co/fineants/api/docs/portfolio/PortfolioRestControllerDocsTest.java
@@ -252,7 +252,7 @@ class PortfolioRestControllerDocsTest extends RestDocsSupport {
 					queryParameters(
 						parameterWithName("page").description("페이지 번호(0부터 시작, 기본값: 0)").optional(),
 						parameterWithName("size").description("페이지 크기(한 페이지에 포함된 항목 개수, 기본값: 10)").optional(),
-						parameterWithName("direction").description("정렬 방향(ASC 또는 DESC, 기본값: DESC)").optional()
+						parameterWithName("direction").description("생성일자 기준 정렬 방향(ASC 또는 DESC, 기본값: DESC)").optional()
 					),
 					responseFields(
 						fieldWithPath("code").type(JsonFieldType.NUMBER)

--- a/src/test/java/co/fineants/api/docs/portfolio/PortfolioRestControllerDocsTest.java
+++ b/src/test/java/co/fineants/api/docs/portfolio/PortfolioRestControllerDocsTest.java
@@ -19,6 +19,9 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
@@ -39,11 +42,10 @@ import co.fineants.api.domain.portfolio.domain.dto.request.PortfolioModifyReques
 import co.fineants.api.domain.portfolio.domain.dto.response.PortFolioCreateResponse;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortFolioItem;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioModifyResponse;
-import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameItem;
-import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameResponse;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfoliosResponse;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.domain.portfolio.service.PortFolioService;
+import co.fineants.api.global.common.page.CustomPageRequest;
 import co.fineants.api.global.success.PortfolioSuccessCode;
 import co.fineants.api.global.util.ObjectMapperUtil;
 
@@ -206,10 +208,11 @@ class PortfolioRestControllerDocsTest extends RestDocsSupport {
 	@Test
 	void searchMyAllPortfolioNames() throws Exception {
 		// given
-		Portfolio portfolio = createPortfolio(createMember());
-		PortfolioNameItem item = PortfolioNameItem.from(portfolio);
-		given(portFolioService.readMyAllPortfolioNames(anyLong()))
-			.willReturn(PortfolioNameResponse.from(List.of(item)));
+		Member member = createMember();
+		Portfolio portfolio = createPortfolio(member);
+		Pageable pageable = new CustomPageRequest(0, 10, Sort.Direction.DESC).of();
+		given(portFolioService.readMyAllPortfolioNamesUsingPaging(member.getId(), pageable))
+			.willReturn(new PageImpl<>(List.of(portfolio), pageable, 1));
 
 		// when & then
 		mockMvc.perform(get("/api/portfolios/names")
@@ -218,6 +221,26 @@ class PortfolioRestControllerDocsTest extends RestDocsSupport {
 			.andExpect(jsonPath("code").value(equalTo(200)))
 			.andExpect(jsonPath("status").value(equalTo("OK")))
 			.andExpect(jsonPath("message").value(equalTo(PortfolioSuccessCode.OK_SEARCH_PORTFOLIO_NAMES.getMessage())))
+			.andExpect(jsonPath("data.pageable.pageNumber").value(equalTo(0)))
+			.andExpect(jsonPath("data.pageable.pageSize").value(equalTo(10)))
+			.andExpect(jsonPath("data.pageable.sort.empty").value(equalTo(false)))
+			.andExpect(jsonPath("data.pageable.sort.unsorted").value(equalTo(false)))
+			.andExpect(jsonPath("data.pageable.sort.sorted").value(equalTo(true)))
+			.andExpect(jsonPath("data.pageable.offset").value(equalTo(0)))
+			.andExpect(jsonPath("data.pageable.paged").value(equalTo(true)))
+			.andExpect(jsonPath("data.pageable.unpaged").value(equalTo(false)))
+			.andExpect(jsonPath("data.first").value(equalTo(true)))
+			.andExpect(jsonPath("data.last").value(equalTo(true)))
+			.andExpect(jsonPath("data.totalElements").value(equalTo(1)))
+			.andExpect(jsonPath("data.totalPages").value(equalTo(1)))
+			.andExpect(jsonPath("data.size").value(equalTo(10)))
+			.andExpect(jsonPath("data.number").value(equalTo(0)))
+			.andExpect(jsonPath("data.sort.empty").value(equalTo(false)))
+			.andExpect(jsonPath("data.sort.unsorted").value(equalTo(false)))
+			.andExpect(jsonPath("data.sort.sorted").value(equalTo(true)))
+			.andExpect(jsonPath("data.numberOfElements").value(equalTo(1)))
+			.andExpect(jsonPath("data.empty").value(equalTo(false)))
+			.andExpect(jsonPath("data.portfolios").isArray())
 			.andExpect(jsonPath("data.portfolios[0].id").value(equalTo(portfolio.getId().intValue())))
 			.andExpect(jsonPath("data.portfolios[0].name").value(equalTo("내꿈은 워렌버핏")))
 			.andExpect(jsonPath("data.portfolios[0].dateCreated").isNotEmpty())
@@ -226,6 +249,11 @@ class PortfolioRestControllerDocsTest extends RestDocsSupport {
 					"portfolio-search-names",
 					preprocessRequest(prettyPrint()),
 					preprocessResponse(prettyPrint()),
+					queryParameters(
+						parameterWithName("page").description("페이지 번호(0부터 시작, 기본값: 0)").optional(),
+						parameterWithName("size").description("페이지 크기(한 페이지에 포함된 항목 개수, 기본값: 10)").optional(),
+						parameterWithName("direction").description("정렬 방향(ASC 또는 DESC, 기본값: DESC)").optional()
+					),
 					responseFields(
 						fieldWithPath("code").type(JsonFieldType.NUMBER)
 							.description("코드"),
@@ -235,12 +263,56 @@ class PortfolioRestControllerDocsTest extends RestDocsSupport {
 							.description("메시지"),
 						fieldWithPath("data").type(JsonFieldType.OBJECT)
 							.description("응답 데이터"),
+						fieldWithPath("data.pageable.pageNumber").type(JsonFieldType.NUMBER)
+							.description("현재 페이지 번호(0부터 시작)"),
+						fieldWithPath("data.pageable.pageSize").type(JsonFieldType.NUMBER)
+							.description("한 페이지에 포함된 항목 개수"),
+						fieldWithPath("data.pageable.sort").type(JsonFieldType.OBJECT)
+							.description("정렬 정보"),
+						fieldWithPath("data.pageable.sort.empty").type(JsonFieldType.BOOLEAN)
+							.description("정렬 기준이 비어 있는지 여부(false: 정렬 기준 존재, true: 정렬 기준 없음)"),
+						fieldWithPath("data.pageable.sort.unsorted").type(JsonFieldType.BOOLEAN)
+							.description("정렬이 적용되지 않았는지 여부(false: 정렬 적용, true: 정렬 미적용)"),
+						fieldWithPath("data.pageable.sort.sorted").type(JsonFieldType.BOOLEAN)
+							.description("정렬이 적용되었는지 여부(false: 정렬 미적용, true: 정렬 적용)"),
+						fieldWithPath("data.pageable.offset").type(JsonFieldType.NUMBER)
+							.description("전체 결과에서 현재 페이지의 시작 위(예: 0페이이면 0, 1페이지 pageSize*1"),
+						fieldWithPath("data.pageable.paged").type(JsonFieldType.BOOLEAN)
+							.description("페이징이 적용되었는지 여부"),
+						fieldWithPath("data.pageable.unpaged").type(JsonFieldType.BOOLEAN)
+							.description("페이징이 적용되지 않았는지 여부"),
+						fieldWithPath("data.first").type(JsonFieldType.BOOLEAN)
+							.description("첫 페이지 여부"),
+						fieldWithPath("data.last").type(JsonFieldType.BOOLEAN)
+							.description("마지막 페이지 여부"),
+						fieldWithPath("data.totalElements").type(JsonFieldType.NUMBER)
+							.description("전체 항목 개수"),
+						fieldWithPath("data.totalPages").type(JsonFieldType.NUMBER)
+							.description("전체 페이지 개수"),
+						fieldWithPath("data.size").type(JsonFieldType.NUMBER)
+							.description("한 페이지에 포함된 항목 개수"),
+						fieldWithPath("data.number").type(JsonFieldType.NUMBER)
+							.description("현재 페이지 번호(0부터 시작)"),
+						fieldWithPath("data.sort").type(JsonFieldType.OBJECT)
+							.description("정렬 정보"),
+						fieldWithPath("data.sort.empty").type(JsonFieldType.BOOLEAN)
+							.description("정렬 기준이 비어 있는지 여부(false: 정렬 기준 존재, true: 정렬 기준 없음)"),
+						fieldWithPath("data.sort.unsorted").type(JsonFieldType.BOOLEAN)
+							.description("정렬이 적용되지 않았는지 여부(false: 정렬 적용, true: 정렬 미적용)"),
+						fieldWithPath("data.sort.sorted").type(JsonFieldType.BOOLEAN)
+							.description("정렬이 적용되었는지 여부(false: 정렬 미적용, true: 정렬 적용)"),
+						fieldWithPath("data.numberOfElements").type(JsonFieldType.NUMBER)
+							.description("현재 페이지에 포함된 항목 개수"),
+						fieldWithPath("data.empty").type(JsonFieldType.BOOLEAN)
+							.description("현재 페이지가 비어 있는지 여부"),
+						fieldWithPath("data.portfolios").type(JsonFieldType.ARRAY)
+							.description("포트폴리오 목록"),
 						fieldWithPath("data.portfolios[].id").type(JsonFieldType.NUMBER)
 							.description("포트폴리오 등록번호"),
 						fieldWithPath("data.portfolios[].name").type(JsonFieldType.STRING)
 							.description("포트폴리오 이름"),
 						fieldWithPath("data.portfolios[].dateCreated").type(JsonFieldType.STRING)
-							.description("추가일자")
+							.description("생성일자")
 					)
 				)
 			);

--- a/src/test/java/co/fineants/api/docs/portfolio/PortfolioRestControllerDocsTest.java
+++ b/src/test/java/co/fineants/api/docs/portfolio/PortfolioRestControllerDocsTest.java
@@ -251,7 +251,7 @@ class PortfolioRestControllerDocsTest extends RestDocsSupport {
 					preprocessResponse(prettyPrint()),
 					queryParameters(
 						parameterWithName("page").description("페이지 번호(0부터 시작, 기본값: 0)").optional(),
-						parameterWithName("size").description("페이지 크기(한 페이지에 포함된 항목 개수, 기본값: 10)").optional(),
+						parameterWithName("size").description("페이지 크기(한 페이지에 포함된 항목 개수, 기본값: 50)").optional(),
 						parameterWithName("direction").description("생성일자 기준 정렬 방향(ASC 또는 DESC, 기본값: DESC)").optional()
 					),
 					responseFields(

--- a/src/test/java/co/fineants/api/domain/portfolio/repository/PortfolioRepositoryTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/repository/PortfolioRepositoryTest.java
@@ -2,6 +2,7 @@ package co.fineants.api.domain.portfolio.repository;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -9,11 +10,16 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 
 import co.fineants.AbstractContainerBaseTest;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.member.repository.MemberRepository;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
+import co.fineants.api.domain.portfolio.domain.entity.PortfolioDetail;
+import co.fineants.api.global.common.page.CustomPageRequest;
 
 class PortfolioRepositoryTest extends AbstractContainerBaseTest {
 
@@ -78,5 +84,32 @@ class PortfolioRepositoryTest extends AbstractContainerBaseTest {
 
 		// then
 		Assertions.assertThat(portfolio.getId()).isEqualTo(findPortfolio.getId());
+	}
+
+	@DisplayName("포트폴리오들이 주어지고 포트폴리오의 생성일자를 기준으로 내림차순으로 조회한다")
+	@Test
+	void findAllByMemberIdOrderByCreateAtDesc() {
+		// given
+		Member member = memberRepository.save(createMember());
+		List<Portfolio> portfolios = new ArrayList<>();
+		for (int i = 0; i < 11; i++) {
+			portfolios.add(createPortfolio(member, "포트폴리오" + i));
+		}
+		portfolioRepository.saveAll(portfolios);
+		CustomPageRequest pageRequest = new CustomPageRequest(1, 10, Sort.Direction.DESC);
+		Pageable pageable = pageRequest.of();
+		// when
+		Page<Portfolio> actual = portfolioRepository.findAllByMemberIdAndPageable(
+			member.getId(), pageable);
+		// then
+		List<String> expected = new ArrayList<>();
+		for (int i = 10; i >= 1; i--) {
+			expected.add("포트폴리오" + i);
+		}
+		assertThat(actual)
+			.hasSize(10)
+			.extracting(Portfolio::getDetail)
+			.extracting(PortfolioDetail::name)
+			.containsExactlyElementsOf(expected);
 	}
 }

--- a/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/portfolio/service/PortFolioServiceTest.java
@@ -36,7 +36,6 @@ import co.fineants.api.domain.member.repository.MemberRepository;
 import co.fineants.api.domain.portfolio.domain.dto.request.PortfolioCreateRequest;
 import co.fineants.api.domain.portfolio.domain.dto.request.PortfolioModifyRequest;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortFolioCreateResponse;
-import co.fineants.api.domain.portfolio.domain.dto.response.PortfolioNameResponse;
 import co.fineants.api.domain.portfolio.domain.dto.response.PortfoliosResponse;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.domain.portfolio.repository.PortfolioRepository;
@@ -434,22 +433,6 @@ class PortFolioServiceTest extends AbstractContainerBaseTest {
 				Money.won(-150000),
 				Percentage.from(-0.5556)
 			));
-	}
-
-	@DisplayName("회원의 포트폴리오 이름 목록을 조회한다")
-	@Test
-	void givenPortfolios_whenReadMyAllPortfolioNames_thenSortedByCreatedDescAndReturnPortfolioNameItemsOfPortfolios() {
-		// given
-		Member member = memberRepository.save(createMember());
-		portfolioRepository.saveAll(
-			List.of(createPortfolio(member, "portfolio1"), createPortfolio(member, "portfolio2")));
-		// when
-		PortfolioNameResponse actual = service.readMyAllPortfolioNames(member.getId());
-		// then
-		assertThat(actual)
-			.extracting("portfolios")
-			.asList()
-			.hasSize(2);
 	}
 
 	@DisplayName("회원이 포트폴리오를 삭제한다")


### PR DESCRIPTION
## 구현한 것

- 포트폴리오 이름 목록 API 조회시 페이징을 적용하였습니다.
- 포트폴리오 테이블에 복합 인덱스를 추가하여 쿼리 성능을 개선하였습니다.

## 성능 개선 결과

- 300만건의 포트폴리오 데이터에 대해서 포트폴리오 이름 목록 API 요청시 기존 3970ms -> 948ms로 약 4.18배 개선되었습니다.

## TODO
- 페이징 처리하는 서비스 메서드에 캐싱 추가
- 다른 포트폴리오 쿼리 개선