### PR TITLE
[feat] 종복 배당금 csv 파일의 읽기/삭제 서비스 기능 및 테스트 구현

### DIFF
--- a/src/main/java/co/fineants/api/domain/dividend/config/StockDividendConfig.java
+++ b/src/main/java/co/fineants/api/domain/dividend/config/StockDividendConfig.java
@@ -5,17 +5,25 @@ import org.springframework.context.annotation.Configuration;
 
 import co.fineants.api.domain.dividend.domain.calculator.ExDividendDateCalculator;
 import co.fineants.api.domain.dividend.domain.calculator.MySqlExDividendDateCalculator;
+import co.fineants.api.domain.dividend.domain.parser.StockDividendCsvLineParser;
+import co.fineants.api.domain.dividend.domain.parser.StockDividendCsvParser;
 import co.fineants.api.domain.holiday.service.HolidayService;
 import lombok.RequiredArgsConstructor;
 
 @Configuration
 @RequiredArgsConstructor
-public class DividendConfig {
+public class StockDividendConfig {
 
 	private final HolidayService service;
 
 	@Bean
 	public ExDividendDateCalculator exDividendDateCalculator() {
 		return new MySqlExDividendDateCalculator(service);
+	}
+
+	@Bean
+	public StockDividendCsvParser stockDividendCsvParser(StockDividendCsvLineParser lineParser) {
+		String csvSeparator = ",";
+		return new StockDividendCsvParser(csvSeparator, lineParser);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/dividend/config/StockDividendConfig.java
+++ b/src/main/java/co/fineants/api/domain/dividend/config/StockDividendConfig.java
@@ -1,5 +1,6 @@
 package co.fineants.api.domain.dividend.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -22,8 +23,8 @@ public class StockDividendConfig {
 	}
 
 	@Bean
-	public StockDividendCsvParser stockDividendCsvParser(StockDividendCsvLineParser lineParser) {
-		String csvSeparator = ",";
+	public StockDividendCsvParser stockDividendCsvParser(@Value("${csv.stockDividend.delimiter}") String csvSeparator,
+		StockDividendCsvLineParser lineParser) {
 		return new StockDividendCsvParser(csvSeparator, lineParser);
 	}
 }

--- a/src/main/java/co/fineants/api/domain/dividend/domain/parser/StockDividendCsvLineParser.java
+++ b/src/main/java/co/fineants/api/domain/dividend/domain/parser/StockDividendCsvLineParser.java
@@ -15,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
-public class StockDividendParser {
+public class StockDividendCsvLineParser {
 
 	private final ExDividendDateCalculator calculator;
 

--- a/src/main/java/co/fineants/api/domain/dividend/domain/parser/StockDividendCsvParser.java
+++ b/src/main/java/co/fineants/api/domain/dividend/domain/parser/StockDividendCsvParser.java
@@ -1,4 +1,4 @@
-package co.fineants.api.infra.s3.service.imple;
+package co.fineants.api.domain.dividend.domain.parser;
 
 import java.io.BufferedReader;
 import java.io.InputStream;
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
-import co.fineants.api.domain.dividend.domain.parser.StockDividendParser;
 import co.fineants.api.domain.stock.domain.entity.Stock;
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,11 +15,11 @@ import lombok.extern.slf4j.Slf4j;
 public class StockDividendCsvParser {
 
 	private final String csvSeparator;
-	private final StockDividendParser stockDividendParser;
+	private final StockDividendCsvLineParser stockDividendCsvLineParser;
 
-	public StockDividendCsvParser(String csvSeparator, StockDividendParser stockDividendParser) {
+	public StockDividendCsvParser(String csvSeparator, StockDividendCsvLineParser stockDividendCsvLineParser) {
 		this.csvSeparator = csvSeparator;
-		this.stockDividendParser = stockDividendParser;
+		this.stockDividendCsvLineParser = stockDividendCsvLineParser;
 	}
 
 	public List<StockDividend> parse(InputStream inputStream, Map<String, Stock> stockMap) {
@@ -28,7 +27,7 @@ public class StockDividendCsvParser {
 			return reader.lines()
 				.skip(1) // Skip header line
 				.map(line -> line.split(csvSeparator))
-				.map(columns -> stockDividendParser.parseCsvLine(columns,
+				.map(columns -> stockDividendCsvLineParser.parseCsvLine(columns,
 					stockMap))
 				.filter(dividend -> dividend.getStock() != null)
 				.distinct()

--- a/src/main/java/co/fineants/api/infra/s3/config/GoogleCloudStorageConfig.java
+++ b/src/main/java/co/fineants/api/infra/s3/config/GoogleCloudStorageConfig.java
@@ -13,7 +13,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
-import co.fineants.api.domain.dividend.domain.parser.StockDividendParser;
+import co.fineants.api.domain.dividend.domain.parser.StockDividendCsvParser;
 import co.fineants.api.global.common.csv.CsvFormatter;
 import co.fineants.api.infra.s3.service.DeleteDividendService;
 import co.fineants.api.infra.s3.service.DeleteProfileImageFileService;
@@ -78,8 +78,9 @@ public class GoogleCloudStorageConfig {
 
 	@Bean
 	public FetchDividendService fetchDividendService(RemoteFileFetcher fileFetcher,
-		@Value("${gcp.storage.dividend-csv-path}") String dividendPath, StockDividendParser stockDividendParser) {
-		return new GoogleCloudStorageFetchDividendService(fileFetcher, dividendPath, stockDividendParser);
+		@Value("${gcp.storage.dividend-csv-path}") String dividendPath,
+		StockDividendCsvParser stockDividendCsvParser) {
+		return new GoogleCloudStorageFetchDividendService(fileFetcher, dividendPath, stockDividendCsvParser);
 	}
 
 	@Bean

--- a/src/main/java/co/fineants/api/infra/s3/config/GoogleCloudStorageConfig.java
+++ b/src/main/java/co/fineants/api/infra/s3/config/GoogleCloudStorageConfig.java
@@ -84,8 +84,9 @@ public class GoogleCloudStorageConfig {
 	}
 
 	@Bean
-	public DeleteDividendService deleteDividendService() {
-		return new GoogleCloudStorageDeleteDividendService();
+	public DeleteDividendService deleteDividendService(Storage storage,
+		@Value("${gcp.storage.dividend-csv-path}") String dividendPath) {
+		return new GoogleCloudStorageDeleteDividendService(storage, bucketName, dividendPath);
 	}
 
 	@Bean

--- a/src/main/java/co/fineants/api/infra/s3/config/GoogleCloudStorageConfig.java
+++ b/src/main/java/co/fineants/api/infra/s3/config/GoogleCloudStorageConfig.java
@@ -45,7 +45,7 @@ public class GoogleCloudStorageConfig {
 
 	@Value("${gcp.credentials}")
 	private Resource credentials;
-
+	
 	@Bean
 	public Storage storage() throws IOException {
 		GoogleCredentials googleCredentials = GoogleCredentials.fromStream(this.credentials.getInputStream());
@@ -76,8 +76,9 @@ public class GoogleCloudStorageConfig {
 	}
 
 	@Bean
-	public FetchDividendService fetchDividendService() {
-		return new GoogleCloudStorageFetchDividendService();
+	public FetchDividendService fetchDividendService(RemoteFileFetcher fileFetcher,
+		@Value("${gcp.storage.dividend-csv-path}") String dividendPath) {
+		return new GoogleCloudStorageFetchDividendService(fileFetcher, dividendPath);
 	}
 
 	@Bean

--- a/src/main/java/co/fineants/api/infra/s3/config/GoogleCloudStorageConfig.java
+++ b/src/main/java/co/fineants/api/infra/s3/config/GoogleCloudStorageConfig.java
@@ -13,6 +13,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
+import co.fineants.api.domain.dividend.domain.parser.StockDividendParser;
 import co.fineants.api.global.common.csv.CsvFormatter;
 import co.fineants.api.infra.s3.service.DeleteDividendService;
 import co.fineants.api.infra.s3.service.DeleteProfileImageFileService;
@@ -45,7 +46,7 @@ public class GoogleCloudStorageConfig {
 
 	@Value("${gcp.credentials}")
 	private Resource credentials;
-	
+
 	@Bean
 	public Storage storage() throws IOException {
 		GoogleCredentials googleCredentials = GoogleCredentials.fromStream(this.credentials.getInputStream());
@@ -77,8 +78,8 @@ public class GoogleCloudStorageConfig {
 
 	@Bean
 	public FetchDividendService fetchDividendService(RemoteFileFetcher fileFetcher,
-		@Value("${gcp.storage.dividend-csv-path}") String dividendPath) {
-		return new GoogleCloudStorageFetchDividendService(fileFetcher, dividendPath);
+		@Value("${gcp.storage.dividend-csv-path}") String dividendPath, StockDividendParser stockDividendParser) {
+		return new GoogleCloudStorageFetchDividendService(fileFetcher, dividendPath, stockDividendParser);
 	}
 
 	@Bean

--- a/src/main/java/co/fineants/api/infra/s3/config/S3Config.java
+++ b/src/main/java/co/fineants/api/infra/s3/config/S3Config.java
@@ -12,7 +12,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
-import co.fineants.api.domain.dividend.domain.parser.StockDividendParser;
+import co.fineants.api.domain.dividend.domain.parser.StockDividendCsvParser;
 import co.fineants.api.domain.holding.domain.factory.UuidGenerator;
 import co.fineants.api.domain.stock.domain.entity.Stock;
 import co.fineants.api.domain.stock.parser.StockParser;
@@ -71,8 +71,9 @@ public class S3Config {
 
 	@Bean
 	public FetchDividendService fetchDividendService(RemoteFileFetcher fileFetcher,
-		@Value("${aws.s3.dividend-csv-path}") String dividendPath, StockDividendParser stockDividendParser) {
-		return new AmazonS3FetchDividendService(fileFetcher, dividendPath, stockDividendParser);
+		@Value("${aws.s3.dividend-csv-path}") String dividendPath,
+		StockDividendCsvParser stockDividendCsvParser) {
+		return new AmazonS3FetchDividendService(fileFetcher, dividendPath, stockDividendCsvParser);
 	}
 
 	@Bean

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/AmazonS3FetchDividendService.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/AmazonS3FetchDividendService.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Value;
 
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
-import co.fineants.api.domain.dividend.domain.parser.StockDividendParser;
+import co.fineants.api.domain.dividend.domain.parser.StockDividendCsvParser;
 import co.fineants.api.domain.stock.domain.entity.Stock;
 import co.fineants.api.infra.s3.dto.StockDividendDto;
 import co.fineants.api.infra.s3.service.FetchDividendService;
@@ -23,15 +23,15 @@ public class AmazonS3FetchDividendService implements FetchDividendService {
 	private static final String CSV_SEPARATOR = ",";
 	private final RemoteFileFetcher fileFetcher;
 	private final String dividendPath;
-	private final StockDividendParser stockDividendParser;
+	private final StockDividendCsvParser stockDividendCsvParser;
 
 	public AmazonS3FetchDividendService(
 		RemoteFileFetcher fileFetcher,
 		@Value("${aws.s3.dividend-csv-path}") String dividendPath,
-		StockDividendParser stockDividendParser) {
+		StockDividendCsvParser stockDividendCsvParser) {
 		this.fileFetcher = fileFetcher;
 		this.dividendPath = dividendPath;
-		this.stockDividendParser = stockDividendParser;
+		this.stockDividendCsvParser = stockDividendCsvParser;
 	}
 
 	@Override
@@ -58,7 +58,6 @@ public class AmazonS3FetchDividendService implements FetchDividendService {
 		Map<String, Stock> stockMap = stocks.stream()
 			.collect(Collectors.toMap(Stock::getStockCode, stock -> stock));
 
-		return new StockDividendCsvParser(CSV_SEPARATOR, stockDividendParser)
-			.parse(fileFetcher.read(dividendPath).orElseThrow(), stockMap);
+		return stockDividendCsvParser.parse(fileFetcher.read(dividendPath).orElseThrow(), stockMap);
 	}
 }

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/AmazonS3FetchDividendService.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/AmazonS3FetchDividendService.java
@@ -49,7 +49,7 @@ public class AmazonS3FetchDividendService implements FetchDividendService {
 	private List<StockDividendDto> getStockDividendDtoList(BufferedReader reader) {
 		return reader.lines()
 			.skip(1) // Skip header line
-			.map(line -> line.split(","))
+			.map(line -> line.split(CSV_SEPARATOR))
 			.map(StockDividendDto::from)
 			.toList();
 	}

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageDeleteDividendService.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageDeleteDividendService.java
@@ -1,10 +1,28 @@
 package co.fineants.api.infra.s3.service.imple;
 
-import co.fineants.api.infra.s3.service.DeleteDividendService;
+import com.google.cloud.storage.BlobId;
+import com.google.cloud.storage.Storage;
 
+import co.fineants.api.infra.s3.service.DeleteDividendService;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public class GoogleCloudStorageDeleteDividendService implements DeleteDividendService {
+
+	private final Storage storage;
+	private final String bucketName;
+	private final String dividendPath;
+
+	public GoogleCloudStorageDeleteDividendService(Storage storage, String bucketName, String dividendPath) {
+		this.storage = storage;
+		this.bucketName = bucketName;
+		this.dividendPath = dividendPath;
+	}
+
 	@Override
 	public void delete() {
-
+		BlobId blobId = BlobId.of(bucketName, dividendPath);
+		boolean delete = storage.delete(blobId);
+		log.info("Deleted file at path: {} from bucket: {}. Success: {}", dividendPath, bucketName, delete);
 	}
 }

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendService.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendService.java
@@ -1,5 +1,7 @@
 package co.fineants.api.infra.s3.service.imple;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
 import java.util.Collections;
 import java.util.List;
 
@@ -7,11 +9,37 @@ import co.fineants.api.domain.dividend.domain.entity.StockDividend;
 import co.fineants.api.domain.stock.domain.entity.Stock;
 import co.fineants.api.infra.s3.dto.StockDividendDto;
 import co.fineants.api.infra.s3.service.FetchDividendService;
+import co.fineants.api.infra.s3.service.RemoteFileFetcher;
+import jakarta.validation.constraints.NotNull;
 
 public class GoogleCloudStorageFetchDividendService implements FetchDividendService {
+
+	private final RemoteFileFetcher fileFetcher;
+
+	private final String dividendPath;
+
+	public GoogleCloudStorageFetchDividendService(RemoteFileFetcher fileFetcher, String dividendPath) {
+		this.fileFetcher = fileFetcher;
+		this.dividendPath = dividendPath;
+	}
+
 	@Override
 	public List<StockDividendDto> fetchDividend() {
-		return Collections.emptyList();
+		try (BufferedReader reader = new BufferedReader(
+			new InputStreamReader(fileFetcher.read(dividendPath).orElseThrow()))) {
+			return getStockDividendDtoList(reader);
+		} catch (Exception e) {
+			throw new IllegalStateException("Failed to read dividend file from Google Storage", e);
+		}
+	}
+
+	@NotNull
+	private List<StockDividendDto> getStockDividendDtoList(BufferedReader reader) {
+		return reader.lines()
+			.skip(1) // Skip header line
+			.map(line -> line.split(","))
+			.map(StockDividendDto::from)
+			.toList();
 	}
 
 	@Override

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendService.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendService.java
@@ -2,7 +2,6 @@ package co.fineants.api.infra.s3.service.imple;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -45,7 +44,7 @@ public class GoogleCloudStorageFetchDividendService implements FetchDividendServ
 	private List<StockDividendDto> getStockDividendDtoList(BufferedReader reader) {
 		return reader.lines()
 			.skip(1) // Skip header line
-			.map(line -> line.split(","))
+			.map(line -> line.split(CSV_SEPARATOR))
 			.map(StockDividendDto::from)
 			.toList();
 	}
@@ -54,19 +53,7 @@ public class GoogleCloudStorageFetchDividendService implements FetchDividendServ
 	public List<StockDividend> fetchDividendEntityIn(List<Stock> stocks) {
 		Map<String, Stock> stockMap = stocks.stream()
 			.collect(Collectors.toMap(Stock::getStockCode, stock -> stock));
-
-		try (BufferedReader reader = new BufferedReader(
-			new InputStreamReader(fileFetcher.read(dividendPath).orElseThrow()))) {
-			return reader.lines()
-				.skip(1) // Skip header line
-				.map(line -> line.split(CSV_SEPARATOR))
-				.map(columns -> stockDividendParser.parseCsvLine(columns, stockMap))
-				.filter(dividend -> dividend.getStock() != null)
-				.distinct()
-				.toList();
-		} catch (Exception e) {
-			log.error("Failed to read dividend file from S3", e);
-			return Collections.emptyList();
-		}
+		return new StockDividendCsvParser(CSV_SEPARATOR, stockDividendParser)
+			.parse(fileFetcher.read(dividendPath).orElseThrow(), stockMap);
 	}
 }

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendService.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendService.java
@@ -7,7 +7,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
-import co.fineants.api.domain.dividend.domain.parser.StockDividendParser;
+import co.fineants.api.domain.dividend.domain.parser.StockDividendCsvParser;
 import co.fineants.api.domain.stock.domain.entity.Stock;
 import co.fineants.api.infra.s3.dto.StockDividendDto;
 import co.fineants.api.infra.s3.service.FetchDividendService;
@@ -19,15 +19,14 @@ import lombok.extern.slf4j.Slf4j;
 public class GoogleCloudStorageFetchDividendService implements FetchDividendService {
 	private static final String CSV_SEPARATOR = ",";
 	private final RemoteFileFetcher fileFetcher;
-
 	private final String dividendPath;
-	private final StockDividendParser stockDividendParser;
+	private final StockDividendCsvParser stockDividendCsvParser;
 
 	public GoogleCloudStorageFetchDividendService(RemoteFileFetcher fileFetcher, String dividendPath,
-		StockDividendParser stockDividendParser) {
+		StockDividendCsvParser stockDividendCsvLineParser) {
 		this.fileFetcher = fileFetcher;
 		this.dividendPath = dividendPath;
-		this.stockDividendParser = stockDividendParser;
+		this.stockDividendCsvParser = stockDividendCsvLineParser;
 	}
 
 	@Override
@@ -53,7 +52,6 @@ public class GoogleCloudStorageFetchDividendService implements FetchDividendServ
 	public List<StockDividend> fetchDividendEntityIn(List<Stock> stocks) {
 		Map<String, Stock> stockMap = stocks.stream()
 			.collect(Collectors.toMap(Stock::getStockCode, stock -> stock));
-		return new StockDividendCsvParser(CSV_SEPARATOR, stockDividendParser)
-			.parse(fileFetcher.read(dividendPath).orElseThrow(), stockMap);
+		return stockDividendCsvParser.parse(fileFetcher.read(dividendPath).orElseThrow(), stockMap);
 	}
 }

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendService.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendService.java
@@ -1,5 +1,6 @@
 package co.fineants.api.infra.s3.service.imple;
 
+import java.util.Collections;
 import java.util.List;
 
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
@@ -10,11 +11,11 @@ import co.fineants.api.infra.s3.service.FetchDividendService;
 public class GoogleCloudStorageFetchDividendService implements FetchDividendService {
 	@Override
 	public List<StockDividendDto> fetchDividend() {
-		return null;
+		return Collections.emptyList();
 	}
 
 	@Override
 	public List<StockDividend> fetchDividendEntityIn(List<Stock> stocks) {
-		return null;
+		return Collections.emptyList();
 	}
 }

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageRemoteFileFetcher.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageRemoteFileFetcher.java
@@ -23,9 +23,10 @@ public class GoogleCloudStorageRemoteFileFetcher implements RemoteFileFetcher {
 
 	@Override
 	public Optional<InputStream> read(String path) {
-		Blob blob = storage.get(bucketName, path);
+		Optional<Blob> blob = Optional.ofNullable(storage.get(bucketName, path));
 		try {
-			return Optional.of(new ByteArrayInputStream(blob.getContent()));
+			return blob.map(Blob::getContent)
+				.map(ByteArrayInputStream::new);
 		} catch (Exception e) {
 			log.warn("Failed to read file from path: {}", path, e);
 			return Optional.empty();

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/StockDividendCsvParser.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/StockDividendCsvParser.java
@@ -1,0 +1,41 @@
+package co.fineants.api.infra.s3.service.imple;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import co.fineants.api.domain.dividend.domain.entity.StockDividend;
+import co.fineants.api.domain.dividend.domain.parser.StockDividendParser;
+import co.fineants.api.domain.stock.domain.entity.Stock;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class StockDividendCsvParser {
+
+	private final String csvSeparator;
+	private final StockDividendParser stockDividendParser;
+
+	public StockDividendCsvParser(String csvSeparator, StockDividendParser stockDividendParser) {
+		this.csvSeparator = csvSeparator;
+		this.stockDividendParser = stockDividendParser;
+	}
+
+	public List<StockDividend> parse(InputStream inputStream, Map<String, Stock> stockMap) {
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream))) {
+			return reader.lines()
+				.skip(1) // Skip header line
+				.map(line -> line.split(csvSeparator))
+				.map(columns -> stockDividendParser.parseCsvLine(columns,
+					stockMap))
+				.filter(dividend -> dividend.getStock() != null)
+				.distinct()
+				.toList();
+		} catch (Exception e) {
+			log.error("Failed to parse dividend file from Google Storage", e);
+			return Collections.emptyList();
+		}
+	}
+}

--- a/src/main/java/co/fineants/api/infra/s3/service/imple/StockDividendCsvParser.java
+++ b/src/main/java/co/fineants/api/infra/s3/service/imple/StockDividendCsvParser.java
@@ -34,7 +34,7 @@ public class StockDividendCsvParser {
 				.distinct()
 				.toList();
 		} catch (Exception e) {
-			log.error("Failed to parse dividend file from Google Storage", e);
+			log.error("Failed to parse dividend file from Remote Storage", e);
 			return Collections.emptyList();
 		}
 	}

--- a/src/test/java/co/fineants/TestDataFactory.java
+++ b/src/test/java/co/fineants/TestDataFactory.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import org.springframework.core.io.ClassPathResource;
@@ -13,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.multipart.MultipartFile;
 
 import co.fineants.api.domain.common.money.Money;
+import co.fineants.api.domain.dividend.domain.entity.StockDividend;
 import co.fineants.api.domain.kis.client.KisAccessToken;
 import co.fineants.api.domain.member.domain.entity.Member;
 import co.fineants.api.domain.member.domain.entity.MemberProfile;
@@ -260,5 +262,32 @@ public final class TestDataFactory {
 		} catch (IOException e) {
 			throw new RuntimeException(e);
 		}
+	}
+
+	public static StockDividend createSamsungStockDividend(Stock stock) {
+		Money dividend = Money.won(361);
+		LocalDate recordDate = LocalDate.of(2023, 3, 31);
+		LocalDate exDividendDate = LocalDate.of(2023, 3, 30);
+		LocalDate paymentDate = LocalDate.of(2023, 5, 17);
+		return StockDividend.create(
+			1L,
+			dividend,
+			recordDate,
+			exDividendDate,
+			paymentDate,
+			stock
+		);
+	}
+
+	public static StockDividend createKakaoStockDividend(Stock kakaoStock) {
+		StockDividend stockDividend2 = StockDividend.create(
+			2L,
+			Money.won(68),
+			LocalDate.of(2025, 3, 10),
+			LocalDate.of(2025, 3, 7),
+			LocalDate.of(2025, 4, 24),
+			kakaoStock
+		);
+		return stockDividend2;
 	}
 }

--- a/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageDeleteDividendServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageDeleteDividendServiceTest.java
@@ -1,17 +1,61 @@
 package co.fineants.api.infra.s3.service.imple;
 
+import java.util.List;
+
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
 
+import co.fineants.AbstractContainerBaseTest;
+import co.fineants.TestDataFactory;
+import co.fineants.api.domain.dividend.domain.entity.StockDividend;
+import co.fineants.api.domain.stock.domain.entity.Stock;
 import co.fineants.api.infra.s3.service.DeleteDividendService;
+import co.fineants.api.infra.s3.service.FetchDividendService;
+import co.fineants.api.infra.s3.service.WriteDividendService;
+import co.fineants.config.GoogleCloudStorageBucketInitializer;
+import co.fineants.config.GoogleCloudStorageTestConfig;
 
-class GoogleCloudStorageDeleteDividendServiceTest {
+@ActiveProfiles(value = {"test", "gcp"}, inheritProfiles = false)
+@ContextConfiguration(classes = {GoogleCloudStorageTestConfig.class, GoogleCloudStorageBucketInitializer.class})
+class GoogleCloudStorageDeleteDividendServiceTest extends AbstractContainerBaseTest {
+
+	@Autowired
+	private DeleteDividendService service;
+
+	@Autowired
+	private WriteDividendService writeDividendService;
+
+	@Autowired
+	private FetchDividendService fetchDividendService;
+
+	@BeforeEach
+	void setUp() {
+		Stock stock = TestDataFactory.createSamsungStock();
+		StockDividend stockDividend = TestDataFactory.createSamsungStockDividend(stock);
+
+		Stock kakaoStock = TestDataFactory.createKakaoStock();
+		StockDividend stockDividend2 = TestDataFactory.createKakaoStockDividend(kakaoStock);
+
+		writeDividendService.writeDividend(List.of(stockDividend, stockDividend2));
+	}
 
 	@Test
 	void canCreated() {
-		DeleteDividendService service = new GoogleCloudStorageDeleteDividendService();
-
 		Assertions.assertThat(service).isNotNull();
+	}
+
+	@Test
+	void delete() {
+		service.delete();
+
+		Throwable throwable = Assertions.catchThrowable(() -> fetchDividendService.fetchDividend());
+		Assertions.assertThat(throwable)
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining("Failed to read dividend file from Google Storage");
 	}
 
 }

--- a/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageDeleteDividendServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageDeleteDividendServiceTest.java
@@ -1,0 +1,17 @@
+package co.fineants.api.infra.s3.service.imple;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import co.fineants.api.infra.s3.service.DeleteDividendService;
+
+class GoogleCloudStorageDeleteDividendServiceTest {
+
+	@Test
+	void canCreated() {
+		DeleteDividendService service = new GoogleCloudStorageDeleteDividendService();
+
+		Assertions.assertThat(service).isNotNull();
+	}
+
+}

--- a/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageDeleteDividendServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageDeleteDividendServiceTest.java
@@ -58,4 +58,11 @@ class GoogleCloudStorageDeleteDividendServiceTest extends AbstractContainerBaseT
 			.hasMessageContaining("Failed to read dividend file from Google Storage");
 	}
 
+	@Test
+	void delete_whenFileNotExists_thenNotThrowAnyException() {
+		service.delete();
+
+		Assertions.assertThatCode(() -> service.delete()).doesNotThrowAnyException();
+	}
+
 }

--- a/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
@@ -1,0 +1,23 @@
+package co.fineants.api.infra.s3.service.imple;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+
+import co.fineants.AbstractContainerBaseTest;
+import co.fineants.api.infra.s3.service.FetchDividendService;
+import co.fineants.config.GoogleCloudStorageBucketInitializer;
+import co.fineants.config.GoogleCloudStorageTestConfig;
+
+@ActiveProfiles(value = {"test", "gcp"}, inheritProfiles = false)
+@ContextConfiguration(classes = {GoogleCloudStorageTestConfig.class, GoogleCloudStorageBucketInitializer.class})
+class GoogleCloudStorageFetchDividendServiceTest extends AbstractContainerBaseTest {
+
+	@Test
+	void canCreated() {
+		FetchDividendService service = new GoogleCloudStorageFetchDividendService();
+
+		Assertions.assertThat(service).isNotNull();
+	}
+}

--- a/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
@@ -51,4 +51,21 @@ class GoogleCloudStorageFetchDividendServiceTest extends AbstractContainerBaseTe
 
 		Assertions.assertThat(list).hasSize(2);
 	}
+
+	@Test
+	void fetchDividendEntityIn_whenStockIsEmpty() {
+		List<StockDividend> list = service.fetchDividendEntityIn(List.of());
+
+		Assertions.assertThat(list).isEmpty();
+	}
+
+	@Test
+	void fetchDividendEntityIn() {
+		Stock stock = TestDataFactory.createSamsungStock();
+		Stock kakaoStock = TestDataFactory.createKakaoStock();
+
+		List<StockDividend> list = service.fetchDividendEntityIn(List.of(stock, kakaoStock));
+
+		Assertions.assertThat(list).hasSize(2);
+	}
 }

--- a/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
@@ -1,11 +1,14 @@
 package co.fineants.api.infra.s3.service.imple;
 
+import java.util.List;
+
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
 import co.fineants.AbstractContainerBaseTest;
+import co.fineants.api.infra.s3.dto.StockDividendDto;
 import co.fineants.api.infra.s3.service.FetchDividendService;
 import co.fineants.config.GoogleCloudStorageBucketInitializer;
 import co.fineants.config.GoogleCloudStorageTestConfig;
@@ -19,5 +22,14 @@ class GoogleCloudStorageFetchDividendServiceTest extends AbstractContainerBaseTe
 		FetchDividendService service = new GoogleCloudStorageFetchDividendService();
 
 		Assertions.assertThat(service).isNotNull();
+	}
+
+	@Test
+	void fetchDividend() {
+		FetchDividendService service = new GoogleCloudStorageFetchDividendService();
+
+		List<StockDividendDto> dtos = service.fetchDividend();
+
+		Assertions.assertThat(dtos).isEmpty();
 	}
 }

--- a/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
@@ -3,14 +3,19 @@ package co.fineants.api.infra.s3.service.imple;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
 import co.fineants.AbstractContainerBaseTest;
+import co.fineants.TestDataFactory;
+import co.fineants.api.domain.dividend.domain.entity.StockDividend;
+import co.fineants.api.domain.stock.domain.entity.Stock;
 import co.fineants.api.infra.s3.dto.StockDividendDto;
 import co.fineants.api.infra.s3.service.FetchDividendService;
+import co.fineants.api.infra.s3.service.WriteDividendService;
 import co.fineants.config.GoogleCloudStorageBucketInitializer;
 import co.fineants.config.GoogleCloudStorageTestConfig;
 
@@ -19,7 +24,21 @@ import co.fineants.config.GoogleCloudStorageTestConfig;
 class GoogleCloudStorageFetchDividendServiceTest extends AbstractContainerBaseTest {
 
 	@Autowired
+	private WriteDividendService writeDividendService;
+
+	@Autowired
 	private FetchDividendService service;
+
+	@BeforeEach
+	void setUp() {
+		Stock stock = TestDataFactory.createSamsungStock();
+		StockDividend stockDividend = TestDataFactory.createSamsungStockDividend(stock);
+
+		Stock kakaoStock = TestDataFactory.createKakaoStock();
+		StockDividend stockDividend2 = TestDataFactory.createKakaoStockDividend(kakaoStock);
+
+		writeDividendService.writeDividend(List.of(stockDividend, stockDividend2));
+	}
 
 	@Test
 	void canCreated() {
@@ -30,6 +49,6 @@ class GoogleCloudStorageFetchDividendServiceTest extends AbstractContainerBaseTe
 	void fetchDividend() {
 		List<StockDividendDto> list = service.fetchDividend();
 
-		Assertions.assertThat(list).isEmpty();
+		Assertions.assertThat(list).hasSize(2);
 	}
 }

--- a/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageFetchDividendServiceTest.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 
@@ -17,19 +18,18 @@ import co.fineants.config.GoogleCloudStorageTestConfig;
 @ContextConfiguration(classes = {GoogleCloudStorageTestConfig.class, GoogleCloudStorageBucketInitializer.class})
 class GoogleCloudStorageFetchDividendServiceTest extends AbstractContainerBaseTest {
 
+	@Autowired
+	private FetchDividendService service;
+
 	@Test
 	void canCreated() {
-		FetchDividendService service = new GoogleCloudStorageFetchDividendService();
-
 		Assertions.assertThat(service).isNotNull();
 	}
 
 	@Test
 	void fetchDividend() {
-		FetchDividendService service = new GoogleCloudStorageFetchDividendService();
+		List<StockDividendDto> list = service.fetchDividend();
 
-		List<StockDividendDto> dtos = service.fetchDividend();
-
-		Assertions.assertThat(dtos).isEmpty();
+		Assertions.assertThat(list).isEmpty();
 	}
 }

--- a/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageWriteDividendServiceTest.java
+++ b/src/test/java/co/fineants/api/infra/s3/service/imple/GoogleCloudStorageWriteDividendServiceTest.java
@@ -1,7 +1,6 @@
 package co.fineants.api.infra.s3.service.imple;
 
 import java.io.InputStream;
-import java.time.LocalDate;
 import java.util.List;
 
 import org.assertj.core.api.Assertions;
@@ -13,7 +12,6 @@ import org.springframework.test.context.ContextConfiguration;
 
 import co.fineants.AbstractContainerBaseTest;
 import co.fineants.TestDataFactory;
-import co.fineants.api.domain.common.money.Money;
 import co.fineants.api.domain.dividend.domain.entity.StockDividend;
 import co.fineants.api.domain.stock.domain.entity.Stock;
 import co.fineants.api.infra.s3.service.RemoteFileFetcher;
@@ -34,21 +32,6 @@ class GoogleCloudStorageWriteDividendServiceTest extends AbstractContainerBaseTe
 	@Value("${gcp.storage.dividend-csv-path}")
 	private String dividendPath;
 
-	private StockDividend createSamsungStockDividend(Stock stock) {
-		Money dividend = Money.won(361);
-		LocalDate recordDate = LocalDate.of(2023, 3, 31);
-		LocalDate exDividendDate = LocalDate.of(2023, 3, 30);
-		LocalDate paymentDate = LocalDate.of(2023, 5, 17);
-		return StockDividend.create(
-			1L,
-			dividend,
-			recordDate,
-			exDividendDate,
-			paymentDate,
-			stock
-		);
-	}
-
 	@Test
 	void canCreated() {
 		Assertions.assertThat(service).isNotNull();
@@ -68,7 +51,7 @@ class GoogleCloudStorageWriteDividendServiceTest extends AbstractContainerBaseTe
 	@Test
 	void writeDividend_whenDataIsOne() {
 		Stock stock = TestDataFactory.createSamsungStock();
-		StockDividend stockDividend = createSamsungStockDividend(stock);
+		StockDividend stockDividend = TestDataFactory.createSamsungStockDividend(stock);
 
 		service.writeDividend(List.of(stockDividend));
 
@@ -80,17 +63,10 @@ class GoogleCloudStorageWriteDividendServiceTest extends AbstractContainerBaseTe
 	@Test
 	void writeDividend_whenDataIsTwo() {
 		Stock stock = TestDataFactory.createSamsungStock();
-		StockDividend stockDividend = createSamsungStockDividend(stock);
+		StockDividend stockDividend = TestDataFactory.createSamsungStockDividend(stock);
 
 		Stock kakaoStock = TestDataFactory.createKakaoStock();
-		StockDividend stockDividend2 = StockDividend.create(
-			2L,
-			Money.won(68),
-			LocalDate.of(2025, 3, 10),
-			LocalDate.of(2025, 3, 7),
-			LocalDate.of(2025, 4, 24),
-			kakaoStock
-		);
+		StockDividend stockDividend2 = TestDataFactory.createKakaoStockDividend(kakaoStock);
 
 		service.writeDividend(List.of(stockDividend, stockDividend2));
 


### PR DESCRIPTION
## 구현한 것

- 종목 배당금 csv 파일 읽기 서비스에 대한 테스트 코드 구현
- 배당금 csv 파일의 파싱하는 코드를 추출하여 클래스로 구현
- 종목 배당금 csv 파일 삭제 서비스 구현(GCP 버전)

## todo
- 종목 csv 파일에 대한 읽기/쓰기/삭제 서비스에 대한 구현체 확장 구현
