### PR TITLE
[fix] 상장 폐지된 종목과 관련된 API 문제 해결 (#759)

### DIFF
--- a/src/main/java/co/fineants/stock/domain/Stock.java
+++ b/src/main/java/co/fineants/stock/domain/Stock.java
@@ -85,6 +85,13 @@ public class Stock extends BaseEntity implements CsvLineConvertible {
 		return new Stock(tickerSymbol, companyName, companyNameEng, stockCode, sector, market);
 	}
 
+	public static Stock delisted(String tickerSymbol, String companyName, String companyNameEng, String stockCode,
+		String sector, Market market) {
+		Stock stock = new Stock(tickerSymbol, companyName, companyNameEng, stockCode, sector, market);
+		stock.isDeleted = true;
+		return stock;
+	}
+
 	public void addStockDividend(StockDividend stockDividend) {
 		if (!stockDividends.contains(stockDividend)) {
 			stockDividends.add(stockDividend);

--- a/src/test/java/co/fineants/TestDataFactory.java
+++ b/src/test/java/co/fineants/TestDataFactory.java
@@ -432,4 +432,15 @@ public final class TestDataFactory {
 			)
 		);
 	}
+
+	public static Stock createDelistedStock() {
+		return Stock.delisted(
+			"065560",
+			"녹원씨엔아이",
+			"Nokwon Commercials & Industries, Inc.",
+			"KR7065560005",
+			"소프트웨어",
+			Market.KOSDAQ
+		);
+	}
 }


### PR DESCRIPTION
* add mapping - kisCurrentPrice

외부 API로부터 상장폐지된 종목에 대하여 응답을 받으면 tickerSymbol=null로 응답됨

상장 폐지된 종목에 대해서는 Redis에 0원으로 저장되도록 함

* add test - portfolioHolding case

* fix var name
