### PR TITLE
[feat] 일괄 종목 현재가 갱신 스케줄러 구현

### DIFF
--- a/src/main/java/co/fineants/api/domain/kis/repository/CurrentPriceMemoryRepository.java
+++ b/src/main/java/co/fineants/api/domain/kis/repository/CurrentPriceMemoryRepository.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.logging.log4j.util.Strings;
@@ -60,6 +61,11 @@ public class CurrentPriceMemoryRepository implements CurrentPriceRepository {
 
 	private boolean isBlankTickerSymbol(String tickerSymbol) {
 		return Strings.isBlank(tickerSymbol);
+	}
+
+	@Override
+	public Set<CurrentPriceRedisEntity> findAll() {
+		return Set.copyOf(store.values());
 	}
 
 	@Override

--- a/src/main/java/co/fineants/api/domain/kis/repository/CurrentPriceRedisHashRepository.java
+++ b/src/main/java/co/fineants/api/domain/kis/repository/CurrentPriceRedisHashRepository.java
@@ -2,6 +2,8 @@ package co.fineants.api.domain.kis.repository;
 
 import java.time.Clock;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.util.Strings;
 import org.springframework.context.annotation.Primary;
@@ -110,6 +112,13 @@ public class CurrentPriceRedisHashRepository implements CurrentPriceRepository {
 			log.error("Failed to deserialize JSON to CurrentPriceRedisEntity", e);
 			throw new IllegalArgumentException("Deserialization error", e);
 		}
+	}
+
+	@Override
+	public Set<CurrentPriceRedisEntity> findAll() {
+		return template.opsForHash().entries(KEY).values().stream()
+			.map(value -> fromJson((String)value))
+			.collect(Collectors.toUnmodifiableSet());
 	}
 
 	@Override

--- a/src/main/java/co/fineants/api/domain/kis/repository/CurrentPriceRepository.java
+++ b/src/main/java/co/fineants/api/domain/kis/repository/CurrentPriceRepository.java
@@ -1,6 +1,7 @@
 package co.fineants.api.domain.kis.repository;
 
 import java.util.Optional;
+import java.util.Set;
 
 import co.fineants.api.domain.kis.client.KisCurrentPrice;
 import co.fineants.api.domain.kis.domain.CurrentPriceRedisEntity;
@@ -15,6 +16,7 @@ public interface CurrentPriceRepository {
 
 	Optional<CurrentPriceRedisEntity> fetchPriceBy(String tickerSymbol);
 
-	void clear();
+	Set<CurrentPriceRedisEntity> findAll();
 
+	void clear();
 }

--- a/src/main/java/co/fineants/api/domain/kis/service/CurrentPriceService.java
+++ b/src/main/java/co/fineants/api/domain/kis/service/CurrentPriceService.java
@@ -1,6 +1,8 @@
 package co.fineants.api.domain.kis.service;
 
 import java.time.Clock;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
@@ -83,5 +85,15 @@ public class CurrentPriceService {
 
 	private void triggerSyncRefresh(String tickerSymbol) {
 		eventPublisher.publishEvent(new StockCurrentPriceRequiredEvent(tickerSymbol));
+	}
+
+	/**
+	 * 현재 캐시 저장소에 저장된 모든 종목의 티커 심볼을 조회한다.
+	 * @return 현재 캐시 저장소에 저장된 모든 종목의 티커 심볼 리스트
+	 */
+	public Set<String> getAllTickers() {
+		return currentPriceRepository.findAll().stream()
+			.map(CurrentPriceRedisEntity::getTickerSymbol)
+			.collect(Collectors.toUnmodifiableSet());
 	}
 }

