### PR TITLE
[refactor] 기존 포트폴리오 종목 생성 메서드 수정

### DIFF
--- a/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingFacadeTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingFacadeTest.java
@@ -138,4 +138,30 @@ class PortfolioHoldingFacadeTest extends AbstractContainerBaseTest {
 		Assertions.assertThat(purchaseHistoryRepository.findAllByPortfolioHoldingId(portfolioHolding.getId()))
 			.hasSize(1);
 	}
+
+	@DisplayName("포트폴리오 종목과 매입 이력 추가시 매입 이력 필수 입력 정보를 넣지 않으면 포트폴리오 종목만 추가된다")
+	@Test
+	void createPortfolioHolding_whenInvalidPurchaseHistory_thenSaveOnlyPortfolioHolding() {
+		Member member = memberRepository.save(createMember());
+		setAuthentication(member);
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock samsung = stockRepository.save(createSamsungStock());
+
+		PurchaseHistoryCreateRequest purchaseHistoryCreateRequest = PurchaseHistoryCreateRequest.create(
+			null,
+			null,
+			null,
+			null
+		);
+		PortfolioHoldingCreateRequest request = PortfolioHoldingCreateRequest.create(samsung.getTickerSymbol(),
+			purchaseHistoryCreateRequest);
+		// when
+		PortfolioHolding portfolioHolding = portfolioHoldingFacade.createPortfolioHolding(request, portfolio.getId());
+
+		// then
+		Assertions.assertThat(portfolioHolding).isNotNull();
+		Assertions.assertThat(portfolioHoldingRepository.findAllByPortfolio(portfolio)).hasSize(1);
+		Assertions.assertThat(purchaseHistoryRepository.findAllByPortfolioHoldingId(portfolioHolding.getId()))
+			.isEmpty();
+	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingFacadeTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingFacadeTest.java
@@ -17,6 +17,7 @@ import co.fineants.api.domain.member.repository.MemberRepository;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.domain.portfolio.repository.PortfolioRepository;
 import co.fineants.api.domain.purchasehistory.domain.dto.request.PurchaseHistoryCreateRequest;
+import co.fineants.api.domain.purchasehistory.repository.PurchaseHistoryRepository;
 import co.fineants.api.domain.stock.domain.entity.Stock;
 import co.fineants.api.domain.stock.repository.StockRepository;
 import co.fineants.api.global.errors.exception.business.ForbiddenException;
@@ -34,6 +35,9 @@ class PortfolioHoldingFacadeTest extends AbstractContainerBaseTest {
 
 	@Autowired
 	private StockRepository stockRepository;
+
+	@Autowired
+	private PurchaseHistoryRepository purchaseHistoryRepository;
 
 	@DisplayName("사용자는 다른 사용자의 포트폴리오를 대상으로 포트폴리오 종목을 추가할 수 없다")
 	@Test
@@ -61,6 +65,7 @@ class PortfolioHoldingFacadeTest extends AbstractContainerBaseTest {
 			.isInstanceOf(ForbiddenException.class);
 	}
 
+	@DisplayName("포트폴리오 종목 생성 시 매입 이력 생성 요청이 null인 경우, 포트폴리오 종목만 저장한다")
 	@Test
 	void createPortfolioHolding_whenOnlyPortfolioHolding_thenSavePortfolioHolding() {
 		// given
@@ -75,5 +80,31 @@ class PortfolioHoldingFacadeTest extends AbstractContainerBaseTest {
 
 		// then
 		Assertions.assertThat(portfolioHolding).isNotNull();
+	}
+
+	@DisplayName("포트폴리오 종목 생성 시 매입 이력 생성 요청이 null이 아닌 경우, 포트폴리오 종목과 매입 이력을 저장한다")
+	@Test
+	void createPortfolioHolding_whenPurchaseHistoryCreateRequestIsNotNull_thenSavePortfolioHoldingAndPurchaseHistory() {
+		// given
+		Member member = memberRepository.save(createMember());
+		setAuthentication(member);
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock samsung = stockRepository.save(createSamsungStock());
+
+		PurchaseHistoryCreateRequest purchaseHistoryCreateRequest = PurchaseHistoryCreateRequest.create(
+			LocalDateTime.now(),
+			Count.from(3),
+			Money.won(50_000),
+			"memo"
+		);
+		PortfolioHoldingCreateRequest request = PortfolioHoldingCreateRequest.create(samsung.getTickerSymbol(),
+			purchaseHistoryCreateRequest);
+		// when
+		PortfolioHolding portfolioHolding = portfolioHoldingFacade.createPortfolioHolding(request, portfolio.getId());
+
+		// then
+		Assertions.assertThat(portfolioHolding).isNotNull();
+		Assertions.assertThat(purchaseHistoryRepository.findAllByPortfolioHoldingId(portfolioHolding.getId()))
+			.hasSize(1);
 	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingFacadeTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingFacadeTest.java
@@ -11,11 +11,14 @@ import co.fineants.AbstractContainerBaseTest;
 import co.fineants.api.domain.common.count.Count;
 import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.holding.domain.dto.request.PortfolioHoldingCreateRequest;
+import co.fineants.api.domain.holding.domain.entity.PortfolioHolding;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.member.repository.MemberRepository;
 import co.fineants.api.domain.portfolio.domain.entity.Portfolio;
 import co.fineants.api.domain.portfolio.repository.PortfolioRepository;
 import co.fineants.api.domain.purchasehistory.domain.dto.request.PurchaseHistoryCreateRequest;
+import co.fineants.api.domain.stock.domain.entity.Stock;
+import co.fineants.api.domain.stock.repository.StockRepository;
 import co.fineants.api.global.errors.exception.business.ForbiddenException;
 
 class PortfolioHoldingFacadeTest extends AbstractContainerBaseTest {
@@ -28,6 +31,9 @@ class PortfolioHoldingFacadeTest extends AbstractContainerBaseTest {
 
 	@Autowired
 	private PortfolioRepository portfolioRepository;
+
+	@Autowired
+	private StockRepository stockRepository;
 
 	@DisplayName("사용자는 다른 사용자의 포트폴리오를 대상으로 포트폴리오 종목을 추가할 수 없다")
 	@Test
@@ -53,5 +59,21 @@ class PortfolioHoldingFacadeTest extends AbstractContainerBaseTest {
 		// then
 		Assertions.assertThat(throwable)
 			.isInstanceOf(ForbiddenException.class);
+	}
+
+	@Test
+	void createPortfolioHolding_whenOnlyPortfolioHolding_thenSavePortfolioHolding() {
+		// given
+		Member member = memberRepository.save(createMember());
+		setAuthentication(member);
+		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
+		Stock samsung = stockRepository.save(createSamsungStock());
+
+		PortfolioHoldingCreateRequest request = PortfolioHoldingCreateRequest.create(samsung.getTickerSymbol(), null);
+		// when
+		PortfolioHolding portfolioHolding = portfolioHoldingFacade.createPortfolioHolding(request, portfolio.getId());
+
+		// then
+		Assertions.assertThat(portfolioHolding).isNotNull();
 	}
 }

--- a/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingFacadeTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingFacadeTest.java
@@ -114,7 +114,7 @@ class PortfolioHoldingFacadeTest extends AbstractContainerBaseTest {
 
 	@DisplayName("기존 포트폴리오 종목이 있는 상태에서 매입 이력과 같이 포트폴리오 종목을 같이 생성 요청 시, 매입 이력을 추가한다")
 	@Test
-	void whenExistPortfolioHolding_thenSavePurchaseHistory() {
+	void createPortfolioHolding_whenExistPortfolioHolding_thenSavePurchaseHistory() {
 		Member member = memberRepository.save(createMember());
 		setAuthentication(member);
 		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));

--- a/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 
 import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.AfterEach;
@@ -31,7 +30,6 @@ import co.fineants.api.domain.dividend.repository.StockDividendRepository;
 import co.fineants.api.domain.holding.domain.dto.request.PortfolioHoldingCreateRequest;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioChartResponse;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioDetailResponse;
-import co.fineants.api.domain.holding.domain.dto.response.PortfolioHoldingCreateResponse;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioHoldingsResponse;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioSectorChartItem;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioStockDeleteResponse;
@@ -437,49 +435,6 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 					Tuple.tuple(Money.won(360000L), Money.won(10000L), Percentage.from(0.2),
 						Money.won(60000L),
 						Percentage.from(0.2)))
-		);
-	}
-	
-	@DisplayName("사용자는 포트폴리오 종목이 존재하는 상태에서 매입 이력과 같이 종목을 추가할때 매입 이력만 추가된다")
-	@Test
-	void addPortfolioStock_whenExistHolding_thenAddPurchaseHistory() {
-		// given
-		Member member = memberRepository.save(createMember());
-		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
-		Stock stock = stockRepository.save(createSamsungStock());
-		PortfolioHolding holding = portfolioHoldingRepository.save(PortfolioHolding.of(portfolio, stock));
-		LocalDateTime purchaseDate = LocalDateTime.of(2023, 9, 26, 9, 30, 0);
-		Count numShares = Count.from(5);
-		Money purchasePerShare = Money.won(10000);
-		String memo = "첫구매";
-		purchaseHistoryRepository.save(
-			createPurchaseHistory(null, purchaseDate, numShares, purchasePerShare, memo, holding));
-
-		Map<Object, Object> purchaseHistory = new HashMap<>();
-		purchaseHistory.put("purchaseDate", LocalDateTime.now());
-		purchaseHistory.put("numShares", 2);
-		purchaseHistory.put("purchasePricePerShare", 1000.0);
-
-		Map<String, Object> requestBodyMap = new HashMap<>();
-		requestBodyMap.put("tickerSymbol", stock.getTickerSymbol());
-		requestBodyMap.put("purchaseHistory", purchaseHistory);
-		PortfolioHoldingCreateRequest request = ObjectMapperUtil.deserialize(ObjectMapperUtil.serialize(requestBodyMap),
-			PortfolioHoldingCreateRequest.class);
-
-		setAuthentication(member);
-		// when
-		PortfolioHoldingCreateResponse response = service.createPortfolioHolding(portfolio.getId(), request);
-
-		// then
-		assertAll(
-			() -> assertThat(response)
-				.extracting("portfolioHoldingId")
-				.isNotNull(),
-			() -> assertThat(portfolioHoldingRepository.findAll()).hasSize(1),
-			() -> assertThat(purchaseHistoryRepository.findAllByPortfolioHoldingId(holding.getId())).hasSize(2),
-			() -> assertThat(portfolioCacheSupportService.fetchTickers(portfolio.getId()))
-				.isInstanceOf(Set.class)
-				.hasSize(1)
 		);
 	}
 

--- a/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
@@ -51,7 +51,6 @@ import co.fineants.api.domain.stock.repository.StockRepository;
 import co.fineants.api.global.common.time.LocalDateTimeService;
 import co.fineants.api.global.errors.exception.business.ForbiddenException;
 import co.fineants.api.global.errors.exception.business.HoldingNotFoundException;
-import co.fineants.api.global.errors.exception.business.PurchaseHistoryInvalidInputException;
 import co.fineants.api.global.errors.exception.business.StockNotFoundException;
 import co.fineants.api.global.util.ObjectMapperUtil;
 import co.fineants.support.cache.PortfolioCacheSupportService;
@@ -436,34 +435,6 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 						Money.won(60000L),
 						Percentage.from(0.2)))
 		);
