### PR TITLE
[feat] MarketStatusCheker 기능 추가

### DIFF
--- a/src/main/java/co/fineants/api/domain/holding/config/MarketStatusCheckerConfig.java
+++ b/src/main/java/co/fineants/api/domain/holding/config/MarketStatusCheckerConfig.java
@@ -7,7 +7,7 @@ import co.fineants.api.domain.holding.service.market_status_checker.HolidayMarke
 import co.fineants.api.domain.holding.service.market_status_checker.KoreanMarketStatusChecker;
 import co.fineants.api.domain.holding.service.market_status_checker.TimeMarketStatusCheckerRule;
 import co.fineants.api.domain.holding.service.market_status_checker.WeekdayMarketStatusCheckerRule;
-import co.fineants.api.domain.holding.service.market_status_checker.time_range.MarketTimeRange;
+import co.fineants.api.domain.holding.service.market_status_checker.time_range.KoreanMarketTimeRange;
 import co.fineants.api.domain.holding.service.market_status_checker.time_range.TimeRange;
 import co.fineants.api.domain.holiday.repository.HolidayRepository;
 
@@ -15,7 +15,7 @@ import co.fineants.api.domain.holiday.repository.HolidayRepository;
 public class MarketStatusCheckerConfig {
 	@Bean
 	public TimeMarketStatusCheckerRule timeMarketStatusCheckerRule() {
-		TimeRange timeRange = new MarketTimeRange();
+		TimeRange timeRange = new KoreanMarketTimeRange();
 		return new TimeMarketStatusCheckerRule(timeRange);
 	}
 

--- a/src/main/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusChecker.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusChecker.java
@@ -8,7 +8,15 @@ public class KoreanMarketStatusChecker implements MarketStatusChecker {
 
 	private final List<MarketStatusCheckerRule> rules;
 
-	public KoreanMarketStatusChecker(MarketStatusCheckerRule... rules) {
+	/**
+	 * KoreanMarketStatusChecker 생성자
+	 * @param rules 시장 상태를 확인하기 위한 규칙 배열
+	 * @throws IllegalArgumentException rules 배열이 null이거나 비어있으면 IllegalArgumentException을 발생시킴
+	 */
+	public KoreanMarketStatusChecker(MarketStatusCheckerRule... rules) throws IllegalArgumentException {
+		if (rules == null || rules.length == 0) {
+			throw new IllegalArgumentException("At least one rule must be provided");
+		}
 		this.rules = Arrays.asList(rules);
 	}
 

--- a/src/main/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusChecker.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusChecker.java
@@ -17,4 +17,9 @@ public class KoreanMarketStatusChecker implements MarketStatusChecker {
 		return rules.stream()
 			.allMatch(rule -> rule.isOpen(dateTime));
 	}
+
+	@Override
+	public boolean isClose(LocalDateTime dateTime) {
+		return rules.stream().anyMatch(rule -> rule.isClose(dateTime));
+	}
 }

--- a/src/main/java/co/fineants/api/domain/holding/service/market_status_checker/MarketStatusChecker.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/market_status_checker/MarketStatusChecker.java
@@ -4,4 +4,6 @@ import java.time.LocalDateTime;
 
 public interface MarketStatusChecker {
 	boolean isOpen(LocalDateTime dateTime);
+
+	boolean isClose(LocalDateTime dateTime);
 }

--- a/src/main/java/co/fineants/api/domain/holding/service/market_status_checker/time_range/KoreanMarketTimeRange.java
+++ b/src/main/java/co/fineants/api/domain/holding/service/market_status_checker/time_range/KoreanMarketTimeRange.java
@@ -2,11 +2,11 @@ package co.fineants.api.domain.holding.service.market_status_checker.time_range;
 
 import java.time.LocalTime;
 
-public class MarketTimeRange implements TimeRange {
+public class KoreanMarketTimeRange implements TimeRange {
 	private final LocalTime openTime;
 	private final LocalTime closeTime;
 
-	public MarketTimeRange() {
+	public KoreanMarketTimeRange() {
 		openTime = LocalTime.of(9, 0);
 		closeTime = LocalTime.of(15, 30);
 	}

--- a/src/test/java/co/fineants/api/domain/holding/service/TimeMarketStatusCheckerRuleTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/TimeMarketStatusCheckerRuleTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 import co.fineants.api.domain.holding.service.market_status_checker.MarketStatusCheckerRule;
 import co.fineants.api.domain.holding.service.market_status_checker.TimeMarketStatusCheckerRule;
-import co.fineants.api.domain.holding.service.market_status_checker.time_range.MarketTimeRange;
+import co.fineants.api.domain.holding.service.market_status_checker.time_range.KoreanMarketTimeRange;
 import co.fineants.api.domain.holding.service.market_status_checker.time_range.TimeRange;
 
 class TimeMarketStatusCheckerRuleTest {
@@ -39,7 +39,7 @@ class TimeMarketStatusCheckerRuleTest {
 
 	@BeforeEach
 	void setUp() {
-		TimeRange timeRange = new MarketTimeRange();
+		TimeRange timeRange = new KoreanMarketTimeRange();
 		checker = new TimeMarketStatusCheckerRule(timeRange);
 	}
 

--- a/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
@@ -85,7 +85,7 @@ class KoreanMarketStatusCheckerTest {
 			.hasMessage("At least one rule must be provided");
 	}
 
-	@DisplayName("정규시간 내에서는 true를 반환한다.")
+	@DisplayName("정규시간 외에서는 true를 반환한다.")
 	@ParameterizedTest(name = "{index} : {0} ({1})")
 	@MethodSource(value = "notRegularDateTimeSource")
 	void isClose_shouldReturnFalse_whenDateTimeIsNotInRegularTime(LocalDateTime dateTime, String ignoredDescription) {
@@ -95,5 +95,17 @@ class KoreanMarketStatusCheckerTest {
 		boolean isClose = checker.isClose(dateTime);
 		// then
 		Assertions.assertThat(isClose).isTrue();
+	}
+
+	@DisplayName("정규시간 내에서는 false를 반환한다.")
+	@ParameterizedTest(name = "{index} : {0} ({1})")
+	@MethodSource(value = "regularDateTimeSource")
+	void isClose_shouldReturnFalse_whenDateTimeIsInRegularTime(LocalDateTime dateTime, String ignoredDescription) {
+		// given
+		MarketStatusChecker checker = new KoreanMarketStatusChecker(rule);
+		// when
+		boolean isClose = checker.isClose(dateTime);
+		// then
+		Assertions.assertThat(isClose).isFalse();
 	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
@@ -6,7 +6,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import co.fineants.api.domain.holding.service.market_status_checker.time_range.MarketTimeRange;
+import co.fineants.api.domain.holding.service.market_status_checker.time_range.KoreanMarketTimeRange;
 import co.fineants.api.domain.holding.service.market_status_checker.time_range.TimeRange;
 
 class KoreanMarketStatusCheckerTest {
@@ -15,7 +15,7 @@ class KoreanMarketStatusCheckerTest {
 	@Test
 	void shouldReturnTrue_whenDateTimeIsInRegularTime() {
 		// given
-		TimeRange regularTimeRange = new MarketTimeRange();
+		TimeRange regularTimeRange = new KoreanMarketTimeRange();
 		MarketStatusCheckerRule rule = new TimeMarketStatusCheckerRule(regularTimeRange);
 		MarketStatusChecker checker = new KoreanMarketStatusChecker(rule);
 		LocalDateTime dateTime = LocalDateTime.of(2025, 6, 10, 9, 0);

--- a/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
@@ -1,15 +1,26 @@
 package co.fineants.api.domain.holding.service.market_status_checker;
 
 import java.time.LocalDateTime;
+import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import co.fineants.api.domain.holding.service.market_status_checker.time_range.KoreanMarketTimeRange;
 import co.fineants.api.domain.holding.service.market_status_checker.time_range.TimeRange;
 
 class KoreanMarketStatusCheckerTest {
+
+	public static Stream<Arguments> invalidMarketStatusCheckerRules() {
+		return Stream.of(
+			Arguments.of((Object)null),
+			Arguments.of((Object)new MarketStatusCheckerRule[0])
+		);
+	}
 
 	@DisplayName("정규시간 내에서는 true를 반환한다.")
 	@Test
@@ -25,5 +36,16 @@ class KoreanMarketStatusCheckerTest {
 		Assertions.assertThat(isOpen).isTrue();
 	}
 
-	// todo: 규칙이 아무것도 없으면 false를 반환해야 한다
+	@DisplayName("MarketStatusChecker 생성시 빈 배열이나 null을 전달하면 객체 생성시 인스턴스가 발생한다")
+	@ParameterizedTest
+	@MethodSource(value = "invalidMarketStatusCheckerRules")
+	void shouldReturnFalse_whenEmptyCheckerRule(MarketStatusCheckerRule[] rules) {
+		// given
+		// when
+		Throwable throwable = Assertions.catchThrowable(() -> new KoreanMarketStatusChecker(rules));
+		// then
+		Assertions.assertThat(throwable)
+			.isInstanceOf(IllegalArgumentException.class)
+			.hasMessage("At least one rule must be provided");
+	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
@@ -1,0 +1,29 @@
+package co.fineants.api.domain.holding.service.market_status_checker;
+
+import java.time.LocalDateTime;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import co.fineants.api.domain.holding.service.market_status_checker.time_range.MarketTimeRange;
+import co.fineants.api.domain.holding.service.market_status_checker.time_range.TimeRange;
+
+class KoreanMarketStatusCheckerTest {
+
+	@DisplayName("정규시간 내에서는 true를 반환한다.")
+	@Test
+	void shouldReturnTrue_whenDateTimeIsInRegularTime() {
+		// given
+		TimeRange regularTimeRange = new MarketTimeRange();
+		MarketStatusCheckerRule rule = new TimeMarketStatusCheckerRule(regularTimeRange);
+		MarketStatusChecker checker = new KoreanMarketStatusChecker(rule);
+		LocalDateTime dateTime = LocalDateTime.of(2025, 6, 10, 9, 0);
+		// when
+		boolean isOpen = checker.isOpen(dateTime);
+		// then
+		Assertions.assertThat(isOpen).isTrue();
+	}
+
+	// todo: 규칙이 아무것도 없으면 false를 반환해야 한다
+}

--- a/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
@@ -182,4 +182,23 @@ class KoreanMarketStatusCheckerTest {
 		// then
 		Assertions.assertThat(isOpen).isFalse();
 	}
+
+	@DisplayName("공휴일인 경우에는 true를 반환한다")
+	@ParameterizedTest
+	@MethodSource(value = "regularDateTimeSource")
+	void isClose_shouldReturnTrue_whenHoliday(LocalDateTime dateTime) {
+		// given
+		MarketStatusCheckerRule weekdayRule = new WeekdayMarketStatusCheckerRule();
+		HolidayRepository holidayRepository = Mockito.mock(HolidayRepository.class);
+		LocalDate holidayDate = dateTime.toLocalDate();
+		Holiday holiday = Holiday.close(holidayDate);
+		BDDMockito.given(holidayRepository.findByBaseDate(holidayDate))
+			.willReturn(Optional.of(holiday));
+		MarketStatusCheckerRule holidayRule = new HolidayMarketStatusCheckerRule(holidayRepository);
+		MarketStatusChecker checker = new KoreanMarketStatusChecker(rule, weekdayRule, holidayRule);
+		// when
+		boolean isClose = checker.isClose(dateTime);
+		// then
+		Assertions.assertThat(isClose).isTrue();
+	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
@@ -108,4 +108,18 @@ class KoreanMarketStatusCheckerTest {
 		// then
 		Assertions.assertThat(isClose).isFalse();
 	}
+
+	@DisplayName("평일 정규시간 내에서는 true를 반환한다")
+	@ParameterizedTest
+	@MethodSource(value = "regularDateTimeSource")
+	void isOpen_shouldReturnTrue_whenWeekDayAndDateTimeIsInRegularTime(LocalDateTime dateTime,
+		String ignoredDescription) {
+		// given
+		MarketStatusCheckerRule weekdayRule = new WeekdayMarketStatusCheckerRule();
+		MarketStatusChecker checker = new KoreanMarketStatusChecker(rule, weekdayRule);
+		// when
+		boolean isOpen = checker.isOpen(dateTime);
+		// then
+		Assertions.assertThat(isOpen).isTrue();
+	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
@@ -42,6 +42,27 @@ class KoreanMarketStatusCheckerTest {
 		);
 	}
 
+	public static Stream<Arguments> weekendDateTimeSource() {
+		return Stream.of(
+			Arguments.of(LocalDateTime.of(2025, 6, 14, 8, 59), "토요일 정규시간 이전"),
+			Arguments.of(LocalDateTime.of(2025, 6, 14, 15, 31), "토요일 정규시간 이후"),
+			Arguments.of(LocalDateTime.of(2025, 6, 14, 0, 0), "토요일 정규시간 이전 (자정)"),
+			Arguments.of(LocalDateTime.of(2025, 6, 14, 23, 59), "토요일 정규시간 이후 (23시59분)"),
+			Arguments.of(LocalDateTime.of(2025, 6, 15, 8, 59), "일요일 정규시간 이전"),
+			Arguments.of(LocalDateTime.of(2025, 6, 15, 15, 31), "일요일 정규시간 이후"),
+			Arguments.of(LocalDateTime.of(2025, 6, 15, 0, 0), "일요일 정규시간 이전 (자정)"),
+			Arguments.of(LocalDateTime.of(2025, 6, 15, 23, 59), "일요일 정규시간 이후 (23시59분)"),
+			Arguments.of(LocalDateTime.of(2025, 6, 14, 8, 59), "토요일 정규시간 이전"),
+			Arguments.of(LocalDateTime.of(2025, 6, 14, 15, 31), "토요일 정규시간 이후"),
+			Arguments.of(LocalDateTime.of(2025, 6, 14, 0, 0), "토요일 정규시간 이전 (자정)"),
+			Arguments.of(LocalDateTime.of(2025, 6, 14, 23, 59), "토요일 정규시간 이후 (23시59분)"),
+			Arguments.of(LocalDateTime.of(2025, 6, 15, 8, 59), "일요일 정규시간 이전"),
+			Arguments.of(LocalDateTime.of(2025, 6, 15, 15, 31), "일요일 정규시간 이후"),
+			Arguments.of(LocalDateTime.of(2025, 6, 15, 0, 0), "일요일 정규시간 이전 (자정)"),
+			Arguments.of(LocalDateTime.of(2025, 6, 15, 23, 59), "일요일 정규시간 이후 (23시59분)")
+		);
+	}
+
 	@BeforeEach
 	void setUp() {
 		TimeRange regularTimeRange = new KoreanMarketTimeRange();
@@ -121,5 +142,19 @@ class KoreanMarketStatusCheckerTest {
 		boolean isOpen = checker.isOpen(dateTime);
 		// then
 		Assertions.assertThat(isOpen).isTrue();
+	}
+
+	@DisplayName("주말시간에서는 false를 반환한다")
+	@ParameterizedTest
+	@MethodSource(value = "weekendDateTimeSource")
+	void isOpen_shouldReturnFalse_whenWeekendAndDateTimeIsInRegularTime(LocalDateTime dateTime,
+		String ignoredDescription) {
+		// given
+		MarketStatusCheckerRule weekdayRule = new WeekdayMarketStatusCheckerRule();
+		MarketStatusChecker checker = new KoreanMarketStatusChecker(rule, weekdayRule);
+		// when
+		boolean isOpen = checker.isOpen(dateTime);
+		// then
+		Assertions.assertThat(isOpen).isFalse();
 	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/market_status_checker/KoreanMarketStatusCheckerTest.java
@@ -5,7 +5,6 @@ import java.util.stream.Stream;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -22,14 +21,23 @@ class KoreanMarketStatusCheckerTest {
 		);
 	}
 
+	public static Stream<Arguments> regularDateTimeSource() {
+		return Stream.of(
+			Arguments.of(LocalDateTime.of(2025, 6, 10, 9, 0), "정규시간 시작"),
+			Arguments.of(LocalDateTime.of(2025, 6, 10, 15, 30), "정규시간 종료"),
+			Arguments.of(LocalDateTime.of(2025, 6, 10, 12, 0), "정규시간 중간"),
+			Arguments.of(LocalDateTime.of(2025, 6, 10, 10, 30), "정규시간 중간")
+		);
+	}
+
 	@DisplayName("정규시간 내에서는 true를 반환한다.")
-	@Test
-	void shouldReturnTrue_whenDateTimeIsInRegularTime() {
+	@ParameterizedTest(name = "{index} : {0} ({1})")
+	@MethodSource(value = "regularDateTimeSource")
+	void shouldReturnTrue_whenDateTimeIsInRegularTime(LocalDateTime dateTime, String ignoredDescription) {
 		// given
 		TimeRange regularTimeRange = new KoreanMarketTimeRange();
 		MarketStatusCheckerRule rule = new TimeMarketStatusCheckerRule(regularTimeRange);
 		MarketStatusChecker checker = new KoreanMarketStatusChecker(rule);
-		LocalDateTime dateTime = LocalDateTime.of(2025, 6, 10, 9, 0);
 		// when
 		boolean isOpen = checker.isOpen(dateTime);
 		// then


### PR DESCRIPTION
## 구현한 것

- MarketStatusChecker 인터페이스에 isClose 메서드 정의 및 구현
- KoreanMarketStatusChecker 구현체의 isOpen(), isClose() 메서드에 대한 단위 테스트 추가

## issues
- close #633 