--- a/src/main/java/co/fineants/api/domain/kis/service/CurrentPriceService.java
+++ b/src/main/java/co/fineants/api/domain/kis/service/CurrentPriceService.java
@@ -89,7 +89,7 @@ public class CurrentPriceService {
 
 	/**
 	 * 현재 캐시 저장소에 저장된 모든 종목의 티커 심볼을 조회한다.
-	 * @return 현재 캐시 저장소에 저장된 모든 종목의 티커 심볼 리스트
+	 * @return 현재 캐시 저장소에 저장된 모든 종목의 티커 심볼 집합
 	 */
 	public Set<String> getAllTickers() {
 		return currentPriceRepository.findAll().stream()

--- a/src/main/java/co/fineants/stock/application/StockScheduler.java
+++ b/src/main/java/co/fineants/stock/application/StockScheduler.java
@@ -11,7 +11,7 @@ import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 
 import co.fineants.api.domain.kis.service.CurrentPriceService;
 import co.fineants.stock.domain.event.StockReloadEvent;
-import co.fineants.stock.event.StockCurrentPriceRequiredEvent;
+import co.fineants.stock.event.StockCurrentPriceRefreshEvent;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -36,12 +36,12 @@ public class StockScheduler {
 	/**
 	 * 평일 15:30에 캐시 저장소에 저장된 종목의 현재가를 최신 정보로 갱신합니다.
 	 */
-	@SchedulerLock(name = "batchStockCurrentPriceRefreshScheduler", lockAtLeastFor = "1m", lockAtMostFor = "1m")
+	@SchedulerLock(name = "batchStockRefreshCurrentPriceScheduler", lockAtLeastFor = "1m", lockAtMostFor = "1m")
 	@Scheduled(cron = "0 30 15 ? * MON-FRI")
-	public void scheduledRefreshCurrentPrice() {
+	public void scheduledBatchRefreshCurrentPrice() {
 		// redis에 저장된 현재가 종목들을 가져옵니다.
 		Set<String> tickers = currentPriceService.getAllTickers();
-		// 각 종목의 현재가를 갱신하는 동기 이벤트를 발행합니다.
-		tickers.forEach(ticker -> publisher.publishEvent(new StockCurrentPriceRequiredEvent(ticker)));
+		// 각 종목의 현재가를 갱신하는 비동기 이벤트를 발행합니다.
+		tickers.forEach(ticker -> publisher.publishEvent(new StockCurrentPriceRefreshEvent(ticker)));
 	}
 }

--- a/src/main/java/co/fineants/stock/application/StockScheduler.java
+++ b/src/main/java/co/fineants/stock/application/StockScheduler.java
@@ -1,5 +1,7 @@
 package co.fineants.stock.application;
 
+import java.util.Set;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -7,7 +9,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 
+import co.fineants.api.domain.kis.service.CurrentPriceService;
 import co.fineants.stock.domain.event.StockReloadEvent;
+import co.fineants.stock.event.StockCurrentPriceRequiredEvent;
 import lombok.RequiredArgsConstructor;
 
 @Component
@@ -16,6 +20,7 @@ public class StockScheduler {
 
 	private final ReloadStock reloadStock;
 	private final ApplicationEventPublisher publisher;
+	private final CurrentPriceService currentPriceService;
 
 	/**
 	 * 매일 오전 8시에 주식 정보를 업데이트합니다.
@@ -26,5 +31,17 @@ public class StockScheduler {
 	public void scheduledReloadStocks() {
 		reloadStock.reloadStocks();
 		publisher.publishEvent(new StockReloadEvent());
+	}
+
+	/**
+	 * 평일 15:30에 캐시 저장소에 저장된 종목의 현재가를 최신 정보로 갱신합니다.
+	 */
+	@SchedulerLock(name = "stockCurrentPriceRefreshScheduler", lockAtLeastFor = "1m", lockAtMostFor = "1m")
+	@Scheduled(cron = "${cron.expression.refresh-current-price:0 30 15 ? * MON-FRI}")
+	public void scheduledRefreshCurrentPrice() {
+		// redis에 저장된 현재가 종목들을 가져옵니다.
+		Set<String> tickers = currentPriceService.getAllTickers();
+		// 각 종목의 현재가를 갱신하는 동기 이벤트를 발행합니다.
+		tickers.forEach(ticker -> publisher.publishEvent(new StockCurrentPriceRequiredEvent(ticker)));
 	}
 }

--- a/src/main/java/co/fineants/stock/application/StockScheduler.java
+++ b/src/main/java/co/fineants/stock/application/StockScheduler.java
@@ -36,8 +36,8 @@ public class StockScheduler {
 	/**
 	 * 평일 15:30에 캐시 저장소에 저장된 종목의 현재가를 최신 정보로 갱신합니다.
 	 */
-	@SchedulerLock(name = "stockCurrentPriceRefreshScheduler", lockAtLeastFor = "1m", lockAtMostFor = "1m")
-	@Scheduled(cron = "${cron.expression.refresh-current-price:0 30 15 ? * MON-FRI}")
+	@SchedulerLock(name = "batchStockCurrentPriceRefreshScheduler", lockAtLeastFor = "1m", lockAtMostFor = "1m")
+	@Scheduled(cron = "0 30 15 ? * MON-FRI")
 	public void scheduledRefreshCurrentPrice() {
 		// redis에 저장된 현재가 종목들을 가져옵니다.
 		Set<String> tickers = currentPriceService.getAllTickers();

--- a/src/test/java/co/fineants/api/domain/kis/repository/CurrentPriceMemoryRepositoryTest.java
+++ b/src/test/java/co/fineants/api/domain/kis/repository/CurrentPriceMemoryRepositoryTest.java
@@ -144,4 +144,23 @@ class CurrentPriceMemoryRepositoryTest extends AbstractContainerBaseTest {
 			.hasFieldOrPropertyWithValue("tickerSymbol", tickerSymbol)
 			.hasFieldOrPropertyWithValue("price", price);
 	}
+
+	@DisplayName("모든 현재가 엔티티 조회 - 저장된 모든 현재가 엔티티를 조회한다.")
+	@Test
+	void findAll() {
+		// given
+		currentPriceMemoryRepository.savePrice("005930", 50000L);
+		currentPriceMemoryRepository.savePrice("035720", 30000L);
+
+		// when
+		var entities = currentPriceMemoryRepository.findAll();
+
+		// then
+		Assertions.assertThat(entities)
+			.extracting(CurrentPriceRedisEntity::getTickerSymbol, CurrentPriceRedisEntity::getPrice)
+			.containsExactlyInAnyOrder(
+				Assertions.tuple("005930", 50000L),
+				Assertions.tuple("035720", 30000L)
+			);
+	}
 }

--- a/src/test/java/co/fineants/api/domain/kis/repository/CurrentPriceRedisHashRepositoryTest.java
+++ b/src/test/java/co/fineants/api/domain/kis/repository/CurrentPriceRedisHashRepositoryTest.java
@@ -166,4 +166,23 @@ class CurrentPriceRedisHashRepositoryTest extends AbstractContainerBaseTest {
 		Assertions.assertThat(repository.fetchPriceBy(Strings.EMPTY)).isEmpty();
 		Assertions.assertThat(repository.fetchPriceBy("  ")).isEmpty();
 	}
+	
+	@DisplayName("모든 현재가 엔티티 조회 - 저장된 모든 현재가 엔티티를 조회한다.")
+	@Test
+	void findAll() {
+		// given
+		repository.savePrice("005930", 50000L);
+		repository.savePrice("035720", 30000L);
+
+		// when
+		var entities = repository.findAll();
+
+		// then
+		Assertions.assertThat(entities)
+			.extracting(CurrentPriceRedisEntity::getTickerSymbol, CurrentPriceRedisEntity::getPrice)
+			.containsExactlyInAnyOrder(
+				Assertions.tuple("005930", 50000L),
+				Assertions.tuple("035720", 30000L)
+			);
+	}
 }

--- a/src/test/java/co/fineants/api/domain/kis/repository/CurrentPriceRedisRepositoryTest.java
+++ b/src/test/java/co/fineants/api/domain/kis/repository/CurrentPriceRedisRepositoryTest.java
@@ -1,6 +1,7 @@
 package co.fineants.api.domain.kis.repository;
 
 import java.util.Optional;
+import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -159,5 +160,24 @@ class CurrentPriceRedisRepositoryTest extends AbstractContainerBaseTest {
 		Assertions.assertThat(currentPriceRedisRepository.fetchPriceBy("005930")).isEmpty();
 		Assertions.assertThat(currentPriceRedisRepository.fetchPriceBy("000660")).isEmpty();
 		Assertions.assertThat(stringRedisTemplate.keys("cp:*")).isEmpty();
+	}
+
+	@DisplayName("모든 현재가 엔티티 조회 - 저장된 모든 현재가 엔티티를 조회한다.")
+	@Test
+	void findAll() {
+		// given
+		currentPriceRedisRepository.savePrice("005930", 50000L);
+		currentPriceRedisRepository.savePrice("035720", 30000L);
+
+		// when
+		Set<CurrentPriceRedisEntity> entities = currentPriceRedisRepository.findAll();
+
+		// then
+		Assertions.assertThat(entities)
+			.extracting(CurrentPriceRedisEntity::getTickerSymbol, CurrentPriceRedisEntity::getPrice)
+			.containsExactlyInAnyOrder(
+				Assertions.tuple("005930", 50000L),
+				Assertions.tuple("035720", 30000L)
+			);
 	}
 }

--- a/src/test/java/co/fineants/api/domain/kis/service/CurrentPriceServiceTest.java
+++ b/src/test/java/co/fineants/api/domain/kis/service/CurrentPriceServiceTest.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Set;
 
 import org.assertj.core.api.Assertions;
 import org.awaitility.Awaitility;
@@ -294,5 +295,20 @@ class CurrentPriceServiceTest extends AbstractContainerBaseTest {
 			.hasFieldOrPropertyWithValue("price", stalePrice);
 		// 이벤트는 비즈니스 흐름상 발행될 수 있으나, 리스너의 필터링 로직에 의해 고비용 작업인 API 호출이 차단됨을 검증함
 		BDDMockito.verify(kisService, BDDMockito.never()).fetchCurrentPrice(tickerSymbol);
+	}
+
+	@DisplayName("모든 종목 티커 조회 - 저장된 모든 종목 티커에 대한 현재가를 조회한다")
+	@Test
+	void getAllTickers_thenReturnAllTickers() {
+		// given
+		currentPriceRepository.savePrice("005930", 50000L);
+		currentPriceRepository.savePrice("000660", 30000L);
+
+		// when
+		Set<String> actual = service.getAllTickers();
+
+		// then
+		Assertions.assertThat(actual)
+			.containsExactlyInAnyOrder("005930", "000660");
 	}
 }


### PR DESCRIPTION
## 구현한 것

- 평일 15시 30분에 한번씩 수행되는 일괄 종목 현재가 갱신 스케줄러 갱신 스케줄러 구현

## AS-IS
- 스케줄러가 작동하면 Redis에 저장된 current_prices hash에 저장된 종목들을 대상으로 최신 종목 현재가로 갱신합니다.

Resolved #779 