-	}
-
-	@DisplayName("사용자는 포트폴리오에 종목과 매입이력 중 일부를 추가할 수 없다")
-	@Test
-	void addPortfolioStockWithInvalidInput() {
-		// given
-		Member member = memberRepository.save(createMember());
-		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
-		Stock stock = stockRepository.save(createSamsungStock());
-
-		Map<Object, Object> purchaseHistory = new HashMap<>();
-		purchaseHistory.put("purchaseDate", LocalDateTime.now());
-		purchaseHistory.put("purchasePricePerShare", 1000.0);
-
-		Map<String, Object> requestBodyMap = new HashMap<>();
-		requestBodyMap.put("tickerSymbol", stock.getTickerSymbol());
-		requestBodyMap.put("purchaseHistory", purchaseHistory);
-		PortfolioHoldingCreateRequest request = ObjectMapperUtil.deserialize(ObjectMapperUtil.serialize(requestBodyMap),
-			PortfolioHoldingCreateRequest.class);
-
-		setAuthentication(member);
-		// when
-		Throwable throwable = catchThrowable(() -> service.createPortfolioHolding(portfolio.getId(), request));
-
-		// then
-		assertThat(throwable)
-			.isInstanceOf(PurchaseHistoryInvalidInputException.class)
-			.hasMessage(request.toString());
 	}
 
 	@DisplayName("사용자는 포트폴리오에 존재하지 않는 종목을 추가할 수 없다")

