### PR TITLE
[refactor] SseEventBuilder 중복 개선

### DIFF
--- a/src/main/java/co/fineants/api/domain/holding/config/PortfolioStreamerConfig.java
+++ b/src/main/java/co/fineants/api/domain/holding/config/PortfolioStreamerConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 
 import co.fineants.api.domain.holding.service.PortfolioHoldingService;
 import co.fineants.api.domain.holding.service.market_status_checker.MarketStatusChecker;
+import co.fineants.api.domain.holding.service.streamer.AlwaysOpenPortfolioStreamer;
 import co.fineants.api.domain.holding.service.streamer.ClosedMarketPortfolioStreamer;
 import co.fineants.api.domain.holding.service.streamer.FluxIntervalPortfolioStreamer;
 
@@ -21,5 +22,12 @@ public class PortfolioStreamerConfig {
 	@Bean
 	public ClosedMarketPortfolioStreamer closedMarketPortfolioStreamer(MarketStatusChecker koreanMarketStatusChecker) {
 		return new ClosedMarketPortfolioStreamer(koreanMarketStatusChecker);
+	}
+
+	@Bean
+	public AlwaysOpenPortfolioStreamer alwaysOpenPortfolioStreamer(PortfolioHoldingService service) {
+		int second = 5;
+		int maxCount = 6;
+		return new AlwaysOpenPortfolioStreamer(service, second, maxCount);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/config/PortfolioStreamerFactoryConfig.java
+++ b/src/main/java/co/fineants/api/domain/holding/config/PortfolioStreamerFactoryConfig.java
@@ -6,8 +6,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import co.fineants.api.domain.holding.domain.factory.AlwaysOpenPortfolioStreamerFactory;
 import co.fineants.api.domain.holding.domain.factory.MarketStatusBasedPortfolioStreamerFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamMessageConsumerFactory;
+import co.fineants.api.domain.holding.service.streamer.AlwaysOpenPortfolioStreamer;
 import co.fineants.api.domain.holding.service.streamer.ClosedMarketPortfolioStreamer;
 import co.fineants.api.domain.holding.service.streamer.FluxIntervalPortfolioStreamer;
 import co.fineants.api.domain.holding.service.streamer.PortfolioStreamer;
@@ -22,6 +24,12 @@ public class PortfolioStreamerFactoryConfig {
 		ClosedMarketPortfolioStreamer closedMarketPortfolioStreamer, LocalDateTimeService localDateTimeService) {
 		List<PortfolioStreamer> streamers = List.of(fluxIntervalPortfolioStreamer, closedMarketPortfolioStreamer);
 		return new MarketStatusBasedPortfolioStreamerFactory(streamers, localDateTimeService);
+	}
+
+	@Bean
+	public AlwaysOpenPortfolioStreamerFactory alwaysOpenPortfolioStreamerFactory(
+		AlwaysOpenPortfolioStreamer alwaysOpenPortfolioStreamer) {
+		return new AlwaysOpenPortfolioStreamerFactory(alwaysOpenPortfolioStreamer);
 	}
 
 	@Bean

--- a/src/main/java/co/fineants/api/domain/holding/config/SseEmitterFactoryConfig.java
+++ b/src/main/java/co/fineants/api/domain/holding/config/SseEmitterFactoryConfig.java
@@ -4,8 +4,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import co.fineants.api.domain.holding.domain.factory.DefaultUuidGenerator;
 import co.fineants.api.domain.holding.domain.factory.PortfolioSseEmitterFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioSseEventBuilderFactory;
+import co.fineants.api.domain.holding.domain.factory.UuidGenerator;
 
 @Configuration
 public class SseEmitterFactoryConfig {
@@ -18,6 +20,7 @@ public class SseEmitterFactoryConfig {
 	@Bean
 	public PortfolioSseEventBuilderFactory portfolioSseEventBuilderFactory(
 		@Value("${sse.portfolio.reconnectTimeMillis:3000}") long reconnectTimeMillis) {
-		return new PortfolioSseEventBuilderFactory(reconnectTimeMillis);
+		UuidGenerator uuidGenerator = new DefaultUuidGenerator();
+		return new PortfolioSseEventBuilderFactory(reconnectTimeMillis, uuidGenerator);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/config/SseEmitterFactoryConfig.java
+++ b/src/main/java/co/fineants/api/domain/holding/config/SseEmitterFactoryConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import co.fineants.api.domain.holding.domain.factory.PortfolioSseEmitterFactory;
+import co.fineants.api.domain.holding.domain.factory.PortfolioSseEventBuilderFactory;
 
 @Configuration
 public class SseEmitterFactoryConfig {
@@ -12,5 +13,11 @@ public class SseEmitterFactoryConfig {
 	@Bean
 	public PortfolioSseEmitterFactory portfolioSseEmitterFactory(@Value("${portfolio.timeout:30000}") long timeout) {
 		return new PortfolioSseEmitterFactory(timeout);
+	}
+
+	@Bean
+	public PortfolioSseEventBuilderFactory portfolioSseEventBuilderFactory(
+		@Value("${sse.portfolio.reconnectTimeMillis:3000}") long reconnectTimeMillis) {
+		return new PortfolioSseEventBuilderFactory(reconnectTimeMillis);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/controller/PortfolioHoldingRestController.java
+++ b/src/main/java/co/fineants/api/domain/holding/controller/PortfolioHoldingRestController.java
@@ -19,7 +19,6 @@ import co.fineants.api.domain.holding.domain.dto.request.PortfolioStocksDeleteRe
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioChartResponse;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioHoldingsResponse;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioStockCreateResponse;
-import co.fineants.api.domain.holding.domain.factory.PortfolioSseEventBuilderFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamMessageConsumerFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamerFactory;
 import co.fineants.api.domain.holding.domain.factory.SseEmitterFactory;
@@ -45,6 +44,7 @@ public class PortfolioHoldingRestController {
 	private final PortfolioStreamerFactory marketStatusBasedPortfolioStreamerFactory;
 	private final PortfolioStreamMessageConsumerFactory portfolioStreamMessageConsumerFactory;
 	private final SseEmitterFactory portfolioSseEmitterFactory;
+	private final SseEventBuilderFactory portfolioSseEventBuilderFactory;
 
 	// 포트폴리오 종목 생성
 	@ResponseStatus(HttpStatus.CREATED)
@@ -73,9 +73,8 @@ public class PortfolioHoldingRestController {
 		StreamSseMessageSender sender = streamer.createStreamSseMessageSender(emitter,
 			portfolioStreamMessageConsumerFactory);
 		// 메시지 생성 및 구독
-		SseEventBuilderFactory sseEventBuilderFactory = new PortfolioSseEventBuilderFactory(3000L);
 		streamer.streamMessages(portfolioId)
-			.map(sseEventBuilderFactory::create)
+			.map(portfolioSseEventBuilderFactory::create)
 			.subscribe(sender);
 		return emitter;
 	}

--- a/src/main/java/co/fineants/api/domain/holding/controller/PortfolioHoldingRestController.java
+++ b/src/main/java/co/fineants/api/domain/holding/controller/PortfolioHoldingRestController.java
@@ -19,9 +19,11 @@ import co.fineants.api.domain.holding.domain.dto.request.PortfolioStocksDeleteRe
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioChartResponse;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioHoldingsResponse;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioStockCreateResponse;
+import co.fineants.api.domain.holding.domain.factory.PortfolioSseEventBuilderFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamMessageConsumerFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamerFactory;
 import co.fineants.api.domain.holding.domain.factory.SseEmitterFactory;
+import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
 import co.fineants.api.domain.holding.service.PortfolioHoldingService;
 import co.fineants.api.domain.holding.service.sender.StreamSseMessageSender;
 import co.fineants.api.domain.holding.service.streamer.PortfolioStreamer;
@@ -71,7 +73,9 @@ public class PortfolioHoldingRestController {
 		StreamSseMessageSender sender = streamer.createStreamSseMessageSender(emitter,
 			portfolioStreamMessageConsumerFactory);
 		// 메시지 생성 및 구독
+		SseEventBuilderFactory sseEventBuilderFactory = new PortfolioSseEventBuilderFactory(3000L);
 		streamer.streamMessages(portfolioId)
+			.map(sseEventBuilderFactory::create)
 			.subscribe(sender);
 		return emitter;
 	}

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/AlwaysOpenPortfolioStreamerFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/AlwaysOpenPortfolioStreamerFactory.java
@@ -1,0 +1,17 @@
+package co.fineants.api.domain.holding.domain.factory;
+
+import co.fineants.api.domain.holding.service.streamer.PortfolioStreamer;
+
+public class AlwaysOpenPortfolioStreamerFactory implements PortfolioStreamerFactory {
+
+	private final PortfolioStreamer portfolioStreamer;
+
+	public AlwaysOpenPortfolioStreamerFactory(PortfolioStreamer portfolioStreamer) {
+		this.portfolioStreamer = portfolioStreamer;
+	}
+
+	@Override
+	public PortfolioStreamer getStreamer() throws IllegalStateException {
+		return portfolioStreamer;
+	}
+}

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/DefaultUuidGenerator.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/DefaultUuidGenerator.java
@@ -1,0 +1,8 @@
+package co.fineants.api.domain.holding.domain.factory;
+
+public class DefaultUuidGenerator implements UuidGenerator {
+	@Override
+	public String generate() {
+		return UuidGenerator.super.generate();
+	}
+}

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEmitterFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEmitterFactory.java
@@ -20,9 +20,7 @@ public class PortfolioSseEmitterFactory implements SseEmitterFactory {
 			log.info("SseEmitter timeout, removing emitter");
 			emitter.complete();
 		});
-		emitter.onCompletion(() -> {
-			log.info("SseEmitter completed, removing emitter");
-		});
+		emitter.onCompletion(() -> log.info("SseEmitter completed, removing emitter"));
 		emitter.onError(throwable -> {
 			log.error("SseEmitter error: {}", throwable.getMessage(), throwable);
 			emitter.completeWithError(throwable);

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEventBuilderFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEventBuilderFactory.java
@@ -1,0 +1,25 @@
+package co.fineants.api.domain.holding.domain.factory;
+
+import java.util.UUID;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import co.fineants.api.domain.holding.domain.message.StreamMessage;
+
+public class PortfolioSseEventBuilderFactory implements SseEventBuilderFactory {
+	private final long reconnectTimeMillis;
+
+	public PortfolioSseEventBuilderFactory(long reconnectTimeMillis) {
+		this.reconnectTimeMillis = reconnectTimeMillis;
+	}
+
+	@Override
+	public SseEmitter.SseEventBuilder create(StreamMessage message) {
+		String id = UUID.randomUUID().toString();
+		return SseEmitter.event()
+			.id(id)
+			.data(message.getData())
+			.name(message.getEventName())
+			.reconnectTime(reconnectTimeMillis);
+	}
+}

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEventBuilderFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEventBuilderFactory.java
@@ -1,21 +1,21 @@
 package co.fineants.api.domain.holding.domain.factory;
 
-import java.util.UUID;
-
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import co.fineants.api.domain.holding.domain.message.StreamMessage;
 
 public class PortfolioSseEventBuilderFactory implements SseEventBuilderFactory {
 	private final long reconnectTimeMillis;
+	private final UuidGenerator uuidGenerator;
 
-	public PortfolioSseEventBuilderFactory(long reconnectTimeMillis) {
+	public PortfolioSseEventBuilderFactory(long reconnectTimeMillis, UuidGenerator uuidGenerator) {
 		this.reconnectTimeMillis = reconnectTimeMillis;
+		this.uuidGenerator = uuidGenerator;
 	}
 
 	@Override
 	public SseEmitter.SseEventBuilder create(StreamMessage message) {
-		String id = UUID.randomUUID().toString();
+		String id = uuidGenerator.generate();
 		return SseEmitter.event()
 			.id(id)
 			.data(message.getData())

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioStreamMessageConsumerFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioStreamMessageConsumerFactory.java
@@ -21,7 +21,6 @@ public class PortfolioStreamMessageConsumerFactory implements StreamMessageConsu
 
 	@Override
 	public StreamSseMessageSender createStreamCompleteMessageSender(SseEmitter emitter) {
-		SseEventBuilderFactory sseEventBuilderFactory = new PortfolioSseEventBuilderFactory(reconnectTimeMillis);
-		return new StreamCompleteMessageSender(emitter, sseEventBuilderFactory);
+		return new StreamCompleteMessageSender(emitter);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioStreamMessageConsumerFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/PortfolioStreamMessageConsumerFactory.java
@@ -21,6 +21,7 @@ public class PortfolioStreamMessageConsumerFactory implements StreamMessageConsu
 
 	@Override
 	public StreamSseMessageSender createStreamCompleteMessageSender(SseEmitter emitter) {
-		return new StreamCompleteMessageSender(emitter, reconnectTimeMillis);
+		SseEventBuilderFactory sseEventBuilderFactory = new PortfolioSseEventBuilderFactory(reconnectTimeMillis);
+		return new StreamCompleteMessageSender(emitter, sseEventBuilderFactory);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/SseEventBuilderFactory.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/SseEventBuilderFactory.java
@@ -1,0 +1,9 @@
+package co.fineants.api.domain.holding.domain.factory;
+
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import co.fineants.api.domain.holding.domain.message.StreamMessage;
+
+public interface SseEventBuilderFactory {
+	SseEmitter.SseEventBuilder create(StreamMessage message);
+}

--- a/src/main/java/co/fineants/api/domain/holding/domain/factory/UuidGenerator.java
+++ b/src/main/java/co/fineants/api/domain/holding/domain/factory/UuidGenerator.java
@@ -1,0 +1,9 @@
+package co.fineants.api.domain.holding.domain.factory;
+
+import java.util.UUID;
+
+public interface UuidGenerator {
+	default String generate() {
+		return UUID.randomUUID().toString();
+	}
+}

--- a/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
@@ -2,7 +2,6 @@ package co.fineants.api.domain.holding.service.sender;
 
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import co.fineants.api.domain.holding.domain.factory.PortfolioSseEventBuilderFactory;
 import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
 import co.fineants.api.domain.holding.domain.message.StreamMessage;
 import lombok.extern.slf4j.Slf4j;
@@ -11,17 +10,17 @@ import lombok.extern.slf4j.Slf4j;
 public class StreamCompleteMessageSender implements StreamSseMessageSender {
 
 	private final SseEmitter emitter;
-	private final long reconnectTimeMillis;
+	private final SseEventBuilderFactory sseEventBuilderFactory;
 
-	public StreamCompleteMessageSender(SseEmitter emitter, long reconnectTimeMillis) {
+	public StreamCompleteMessageSender(SseEmitter emitter,
+		SseEventBuilderFactory sseEventBuilderFactory) {
 		this.emitter = emitter;
-		this.reconnectTimeMillis = reconnectTimeMillis;
+		this.sseEventBuilderFactory = sseEventBuilderFactory;
 	}
 
 	@Override
 	public void accept(StreamMessage message) {
-		SseEventBuilderFactory factory = new PortfolioSseEventBuilderFactory(reconnectTimeMillis);
-		SseEmitter.SseEventBuilder builder = factory.create(message);
+		SseEmitter.SseEventBuilder builder = sseEventBuilderFactory.create(message);
 		try {
 			emitter.send(builder);
 		} catch (Exception exception) {

--- a/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
@@ -1,5 +1,7 @@
 package co.fineants.api.domain.holding.service.sender;
 
+import java.io.IOException;
+
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
@@ -23,7 +25,7 @@ public class StreamCompleteMessageSender implements StreamSseMessageSender {
 		SseEmitter.SseEventBuilder builder = sseEventBuilderFactory.create(message);
 		try {
 			emitter.send(builder);
-		} catch (Exception exception) {
+		} catch (IOException exception) {
 			log.error("Error sending data to SseEmitter: {}", exception.getMessage(), exception);
 			emitter.completeWithError(exception);
 		}

--- a/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
@@ -22,7 +22,8 @@ public class StreamCompleteMessageSender implements StreamSseMessageSender {
 		} catch (IOException exception) {
 			log.error("Error sending data to SseEmitter: {}", exception.getMessage(), exception);
 			emitter.completeWithError(exception);
+		} finally {
+			emitter.complete();
 		}
-		emitter.complete();
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
@@ -1,9 +1,9 @@
 package co.fineants.api.domain.holding.service.sender;
 
-import java.util.UUID;
-
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import co.fineants.api.domain.holding.domain.factory.PortfolioSseEventBuilderFactory;
+import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
 import co.fineants.api.domain.holding.domain.message.StreamMessage;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,12 +20,8 @@ public class StreamCompleteMessageSender implements StreamSseMessageSender {
 
 	@Override
 	public void accept(StreamMessage message) {
-		String id = UUID.randomUUID().toString();
-		SseEmitter.SseEventBuilder builder = SseEmitter.event()
-			.id(id)
-			.data(message.getData())
-			.name(message.getEventName())
-			.reconnectTime(reconnectTimeMillis);
+		SseEventBuilderFactory factory = new PortfolioSseEventBuilderFactory(reconnectTimeMillis);
+		SseEmitter.SseEventBuilder builder = factory.create(message);
 		try {
 			emitter.send(builder);
 		} catch (Exception exception) {

--- a/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSender.java
@@ -4,25 +4,19 @@ import java.io.IOException;
 
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
-import co.fineants.api.domain.holding.domain.message.StreamMessage;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class StreamCompleteMessageSender implements StreamSseMessageSender {
 
 	private final SseEmitter emitter;
-	private final SseEventBuilderFactory sseEventBuilderFactory;
 
-	public StreamCompleteMessageSender(SseEmitter emitter,
-		SseEventBuilderFactory sseEventBuilderFactory) {
+	public StreamCompleteMessageSender(SseEmitter emitter) {
 		this.emitter = emitter;
-		this.sseEventBuilderFactory = sseEventBuilderFactory;
 	}
 
 	@Override
-	public void accept(StreamMessage message) {
-		SseEmitter.SseEventBuilder builder = sseEventBuilderFactory.create(message);
+	public void accept(SseEmitter.SseEventBuilder builder) {
 		try {
 			emitter.send(builder);
 		} catch (IOException exception) {

--- a/src/main/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSender.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSender.java
@@ -1,5 +1,7 @@
 package co.fineants.api.domain.holding.service.sender;
 
+import java.io.IOException;
+
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import co.fineants.api.domain.holding.domain.factory.PortfolioSseEventBuilderFactory;
@@ -24,7 +26,7 @@ public class StreamContinuesMessageSender implements StreamSseMessageSender {
 		SseEmitter.SseEventBuilder builder = factory.create(message);
 		try {
 			emitter.send(builder);
-		} catch (Exception exception) {
+		} catch (IOException exception) {
 			log.error("Error sending data to SseEmitter: {}", exception.getMessage(), exception);
 			emitter.completeWithError(exception);
 		}

--- a/src/main/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSender.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSender.java
@@ -4,9 +4,6 @@ import java.io.IOException;
 
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import co.fineants.api.domain.holding.domain.factory.PortfolioSseEventBuilderFactory;
-import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
-import co.fineants.api.domain.holding.domain.message.StreamMessage;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -21,9 +18,7 @@ public class StreamContinuesMessageSender implements StreamSseMessageSender {
 	}
 
 	@Override
-	public void accept(StreamMessage message) {
-		SseEventBuilderFactory factory = new PortfolioSseEventBuilderFactory(reconnectTimeMillis);
-		SseEmitter.SseEventBuilder builder = factory.create(message);
+	public void accept(SseEmitter.SseEventBuilder builder) {
 		try {
 			emitter.send(builder);
 		} catch (IOException exception) {

--- a/src/main/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSender.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSender.java
@@ -1,9 +1,9 @@
 package co.fineants.api.domain.holding.service.sender;
 
-import java.util.UUID;
-
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import co.fineants.api.domain.holding.domain.factory.PortfolioSseEventBuilderFactory;
+import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
 import co.fineants.api.domain.holding.domain.message.StreamMessage;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,13 +20,8 @@ public class StreamContinuesMessageSender implements StreamSseMessageSender {
 
 	@Override
 	public void accept(StreamMessage message) {
-		// todo: 구현체별 중복 제거
-		String id = UUID.randomUUID().toString();
-		SseEmitter.SseEventBuilder builder = SseEmitter.event()
-			.id(id)
-			.data(message.getData())
-			.name(message.getEventName())
-			.reconnectTime(reconnectTimeMillis);
+		SseEventBuilderFactory factory = new PortfolioSseEventBuilderFactory(reconnectTimeMillis);
+		SseEmitter.SseEventBuilder builder = factory.create(message);
 		try {
 			emitter.send(builder);
 		} catch (Exception exception) {

--- a/src/main/java/co/fineants/api/domain/holding/service/sender/StreamSseMessageSender.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/sender/StreamSseMessageSender.java
@@ -2,10 +2,10 @@ package co.fineants.api.domain.holding.service.sender;
 
 import java.util.function.Consumer;
 
-import co.fineants.api.domain.holding.domain.message.StreamMessage;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-public interface StreamSseMessageSender extends Consumer<StreamMessage> {
+public interface StreamSseMessageSender extends Consumer<SseEmitter.SseEventBuilder> {
 
 	@Override
-	void accept(StreamMessage message);
+	void accept(SseEmitter.SseEventBuilder builder);
 }

--- a/src/main/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamer.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamer.java
@@ -13,10 +13,10 @@ public class AlwaysOpenPortfolioStreamer implements PortfolioStreamer {
 	private final Duration interval;
 	private final long maxCount;
 
-	public AlwaysOpenPortfolioStreamer(PortfolioHoldingService portfolioHoldingService, Duration interval,
+	public AlwaysOpenPortfolioStreamer(PortfolioHoldingService portfolioHoldingService, long second,
 		long maxCount) {
 		this.portfolioHoldingService = portfolioHoldingService;
-		this.interval = interval;
+		this.interval = Duration.ofSeconds(second);
 		this.maxCount = maxCount;
 		if (this.maxCount < 0) {
 			throw new IllegalArgumentException("maxCount must be non-negative");

--- a/src/main/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamer.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamer.java
@@ -1,0 +1,35 @@
+package co.fineants.api.domain.holding.service.streamer;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import co.fineants.api.domain.holding.domain.message.StreamMessage;
+import co.fineants.api.domain.holding.service.PortfolioHoldingService;
+import reactor.core.publisher.Flux;
+import reactor.core.scheduler.Schedulers;
+
+public class AlwaysOpenPortfolioStreamer implements PortfolioStreamer {
+	private final PortfolioHoldingService portfolioHoldingService;
+	private final Duration interval;
+	private final long maxCount;
+
+	public AlwaysOpenPortfolioStreamer(PortfolioHoldingService portfolioHoldingService, Duration interval,
+		long maxCount) {
+		this.portfolioHoldingService = portfolioHoldingService;
+		this.interval = interval;
+		this.maxCount = maxCount;
+	}
+
+	@Override
+	public Flux<StreamMessage> streamMessages(Long portfolioId) {
+		return Flux.interval(interval)
+			.take(maxCount)
+			.publishOn(Schedulers.boundedElastic())
+			.map(i -> portfolioHoldingService.getPortfolioReturns(portfolioId));
+	}
+
+	@Override
+	public boolean supports(LocalDateTime time) {
+		return true;
+	}
+}

--- a/src/main/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamer.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamer.java
@@ -18,6 +18,9 @@ public class AlwaysOpenPortfolioStreamer implements PortfolioStreamer {
 		this.portfolioHoldingService = portfolioHoldingService;
 		this.interval = interval;
 		this.maxCount = maxCount;
+		if (this.maxCount < 0) {
+			throw new IllegalArgumentException("maxCount must be non-negative");
+		}
 	}
 
 	@Override

--- a/src/main/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamer.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamer.java
@@ -13,10 +13,10 @@ public class AlwaysOpenPortfolioStreamer implements PortfolioStreamer {
 	private final Duration interval;
 	private final long maxCount;
 
-	public AlwaysOpenPortfolioStreamer(PortfolioHoldingService portfolioHoldingService, long second,
+	public AlwaysOpenPortfolioStreamer(PortfolioHoldingService portfolioHoldingService, long intervalSeconds,
 		long maxCount) {
 		this.portfolioHoldingService = portfolioHoldingService;
-		this.interval = Duration.ofSeconds(second);
+		this.interval = Duration.ofSeconds(intervalSeconds);
 		this.maxCount = maxCount;
 		if (this.maxCount < 0) {
 			throw new IllegalArgumentException("maxCount must be non-negative");

--- a/src/main/java/co/fineants/api/domain/holding/service/streamer/FluxIntervalPortfolioStreamer.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/streamer/FluxIntervalPortfolioStreamer.java
@@ -3,13 +3,9 @@ package co.fineants.api.domain.holding.service.streamer;
 import java.time.Duration;
 import java.time.LocalDateTime;
 
-import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import co.fineants.api.domain.holding.domain.factory.StreamMessageConsumerFactory;
 import co.fineants.api.domain.holding.domain.message.StreamMessage;
 import co.fineants.api.domain.holding.service.PortfolioHoldingService;
 import co.fineants.api.domain.holding.service.market_status_checker.MarketStatusChecker;
-import co.fineants.api.domain.holding.service.sender.StreamSseMessageSender;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.scheduler.Schedulers;
@@ -41,11 +37,5 @@ public class FluxIntervalPortfolioStreamer implements PortfolioStreamer {
 	@Override
 	public boolean supports(LocalDateTime time) {
 		return marketStatusChecker.isOpen(time);
-	}
-
-	@Override
-	public StreamSseMessageSender createStreamSseMessageSender(SseEmitter emitter,
-		StreamMessageConsumerFactory factory) {
-		return factory.createStreamContinuesMessageSender(emitter);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/service/streamer/FluxIntervalPortfolioStreamer.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/streamer/FluxIntervalPortfolioStreamer.java
@@ -19,10 +19,10 @@ public class FluxIntervalPortfolioStreamer implements PortfolioStreamer {
 	private final long maxCount;
 
 	public FluxIntervalPortfolioStreamer(PortfolioHoldingService portfolioHoldingService,
-		MarketStatusChecker marketStatusChecker, long second, long maxCount) {
+		MarketStatusChecker marketStatusChecker, long intervalSeconds, long maxCount) {
 		this.portfolioHoldingService = portfolioHoldingService;
 		this.marketStatusChecker = marketStatusChecker;
-		this.interval = Duration.ofSeconds(second);
+		this.interval = Duration.ofSeconds(intervalSeconds);
 		this.maxCount = maxCount;
 		if (this.maxCount < 0) {
 			throw new IllegalArgumentException("maxCount must be non-negative");

--- a/src/main/java/co/fineants/api/domain/holding/service/streamer/FluxIntervalPortfolioStreamer.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/streamer/FluxIntervalPortfolioStreamer.java
@@ -24,6 +24,9 @@ public class FluxIntervalPortfolioStreamer implements PortfolioStreamer {
 		this.marketStatusChecker = marketStatusChecker;
 		this.interval = Duration.ofSeconds(second);
 		this.maxCount = maxCount;
+		if (this.maxCount < 0) {
+			throw new IllegalArgumentException("maxCount must be non-negative");
+		}
 	}
 
 	@Override

--- a/src/main/java/co/fineants/api/domain/holding/service/streamer/PortfolioStreamer.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/streamer/PortfolioStreamer.java
@@ -15,5 +15,8 @@ public interface PortfolioStreamer {
 
 	boolean supports(LocalDateTime time);
 
-	StreamSseMessageSender createStreamSseMessageSender(SseEmitter emitter, StreamMessageConsumerFactory factory);
+	default StreamSseMessageSender createStreamSseMessageSender(SseEmitter emitter,
+		StreamMessageConsumerFactory factory) {
+		return factory.createStreamContinuesMessageSender(emitter);
+	}
 }

--- a/src/test/java/co/fineants/api/docs/portfolio_holding/PortfolioHoldingRestControllerDocsTest.java
+++ b/src/test/java/co/fineants/api/docs/portfolio_holding/PortfolioHoldingRestControllerDocsTest.java
@@ -43,6 +43,7 @@ import co.fineants.api.domain.holding.domain.entity.PortfolioHolding;
 import co.fineants.api.domain.holding.domain.factory.PortfolioSseEmitterFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamMessageConsumerFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamerFactory;
+import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
 import co.fineants.api.domain.holding.domain.message.StreamMessage;
 import co.fineants.api.domain.holding.service.PortfolioHoldingService;
 import co.fineants.api.domain.holding.service.sender.StreamSseMessageSender;
@@ -76,8 +77,9 @@ class PortfolioHoldingRestControllerDocsTest extends RestDocsSupport {
 			.willReturn(portfolioStreamer);
 		portfolioStreamMessageConsumerFactory = mock(PortfolioStreamMessageConsumerFactory.class);
 		portfolioSseEmitterFactory = mock(PortfolioSseEmitterFactory.class);
+		SseEventBuilderFactory portfolioSseEventBuilderFactory = mock(SseEventBuilderFactory.class);
 		return new PortfolioHoldingRestController(service, portfolioStreamerFactory,
-			portfolioStreamMessageConsumerFactory, portfolioSseEmitterFactory);
+			portfolioStreamMessageConsumerFactory, portfolioSseEmitterFactory, portfolioSseEventBuilderFactory);
 	}
 
 	@BeforeEach

--- a/src/test/java/co/fineants/api/domain/holding/controller/PortfolioHoldingRestControllerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/controller/PortfolioHoldingRestControllerTest.java
@@ -45,6 +45,7 @@ import co.fineants.api.domain.holding.domain.entity.PortfolioHolding;
 import co.fineants.api.domain.holding.domain.factory.PortfolioSseEmitterFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamMessageConsumerFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamerFactory;
+import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
 import co.fineants.api.domain.holding.service.PortfolioHoldingService;
 import co.fineants.api.domain.kis.repository.CurrentPriceMemoryRepository;
 import co.fineants.api.domain.kis.repository.PriceRepository;
@@ -74,8 +75,9 @@ class PortfolioHoldingRestControllerTest extends ControllerTestSupport {
 		PortfolioStreamMessageConsumerFactory portfolioStreamMessageConsumerFactory = mock(
 			PortfolioStreamMessageConsumerFactory.class);
 		PortfolioSseEmitterFactory portfolioSseEmitterFactory = mock(PortfolioSseEmitterFactory.class);
+		SseEventBuilderFactory portfolioSseEventBuilderFactory = mock(SseEventBuilderFactory.class);
 		return new PortfolioHoldingRestController(mockedPortfolioHoldingService, portfolioStreamerFactory,
-			portfolioStreamMessageConsumerFactory, portfolioSseEmitterFactory);
+			portfolioStreamMessageConsumerFactory, portfolioSseEmitterFactory, portfolioSseEventBuilderFactory);
 	}
 
 	@BeforeEach

--- a/src/test/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEmitterFactoryTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEmitterFactoryTest.java
@@ -1,0 +1,21 @@
+package co.fineants.api.domain.holding.domain.factory;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+class PortfolioSseEmitterFactoryTest {
+
+	@DisplayName("SseEmitter 인스턴스를 생성한다")
+	@Test
+	void shouldReturnSseEmitter() {
+		// given
+		long timeout = 30000L;
+		SseEmitterFactory factory = new PortfolioSseEmitterFactory(timeout);
+		// when
+		SseEmitter emitter = factory.create();
+		// then
+		Assertions.assertThat(emitter).isNotNull();
+	}
+}

--- a/src/test/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEventBuilderFactoryTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/domain/factory/PortfolioSseEventBuilderFactoryTest.java
@@ -1,0 +1,41 @@
+package co.fineants.api.domain.holding.domain.factory;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import co.fineants.api.domain.holding.domain.dto.response.PortfolioDetailRealTimeItem;
+import co.fineants.api.domain.holding.domain.dto.response.PortfolioHoldingRealTimeItem;
+import co.fineants.api.domain.holding.domain.message.PortfolioReturnsStreamMessage;
+import co.fineants.api.domain.holding.domain.message.StreamMessage;
+
+class PortfolioSseEventBuilderFactoryTest {
+
+	@DisplayName("SseEventBuilder 인스턴스를 생성한다")
+	@Test
+	void shouldCreatedSseEventBuilder() {
+		// given
+		UuidGenerator uuidGenerator = Mockito.mock(UuidGenerator.class);
+		String uuid = "09b0798d-46cf-4c97-aae5-3a6f0f687aed";
+		BDDMockito.given(uuidGenerator.generate())
+			.willReturn(uuid);
+		long reconnectTimeMillis = 3000L;
+		SseEventBuilderFactory factory = new PortfolioSseEventBuilderFactory(reconnectTimeMillis, uuidGenerator);
+		PortfolioDetailRealTimeItem details = Mockito.mock(PortfolioDetailRealTimeItem.class);
+		List<PortfolioHoldingRealTimeItem> portfolioHoldings = List.of(
+			Mockito.mock(PortfolioHoldingRealTimeItem.class),
+			Mockito.mock(PortfolioHoldingRealTimeItem.class)
+		);
+		StreamMessage message = new PortfolioReturnsStreamMessage(details, portfolioHoldings);
+		// when
+		SseEmitter.SseEventBuilder builder = factory.create(message);
+		// then
+		assertThat(builder).isNotNull();
+	}
+}

--- a/src/test/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSenderTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSenderTest.java
@@ -1,0 +1,39 @@
+package co.fineants.api.domain.holding.service.sender;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import co.fineants.api.domain.holding.domain.message.PortfolioCompleteStreamMessage;
+import co.fineants.api.domain.holding.domain.message.StreamMessage;
+
+class StreamCompleteMessageSenderTest {
+
+	private StreamSseMessageSender sender;
+	private SseEmitter emitter;
+
+	@BeforeEach
+	void setUp() {
+		emitter = Mockito.mock(SseEmitter.class);
+		long reconnectTimeMillis = 3000L;
+		sender = new StreamCompleteMessageSender(emitter, reconnectTimeMillis);
+	}
+
+	@DisplayName("StreamMessage를 SseEmitter로 전송한다.")
+	@Test
+	void givenStreamMessage_whenAcceptMessage_thenSendEmitter() throws IOException {
+		// given
+		StreamMessage message = new PortfolioCompleteStreamMessage();
+		// when
+		sender.accept(message);
+		// then
+		// assert emitter send
+		BDDMockito.verify(emitter).send(ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
+	}
+}

--- a/src/test/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSenderTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSenderTest.java
@@ -1,15 +1,16 @@
 package co.fineants.api.domain.holding.service.sender;
 
+import static org.mockito.BDDMockito.*;
+
 import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatchers;
-import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
 import co.fineants.api.domain.holding.domain.message.PortfolioCompleteStreamMessage;
 import co.fineants.api.domain.holding.domain.message.StreamMessage;
 
@@ -17,12 +18,13 @@ class StreamCompleteMessageSenderTest {
 
 	private StreamSseMessageSender sender;
 	private SseEmitter emitter;
+	private SseEventBuilderFactory sseEventBuilderFactory;
 
 	@BeforeEach
 	void setUp() {
 		emitter = Mockito.mock(SseEmitter.class);
-		long reconnectTimeMillis = 3000L;
-		sender = new StreamCompleteMessageSender(emitter, reconnectTimeMillis);
+		sseEventBuilderFactory = Mockito.mock(SseEventBuilderFactory.class);
+		sender = new StreamCompleteMessageSender(emitter, sseEventBuilderFactory);
 	}
 
 	@DisplayName("StreamMessage를 SseEmitter로 전송한다.")
@@ -30,10 +32,14 @@ class StreamCompleteMessageSenderTest {
 	void givenStreamMessage_whenAcceptMessage_thenSendEmitter() throws IOException {
 		// given
 		StreamMessage message = new PortfolioCompleteStreamMessage();
+		SseEmitter.SseEventBuilder builder = Mockito.mock(SseEmitter.SseEventBuilder.class);
+		given(sseEventBuilderFactory.create(message))
+			.willReturn(builder);
 		// when
 		sender.accept(message);
 		// then
-		// assert emitter send
-		BDDMockito.verify(emitter).send(ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
+		verify(emitter).send(builder);
+		verify(emitter).complete();
+		verify(emitter, never()).completeWithError(any());
 	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSenderTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/sender/StreamCompleteMessageSenderTest.java
@@ -10,33 +10,24 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
-import co.fineants.api.domain.holding.domain.message.PortfolioCompleteStreamMessage;
-import co.fineants.api.domain.holding.domain.message.StreamMessage;
-
 class StreamCompleteMessageSenderTest {
 
 	private StreamSseMessageSender sender;
 	private SseEmitter emitter;
-	private SseEventBuilderFactory sseEventBuilderFactory;
 
 	@BeforeEach
 	void setUp() {
 		emitter = Mockito.mock(SseEmitter.class);
-		sseEventBuilderFactory = Mockito.mock(SseEventBuilderFactory.class);
-		sender = new StreamCompleteMessageSender(emitter, sseEventBuilderFactory);
+		sender = new StreamCompleteMessageSender(emitter);
 	}
 
 	@DisplayName("StreamMessage를 SseEmitter로 전송한다.")
 	@Test
 	void givenStreamMessage_whenAcceptMessage_thenSendEmitter() throws IOException {
 		// given
-		StreamMessage message = new PortfolioCompleteStreamMessage();
 		SseEmitter.SseEventBuilder builder = Mockito.mock(SseEmitter.SseEventBuilder.class);
-		given(sseEventBuilderFactory.create(message))
-			.willReturn(builder);
 		// when
-		sender.accept(message);
+		sender.accept(builder);
 		// then
 		verify(emitter).send(builder);
 		verify(emitter).complete();

--- a/src/test/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSenderTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSenderTest.java
@@ -44,4 +44,21 @@ class StreamContinuesMessageSenderTest {
 		BDDMockito.verify(emitter, never()).complete();
 		BDDMockito.verify(emitter, never()).completeWithError(any());
 	}
+
+	@DisplayName("StreamMessage가 주어지고 IO 예외가 발생하면 SseEmitter를 에러로 완료한다.")
+	@Test
+	void givenStreamMessage_whenRaisedIOEError_thenCompleteWithError() throws IOException {
+		// given
+		StreamMessage message = Mockito.mock(PortfolioReturnsStreamMessage.class);
+		SseEmitter.SseEventBuilder builder = Mockito.mock(SseEmitter.SseEventBuilder.class);
+		given(sseEventBuilderFactory.create(message))
+			.willReturn(builder);
+		IOException exception = new IOException("Test exception");
+		willThrow(exception)
+			.given(emitter).send(ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
+		// when
+		sender.accept(message);
+		// then
+		BDDMockito.verify(emitter).completeWithError(exception);
+	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSenderTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSenderTest.java
@@ -12,20 +12,14 @@ import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
-import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
-import co.fineants.api.domain.holding.domain.message.PortfolioReturnsStreamMessage;
-import co.fineants.api.domain.holding.domain.message.StreamMessage;
-
 class StreamContinuesMessageSenderTest {
 
 	private StreamSseMessageSender sender;
 	private SseEmitter emitter;
-	private SseEventBuilderFactory sseEventBuilderFactory;
 
 	@BeforeEach
 	void setUp() {
 		emitter = Mockito.mock(SseEmitter.class);
-		sseEventBuilderFactory = Mockito.mock(SseEventBuilderFactory.class);
 		sender = new StreamContinuesMessageSender(emitter, 3000L);
 	}
 
@@ -33,12 +27,9 @@ class StreamContinuesMessageSenderTest {
 	@Test
 	void givenStreamMessage_whenAcceptMessage_thenSendSseEventBuilder() throws IOException {
 		// given
-		StreamMessage message = Mockito.mock(PortfolioReturnsStreamMessage.class);
 		SseEmitter.SseEventBuilder builder = Mockito.mock(SseEmitter.SseEventBuilder.class);
-		given(sseEventBuilderFactory.create(message))
-			.willReturn(builder);
 		// when
-		sender.accept(message);
+		sender.accept(builder);
 		// then
 		BDDMockito.verify(emitter).send(ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
 		BDDMockito.verify(emitter, never()).complete();
@@ -49,15 +40,12 @@ class StreamContinuesMessageSenderTest {
 	@Test
 	void givenStreamMessage_whenRaisedInputOutputError_thenCompleteWithError() throws IOException {
 		// given
-		StreamMessage message = Mockito.mock(PortfolioReturnsStreamMessage.class);
 		SseEmitter.SseEventBuilder builder = Mockito.mock(SseEmitter.SseEventBuilder.class);
-		given(sseEventBuilderFactory.create(message))
-			.willReturn(builder);
 		IOException exception = new IOException("Test exception");
 		willThrow(exception)
 			.given(emitter).send(ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
 		// when
-		sender.accept(message);
+		sender.accept(builder);
 		// then
 		BDDMockito.verify(emitter).completeWithError(exception);
 	}

--- a/src/test/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSenderTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSenderTest.java
@@ -47,7 +47,7 @@ class StreamContinuesMessageSenderTest {
 
 	@DisplayName("StreamMessage가 주어지고 IO 예외가 발생하면 SseEmitter를 에러로 완료한다.")
 	@Test
-	void givenStreamMessage_whenRaisedIOEError_thenCompleteWithError() throws IOException {
+	void givenStreamMessage_whenRaisedInputOutputError_thenCompleteWithError() throws IOException {
 		// given
 		StreamMessage message = Mockito.mock(PortfolioReturnsStreamMessage.class);
 		SseEmitter.SseEventBuilder builder = Mockito.mock(SseEmitter.SseEventBuilder.class);

--- a/src/test/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSenderTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/sender/StreamContinuesMessageSenderTest.java
@@ -1,0 +1,47 @@
+package co.fineants.api.domain.holding.service.sender;
+
+import static org.mockito.BDDMockito.*;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
+import co.fineants.api.domain.holding.domain.message.PortfolioReturnsStreamMessage;
+import co.fineants.api.domain.holding.domain.message.StreamMessage;
+
+class StreamContinuesMessageSenderTest {
+
+	private StreamSseMessageSender sender;
+	private SseEmitter emitter;
+	private SseEventBuilderFactory sseEventBuilderFactory;
+
+	@BeforeEach
+	void setUp() {
+		emitter = Mockito.mock(SseEmitter.class);
+		sseEventBuilderFactory = Mockito.mock(SseEventBuilderFactory.class);
+		sender = new StreamContinuesMessageSender(emitter, 3000L);
+	}
+
+	@DisplayName("StreamMessage가 주어지고 메시지를 접수하면 SseEmitter에 SseEventBuilder를 전송한다.")
+	@Test
+	void givenStreamMessage_whenAcceptMessage_thenSendSseEventBuilder() throws IOException {
+		// given
+		StreamMessage message = Mockito.mock(PortfolioReturnsStreamMessage.class);
+		SseEmitter.SseEventBuilder builder = Mockito.mock(SseEmitter.SseEventBuilder.class);
+		given(sseEventBuilderFactory.create(message))
+			.willReturn(builder);
+		// when
+		sender.accept(message);
+		// then
+		BDDMockito.verify(emitter).send(ArgumentMatchers.any(SseEmitter.SseEventBuilder.class));
+		BDDMockito.verify(emitter, never()).complete();
+		BDDMockito.verify(emitter, never()).completeWithError(any());
+	}
+}

--- a/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
@@ -1,7 +1,11 @@
 package co.fineants.api.domain.holding.service.streamer;
 
+import static org.assertj.core.api.Assertions.*;
+
 import java.time.Duration;
 
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
@@ -13,16 +17,24 @@ import reactor.test.StepVerifier;
 
 class AlwaysOpenPortfolioStreamerTest {
 
+	private PortfolioHoldingService portfolioHoldingService;
+	private Long portfolioId;
+	private Duration interval;
+
+	@BeforeEach
+	void setUp() {
+		portfolioHoldingService = Mockito.mock(PortfolioHoldingService.class);
+		portfolioId = 1L;
+		StreamMessage message = Mockito.mock(StreamMessage.class);
+		BDDMockito.given(portfolioHoldingService.getPortfolioReturns(portfolioId))
+			.willReturn(message);
+		interval = Duration.ofSeconds(5);
+	}
+
 	@DisplayName("반드시 열려있는 포트폴리오 스트리머는 주어진 간격과 최대 개수에 따라 메시지를 스트리밍한다.")
 	@Test
 	void streamMessages_ShouldReturnStreamOfMessages() {
 		// given
-		PortfolioHoldingService portfolioHoldingService = Mockito.mock(PortfolioHoldingService.class);
-		Long portfolioId = 1L;
-		StreamMessage message = Mockito.mock(StreamMessage.class);
-		BDDMockito.given(portfolioHoldingService.getPortfolioReturns(portfolioId))
-			.willReturn(message);
-		Duration interval = Duration.ofSeconds(5);
 		long maxCount = 6L;
 		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount);
 		// when & then
@@ -36,17 +48,24 @@ class AlwaysOpenPortfolioStreamerTest {
 	@Test
 	void givenPortfolioStreamer_whenMaxCountIsZero_thenReturnEmptyFlux() {
 		// given
-		PortfolioHoldingService portfolioHoldingService = Mockito.mock(PortfolioHoldingService.class);
-		Long portfolioId = 1L;
-		StreamMessage message = Mockito.mock(StreamMessage.class);
-		BDDMockito.given(portfolioHoldingService.getPortfolioReturns(portfolioId))
-			.willReturn(message);
-		Duration interval = Duration.ofSeconds(5);
 		long maxCount = 0L;
 		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount);
 		// when & then
 		StepVerifier.withVirtualTime(() -> streamer.streamMessages(portfolioId))
 			.expectNextCount(0L)
 			.verifyComplete();
+	}
+
+	@DisplayName("maxCount의 값이 음수인 경우 예외를 발생시킨다")
+	@Test
+	void givenNegativeMaxCount_whenCreateInstance_thenThrowException() {
+		// given
+		long maxCount = -1;
+		// when
+		Throwable throwable = catchThrowable(
+			() -> new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount));
+		// then
+		Assertions.assertThat(throwable)
+			.isInstanceOf(IllegalArgumentException.class);
 	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
@@ -3,6 +3,7 @@ package co.fineants.api.domain.holding.service.streamer;
 import static org.assertj.core.api.Assertions.*;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -67,5 +68,17 @@ class AlwaysOpenPortfolioStreamerTest {
 		// then
 		Assertions.assertThat(throwable)
 			.isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@DisplayName("구현체 타입이 AlwaysOpenPortfolioStreamer인 경우 일자, 시간, 공휴일 상관없이 언제나 true를 반환한다")
+	@Test
+	void givenPortfolioStreamer_whenAlwaysOpenPortfolioStreamer_thenReturnTrue() {
+		// given
+		long maxCount = 6L;
+		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount);
+		// when
+		boolean supports = streamer.supports(LocalDateTime.now());
+		// then
+		Assertions.assertThat(supports).isTrue();
 	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
@@ -31,4 +31,22 @@ class AlwaysOpenPortfolioStreamerTest {
 			.expectNextCount(maxCount)
 			.verifyComplete();
 	}
+
+	@DisplayName("개수가 0개인 경우 빈 Flux를 반환한다")
+	@Test
+	void givenPortfolioStreamer_whenMaxCountIsZero_thenReturnEmptyFlux() {
+		// given
+		PortfolioHoldingService portfolioHoldingService = Mockito.mock(PortfolioHoldingService.class);
+		Long portfolioId = 1L;
+		StreamMessage message = Mockito.mock(StreamMessage.class);
+		BDDMockito.given(portfolioHoldingService.getPortfolioReturns(portfolioId))
+			.willReturn(message);
+		Duration interval = Duration.ofSeconds(5);
+		long maxCount = 0L;
+		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount);
+		// when & then
+		StepVerifier.withVirtualTime(() -> streamer.streamMessages(portfolioId))
+			.expectNextCount(0L)
+			.verifyComplete();
+	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
@@ -24,7 +24,7 @@ class AlwaysOpenPortfolioStreamerTest {
 
 	private PortfolioHoldingService portfolioHoldingService;
 	private Long portfolioId;
-	private Duration interval;
+	private long second;
 	private long maxCount;
 
 	@BeforeEach
@@ -34,7 +34,7 @@ class AlwaysOpenPortfolioStreamerTest {
 		StreamMessage message = Mockito.mock(StreamMessage.class);
 		BDDMockito.given(portfolioHoldingService.getPortfolioReturns(portfolioId))
 			.willReturn(message);
-		interval = Duration.ofSeconds(5);
+		second = 5;
 		maxCount = 6L;
 	}
 
@@ -42,10 +42,10 @@ class AlwaysOpenPortfolioStreamerTest {
 	@Test
 	void streamMessages_ShouldReturnStreamOfMessages() {
 		// given
-		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount);
+		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, second, maxCount);
 		// when & then
 		StepVerifier.withVirtualTime(() -> streamer.streamMessages(portfolioId))
-			.thenAwait(interval.multipliedBy(maxCount))
+			.thenAwait(Duration.ofSeconds(second * maxCount))
 			.expectNextCount(maxCount)
 			.verifyComplete();
 	}
@@ -55,7 +55,7 @@ class AlwaysOpenPortfolioStreamerTest {
 	void givenPortfolioStreamer_whenMaxCountIsZero_thenReturnEmptyFlux() {
 		// given
 		maxCount = 0L;
-		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount);
+		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, second, maxCount);
 		// when & then
 		StepVerifier.withVirtualTime(() -> streamer.streamMessages(portfolioId))
 			.expectNextCount(0L)
@@ -69,7 +69,7 @@ class AlwaysOpenPortfolioStreamerTest {
 		maxCount = -1;
 		// when
 		Throwable throwable = catchThrowable(
-			() -> new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount));
+			() -> new AlwaysOpenPortfolioStreamer(portfolioHoldingService, second, maxCount));
 		// then
 		Assertions.assertThat(throwable)
 			.isInstanceOf(IllegalArgumentException.class);
@@ -79,7 +79,7 @@ class AlwaysOpenPortfolioStreamerTest {
 	@Test
 	void givenPortfolioStreamer_whenAlwaysOpenPortfolioStreamer_thenReturnTrue() {
 		// given
-		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount);
+		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, second, maxCount);
 		// when
 		boolean supports = streamer.supports(LocalDateTime.now());
 		// then
@@ -90,7 +90,7 @@ class AlwaysOpenPortfolioStreamerTest {
 	@Test
 	void givenPortfolioStreamer_whenAlwaysOpenPortfolioStreamer_thenReturnStreamContinuesMessageSender() {
 		// given
-		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount);
+		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, second, maxCount);
 		SseEmitter emitter = Mockito.mock(SseEmitter.class);
 		StreamMessageConsumerFactory factory = Mockito.mock(StreamMessageConsumerFactory.class);
 		BDDMockito.given(factory.createStreamContinuesMessageSender(emitter))

--- a/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/streamer/AlwaysOpenPortfolioStreamerTest.java
@@ -1,0 +1,34 @@
+package co.fineants.api.domain.holding.service.streamer;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito;
+import org.mockito.Mockito;
+
+import co.fineants.api.domain.holding.domain.message.StreamMessage;
+import co.fineants.api.domain.holding.service.PortfolioHoldingService;
+import reactor.test.StepVerifier;
+
+class AlwaysOpenPortfolioStreamerTest {
+
+	@DisplayName("반드시 열려있는 포트폴리오 스트리머는 주어진 간격과 최대 개수에 따라 메시지를 스트리밍한다.")
+	@Test
+	void streamMessages_ShouldReturnStreamOfMessages() {
+		// given
+		PortfolioHoldingService portfolioHoldingService = Mockito.mock(PortfolioHoldingService.class);
+		Long portfolioId = 1L;
+		StreamMessage message = Mockito.mock(StreamMessage.class);
+		BDDMockito.given(portfolioHoldingService.getPortfolioReturns(portfolioId))
+			.willReturn(message);
+		Duration interval = Duration.ofSeconds(5);
+		long maxCount = 6L;
+		PortfolioStreamer streamer = new AlwaysOpenPortfolioStreamer(portfolioHoldingService, interval, maxCount);
+		// when & then
+		StepVerifier.withVirtualTime(() -> streamer.streamMessages(portfolioId))
+			.thenAwait(interval.multipliedBy(maxCount))
+			.expectNextCount(maxCount)
+			.verifyComplete();
+	}
+}

--- a/src/test/java/co/fineants/config/ControllerTestConfig.java
+++ b/src/test/java/co/fineants/config/ControllerTestConfig.java
@@ -7,6 +7,7 @@ import co.fineants.api.domain.fcm.service.FcmService;
 import co.fineants.api.domain.holding.domain.factory.PortfolioSseEmitterFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamMessageConsumerFactory;
 import co.fineants.api.domain.holding.domain.factory.PortfolioStreamerFactory;
+import co.fineants.api.domain.holding.domain.factory.SseEventBuilderFactory;
 import co.fineants.api.domain.holding.service.PortfolioHoldingService;
 import co.fineants.api.domain.holding.service.market_status_checker.MarketStatusCheckerRule;
 import co.fineants.api.domain.holding.service.streamer.PortfolioStreamer;
@@ -89,4 +90,7 @@ public class ControllerTestConfig {
 
 	@MockBean
 	private PortfolioSseEmitterFactory portfolioSseEmitterFactory;
+
+	@MockBean
+	private SseEventBuilderFactory sseEventBuilderFactory;
 }


### PR DESCRIPTION
## 구현한 것

- SseEventBuilder 객체를 생성하는 중복 로직을 제거하였습니다.
- 주식장 시간에 상관없이 포트폴리오의 수익율을 스트리밍하는 구현체를 확장하였습니다. 해당 구현체를 생성한 이유는 로컬 개발 환경에서 SSE 포트폴리오 수익율 테스트를 하기 위함
- SseEventBuilderFactory 인터페이스를 생성하여 객체 생성 중복 로직을 제거하였습니다.

## todo
- 해당 리팩토링으로 인하여 추가된 클래스들의 단위 테스트 구현