--- a/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
@@ -439,42 +439,7 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 						Percentage.from(0.2)))
 		);
 	}
-
-	@DisplayName("사용자는 포트폴리오에 종목과 매입이력을 추가한다")
-	@Test
-	void addPortfolioStock() {
-		// given
-		Member member = memberRepository.save(createMember());
-		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
-		Stock stock = stockRepository.save(createSamsungStock());
-
-		Map<Object, Object> purchaseHistory = new HashMap<>();
-		purchaseHistory.put("purchaseDate", LocalDateTime.now());
-		purchaseHistory.put("numShares", 2);
-		purchaseHistory.put("purchasePricePerShare", 1000.0);
-
-		Map<String, Object> requestBodyMap = new HashMap<>();
-		requestBodyMap.put("tickerSymbol", stock.getTickerSymbol());
-		requestBodyMap.put("purchaseHistory", purchaseHistory);
-		PortfolioHoldingCreateRequest request = ObjectMapperUtil.deserialize(ObjectMapperUtil.serialize(requestBodyMap),
-			PortfolioHoldingCreateRequest.class);
-
-		setAuthentication(member);
-		// when
-		PortfolioHoldingCreateResponse response = service.createPortfolioHolding(portfolio.getId(), request);
-
-		// then
-		assertAll(
-			() -> assertThat(response)
-				.extracting("portfolioHoldingId")
-				.isNotNull(),
-			() -> assertThat(portfolioHoldingRepository.findAll()).hasSize(1),
-			() -> assertThat(portfolioCacheSupportService.fetchTickers(portfolio.getId()))
-				.isInstanceOf(Set.class)
-				.hasSize(1)
-		);
-	}
-
+	
 	@DisplayName("사용자는 포트폴리오 종목이 존재하는 상태에서 매입 이력과 같이 종목을 추가할때 매입 이력만 추가된다")
 	@Test
 	void addPortfolioStock_whenExistHolding_thenAddPurchaseHistory() {

--- a/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/holding/service/PortfolioHoldingServiceTest.java
@@ -6,9 +6,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 
 import org.assertj.core.groups.Tuple;
@@ -27,7 +25,6 @@ import co.fineants.api.domain.common.money.Percentage;
 import co.fineants.api.domain.common.money.RateDivision;
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
 import co.fineants.api.domain.dividend.repository.StockDividendRepository;
-import co.fineants.api.domain.holding.domain.dto.request.PortfolioHoldingCreateRequest;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioChartResponse;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioDetailResponse;
 import co.fineants.api.domain.holding.domain.dto.response.PortfolioHoldingsResponse;
@@ -51,8 +48,6 @@ import co.fineants.api.domain.stock.repository.StockRepository;
 import co.fineants.api.global.common.time.LocalDateTimeService;
 import co.fineants.api.global.errors.exception.business.ForbiddenException;
 import co.fineants.api.global.errors.exception.business.HoldingNotFoundException;
-import co.fineants.api.global.errors.exception.business.StockNotFoundException;
-import co.fineants.api.global.util.ObjectMapperUtil;
 import co.fineants.support.cache.PortfolioCacheSupportService;
 
 class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
@@ -435,28 +430,6 @@ class PortfolioHoldingServiceTest extends AbstractContainerBaseTest {
 						Money.won(60000L),
 						Percentage.from(0.2)))
 		);
-	}
-
-	@DisplayName("사용자는 포트폴리오에 존재하지 않는 종목을 추가할 수 없다")
-	@Test
-	void addPortfolioStockWithNotExistStock() {
-		// given
-		Member member = memberRepository.save(createMember());
-		Portfolio portfolio = portfolioRepository.save(createPortfolio(member));
-		Map<String, Object> requestBodyMap = new HashMap<>();
-		requestBodyMap.put("tickerSymbol", "999999");
-		PortfolioHoldingCreateRequest request = ObjectMapperUtil.deserialize(ObjectMapperUtil.serialize(requestBodyMap),
-			PortfolioHoldingCreateRequest.class);
-
-		setAuthentication(member);
-		// when
-		Throwable throwable = catchThrowable(() -> service.createPortfolioHolding(portfolio.getId(), request));
-
-		// then
-		assertThat(throwable)
-			.isInstanceOf(StockNotFoundException.class)
-			.hasMessage("999999");
-
 	}
 
 	@DisplayName("사용자는 포트폴리오의 종목을 삭제한다")


### PR DESCRIPTION
## 구현한 것

- 기존 PortfolioHoldingService.createPortfolioHolding 메서드 및 관련 테스트 제거
- PortfolioHoldingFacade.createPortfolioHolding 메서드 대상 테스트 추가

